### PR TITLE
Bind directory for mounted filesystem instead of new mount for each volume

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ uninstall: deploy/k8s.yaml
 .PHONY: driver-dev-apply
 driver-dev-apply:
 	kustomize build deploy/driver/overlays/dev/ | kubectl apply -f -
-	kubectl delete -n kube-system pod juicefs-csi-attacher-0
+	kubectl delete -n kube-system pod juicefs-csi-controller-0
 
 .PHONY: driver-dev-delete
 driver-dev-delete:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Before the example, you need to:
 * [Static provisioning](examples/static-provisioning/)
 * [Mount options](examples/mount-options/)
 * [Accessing the filesystem from multiple pods](examples/multiple-pods-read-write-many/)
+* [Scaling pods](examples/pod-scaling/)
 
 **Notes**:
 

--- a/examples/mount-options/pv-juicefs.yaml
+++ b/examples/mount-options/pv-juicefs.yaml
@@ -5,7 +5,5 @@ metadata:
 spec:
   csi:
     volumeAttributes:
-      metacache: ""
-      cache-size: "124"
-      cache-dir: /var/foo
+      mountOptions: "metacache,cache-size=124,cache-dir=/var/foo"
     volumeHandle: csi-demo

--- a/examples/pod-scaling/Deployment-scaling.yaml
+++ b/examples/pod-scaling/Deployment-scaling.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name:  juicefs-csi-scaling
+spec:
+  selector:
+    matchLabels:
+      app: juicefs-csi-scaling
+  template:
+    metadata:
+      labels:
+        app: juicefs-csi-scaling
+    spec:
+      containers:
+      - name: app
+        image: centos
+        command: ["/bin/sh"]
+        args: ["-c", "while true; do echo $(date -u) >> /data/out-$(POD).txt; sleep 5; done"]
+        env:
+        - name: POD
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        resources:
+          limits:
+            cpu: "20m"
+            memory: "55M"
+        volumeMounts:
+        - name: persistent-storage
+          mountPath: /data
+      volumes:
+      - name: persistent-storage
+        persistentVolumeClaim:
+          claimName: juicefs

--- a/examples/pod-scaling/README.md
+++ b/examples/pod-scaling/README.md
@@ -1,0 +1,59 @@
+# Pod Scaling
+
+This example shows how JuiceFS persistence volume (PV) supports large scale pods replicas.
+
+## Provide secret information
+
+In order to build the example, you need to provide a secret file `Secret-juicefs.env` containing the required credentials
+
+```ini
+token=<juicefs-token>
+accesskey=<juicefs-accesskey>
+secretkey=<juicefs-secretkey>
+```
+
+## Apply the configurations
+
+Build the example with [kustomize](https://github.com/kubernetes-sigs/kustomize) and apply with `kubectl`
+
+```s
+kustomize build | kubectl apply -f -
+```
+
+or apply with kubectl >= 1.14
+
+```s
+kubectl apply -k -f .
+```
+
+## Scaling
+
+Scale up
+
+```s
+kubectl scale -n default deployment juicefs-csi-scaling --replicas=64
+```
+
+Scale down
+
+```s
+kubectl scale -n default deployment juicefs-csi-scaling --replicas=1
+```
+
+## Check JuiceFS filesystem is used
+
+In the example, both pods are writing to the same JuiceFS filesystem at the same time.
+
+After the objects are created, verify that pod is running:
+
+```sh
+>> kubectl get pods
+```
+
+Also you can verify that data is written onto JuiceFS filesystem:
+
+```sh
+kubectl exec -ti juicefs-csi-scaling-85676b4c7c-rzzlf -- ls /data
+out-juicefs-csi-scaling-85676b4c7c-8xfwc.txt  out-juicefs-csi-scaling-85676b4c7c-hlchk.txt
+...
+```

--- a/examples/pod-scaling/kustomization.yaml
+++ b/examples/pod-scaling/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+bases:
+- ../../deploy/volume
+resources:
+- Deployment-scaling.yaml
+patchesStrategicMerge:
+- pv-juicefs.yaml
+secretGenerator:
+- name: juicefs
+  env: Secret-juicefs.env
+  type: Opaque
+  behavior: merge

--- a/examples/pod-scaling/pv-juicefs.yaml
+++ b/examples/pod-scaling/pv-juicefs.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: juicefs
+spec:
+  csi:
+    volumeHandle: csi-demo
+

--- a/pkg/driver/juicefs.go
+++ b/pkg/driver/juicefs.go
@@ -1,0 +1,26 @@
+package driver
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (d *Driver) juicefsAuth(source string, secrets map[string]string) ([]byte, error) {
+	if secrets == nil || secrets["token"] == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "Nil secrets or empty token")
+	}
+
+	token := secrets["token"]
+	args := []string{"auth", source, "--token", token}
+	keys := []string{"accesskey", "secretkey", "accesskey2", "secretkey2"}
+	for _, k := range keys {
+		v := secrets[k]
+		args = append(args, "--"+k)
+		if v != "" {
+			args = append(args, v)
+		} else {
+			args = append(args, "''")
+		}
+	}
+	return d.exec.Run(jfsCmd, args...)
+}

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -94,17 +94,19 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 			options[f] = ""
 		}
 	}
-	for k, v := range req.GetVolumeAttributes() {
-		options[k] = v
+
+	var mountOptions = []string{}
+
+	if opts, ok := req.GetVolumeAttributes()["mountOptions"]; ok {
+		mountOptions = strings.Split(opts, ",")
 	}
-	var mountOptions []string
+
 	for k, v := range options {
 		if v != "" {
 			k = fmt.Sprintf("%s=%s", k, v)
 		}
 		mountOptions = append(mountOptions, k)
 	}
-	klog.V(5).Infof("NodePublishVolume: mount options: %s", strings.Join(mountOptions, ","))
 
 	klog.V(5).Infof("NodePublishVolume: mounting %s at %s with options %v", source, target, mountOptions)
 	if err := d.mounter.Mount(source, target, fsType, mountOptions); err != nil {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -19,6 +19,7 @@ package driver
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
 	"testing"
 
@@ -73,7 +74,7 @@ func TestNodePublishVolume(t *testing.T) {
 				}
 				mockExec.EXPECT().Run(gomock.Eq(jfsCmd), gomock.Any()).Return(nil, nil)
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
-				mockMounter.EXPECT().ExistsPath(gomock.Eq(jfsMnt)).Return(false, nil)
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(jfsMnt)).Return(true, os.ErrNotExist)
 				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(jfsMnt), gomock.Eq(fsTypeJuiceFS), gomock.Any()).Return(nil)
 				mockMounter.EXPECT().Mount(gomock.Eq(jfsMnt), gomock.Eq(targetPath), gomock.Eq(fsTypeNone), gomock.Eq([]string{"bind"})).Return(nil)
 				_, err := driver.NodePublishVolume(ctx, req)
@@ -111,7 +112,7 @@ func TestNodePublishVolume(t *testing.T) {
 
 				mockExec.EXPECT().Run(gomock.Eq(jfsCmd), gomock.Any()).Return(nil, nil)
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
-				mockMounter.EXPECT().ExistsPath(gomock.Eq(jfsMnt)).Return(false, nil)
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(jfsMnt)).Return(true, os.ErrNotExist)
 				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(jfsMnt), gomock.Eq(fsTypeJuiceFS), gomock.Eq([]string{"ro"})).Return(nil)
 				mockMounter.EXPECT().Mount(gomock.Eq(jfsMnt), gomock.Eq(targetPath), gomock.Eq(fsTypeNone), gomock.Eq([]string{"bind"})).Return(nil)
 				_, err := driver.NodePublishVolume(ctx, req)
@@ -157,7 +158,7 @@ func TestNodePublishVolume(t *testing.T) {
 
 				mockExec.EXPECT().Run(gomock.Eq(jfsCmd), gomock.Any()).Return(nil, nil)
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
-				mockMounter.EXPECT().ExistsPath(gomock.Eq(jfsMnt)).Return(false, nil)
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(jfsMnt)).Return(true, os.ErrNotExist)
 				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(jfsMnt), gomock.Eq(fsTypeJuiceFS), gomock.Eq([]string{"tls"})).Return(nil)
 				mockMounter.EXPECT().Mount(gomock.Eq(jfsMnt), gomock.Eq(targetPath), gomock.Eq(fsTypeNone), gomock.Eq([]string{"bind"})).Return(nil)
 
@@ -321,7 +322,7 @@ func TestNodePublishVolume(t *testing.T) {
 				mockExec.EXPECT().Run(gomock.Eq(jfsCmd), gomock.Any()).Return(nil, nil)
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
 				err := fmt.Errorf("failed to Mount")
-				mockMounter.EXPECT().ExistsPath(gomock.Eq(jfsMnt)).Return(false, nil)
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(jfsMnt)).Return(true, os.ErrNotExist)
 				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(jfsMnt), gomock.Eq(fsTypeJuiceFS), gomock.Any()).Return(err)
 
 				_, err = driver.NodePublishVolume(ctx, req)

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -19,6 +19,7 @@ package driver
 import (
 	"context"
 	"fmt"
+	"path"
 	"testing"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
@@ -60,6 +61,7 @@ func TestNodePublishVolume(t *testing.T) {
 					exec:     mockExec,
 				}
 				source := volumeId
+				jfsMnt := path.Join("/jfs", source)
 
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
@@ -71,7 +73,9 @@ func TestNodePublishVolume(t *testing.T) {
 				}
 				mockExec.EXPECT().Run(gomock.Eq(jfsCmd), gomock.Any()).Return(nil, nil)
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
-				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq(fsType), gomock.Any()).Return(nil)
+				mockMounter.EXPECT().ExistsPath(gomock.Eq(jfsMnt)).Return(false, nil)
+				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(jfsMnt), gomock.Eq(fsTypeJuiceFS), gomock.Any()).Return(nil)
+				mockMounter.EXPECT().Mount(gomock.Eq(jfsMnt), gomock.Eq(targetPath), gomock.Eq(fsTypeNone), gomock.Eq([]string{"bind"})).Return(nil)
 				_, err := driver.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -93,6 +97,7 @@ func TestNodePublishVolume(t *testing.T) {
 					exec:     mockExec,
 				}
 				source := volumeId
+				jfsMnt := path.Join("/jfs", source)
 
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
@@ -106,7 +111,9 @@ func TestNodePublishVolume(t *testing.T) {
 
 				mockExec.EXPECT().Run(gomock.Eq(jfsCmd), gomock.Any()).Return(nil, nil)
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
-				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq(fsType), gomock.Eq([]string{"ro"})).Return(nil)
+				mockMounter.EXPECT().ExistsPath(gomock.Eq(jfsMnt)).Return(false, nil)
+				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(jfsMnt), gomock.Eq(fsTypeJuiceFS), gomock.Eq([]string{"ro"})).Return(nil)
+				mockMounter.EXPECT().Mount(gomock.Eq(jfsMnt), gomock.Eq(targetPath), gomock.Eq(fsTypeNone), gomock.Eq([]string{"bind"})).Return(nil)
 				_, err := driver.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -128,6 +135,7 @@ func TestNodePublishVolume(t *testing.T) {
 					exec:     mockExec,
 				}
 				source := volumeId
+				jfsMnt := path.Join("/jfs", source)
 
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
@@ -149,7 +157,10 @@ func TestNodePublishVolume(t *testing.T) {
 
 				mockExec.EXPECT().Run(gomock.Eq(jfsCmd), gomock.Any()).Return(nil, nil)
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
-				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq(fsType), gomock.Eq([]string{"tls"})).Return(nil)
+				mockMounter.EXPECT().ExistsPath(gomock.Eq(jfsMnt)).Return(false, nil)
+				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(jfsMnt), gomock.Eq(fsTypeJuiceFS), gomock.Eq([]string{"tls"})).Return(nil)
+				mockMounter.EXPECT().Mount(gomock.Eq(jfsMnt), gomock.Eq(targetPath), gomock.Eq(fsTypeNone), gomock.Eq([]string{"bind"})).Return(nil)
+
 				_, err := driver.NodePublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodePublishVolume is failed: %v", err)
@@ -305,11 +316,13 @@ func TestNodePublishVolume(t *testing.T) {
 					TargetPath:         targetPath,
 				}
 				source := volumeId
+				jfsMnt := path.Join("/jfs", source)
 
 				mockExec.EXPECT().Run(gomock.Eq(jfsCmd), gomock.Any()).Return(nil, nil)
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
 				err := fmt.Errorf("failed to Mount")
-				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq(fsType), gomock.Any()).Return(err)
+				mockMounter.EXPECT().ExistsPath(gomock.Eq(jfsMnt)).Return(false, nil)
+				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(jfsMnt), gomock.Eq(fsTypeJuiceFS), gomock.Any()).Return(err)
 
 				_, err = driver.NodePublishVolume(ctx, req)
 				if err == nil {


### PR DESCRIPTION
This reduces resources consumption greatly and is a prerequisite for dynamic provisioning.