### PR TITLE
mount options should be passed to `mount`

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -18,10 +18,8 @@ package driver
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"reflect"
-	"strings"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs"
@@ -115,13 +113,7 @@ func (d *nodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	secrets := req.Secrets
 	mountOptions := []string{}
 	if opts, ok := volCtx["mountOptions"]; ok {
-		mountOptions = strings.Split(opts, ",")
-	}
-	for k, v := range options {
-		if v != "" {
-			k = fmt.Sprintf("%s=%s", k, v)
-		}
-		mountOptions = append(mountOptions, k)
+		mountOptions = append(mountOptions, opts)
 	}
 
 	klog.V(5).Infof("NodePublishVolume: mounting juicefs with secret %+v, options %v", reflect.ValueOf(secrets).MapKeys(), mountOptions)

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -18,8 +18,10 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"reflect"
+	"strings"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs"
@@ -113,7 +115,13 @@ func (d *nodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	secrets := req.Secrets
 	mountOptions := []string{}
 	if opts, ok := volCtx["mountOptions"]; ok {
-		mountOptions = append(mountOptions, opts)
+		mountOptions = strings.Split(opts, ",")
+	}
+	for k, v := range options {
+		if v != "" {
+			k = fmt.Sprintf("%s=%s", k, v)
+		}
+		mountOptions = append(mountOptions, k)
 	}
 
 	klog.V(5).Infof("NodePublishVolume: mounting juicefs with secret %+v, options %v", reflect.ValueOf(secrets).MapKeys(), mountOptions)

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -206,7 +206,7 @@ func (j *juicefs) MountFs(volumeID, name string, options []string) (string, erro
 
 	if !exists {
 		klog.V(5).Infof("Mount: mounting %q at %q with options %v", name, mountPath, options)
-		if err := j.Mount(name, mountPath, fsType, []string{}); err != nil {
+		if err := j.Mount(name, mountPath, fsType, options); err != nil {
 			os.Remove(mountPath)
 			return "", status.Errorf(codes.Internal, "Could not mount %q at %q: %v", name, mountPath, err)
 		}
@@ -221,7 +221,7 @@ func (j *juicefs) MountFs(volumeID, name string, options []string) (string, erro
 
 	if notMnt {
 		klog.V(5).Infof("Mount: mounting %q at %q with options %v", name, mountPath, options)
-		if err := j.Mount(name, mountPath, fsType, []string{}); err != nil {
+		if err := j.Mount(name, mountPath, fsType, options); err != nil {
 			return "", status.Errorf(codes.Internal, "Could not mount %q at %q: %v", name, mountPath, err)
 		}
 		return mountPath, nil


### PR DESCRIPTION
`juicefs` will separate options bebind `-o` to fuse options and mount options, e.g. `-o cache-size=100,cache-dir=/var/foo,allow-root` to `--cache-size=100 --cache-dir=/var/foo` as mount options and `--allow-root` as fuse options. hence they should be joined by `','`, not separated as a list.
and `options` were not used in `Mount`, didn't know why...