### PR TITLE
Use alpine as base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ GIT_BRANCH?=$(shell git rev-parse --abbrev-ref HEAD)
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 DEV_TAG=dev-$(shell git describe --always --dirty)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-BUILD_ARG="GIT_COMMIT=$(GIT_COMMIT) BUILD_DATE=$(BUILD_DATE)"
 PKG=github.com/juicedata/juicefs-csi-driver
 LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} -s -w"
 GO111MODULE=on
@@ -53,7 +52,7 @@ push:
 
 .PHONY: image-branch
 image-branch:
-	docker build -t $(IMAGE):$(GIT_BRANCH) -f Dockerfile --build-arg=$(BUILD_ARG) .
+	docker build -t $(IMAGE):$(GIT_BRANCH) -f Dockerfile .
 
 .PHONY: push-branch
 push-branch:

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ push-dev:
 	docker tag $(IMAGE):$(DEV_TAG) $(REGISTRY)/$(IMAGE):$(DEV_TAG)
 	docker push $(REGISTRY)/$(IMAGE):$(DEV_TAG)
 
+.PHONY: deploy-dev/kustomization.yaml
 deploy-dev/kustomization.yaml:
 	mkdir -p $(@D)
 	touch $@
@@ -102,9 +103,8 @@ deploy-dev/k8s.yaml: deploy-dev/kustomization.yaml deploy/kubernetes/base/*.yaml
 
 .PHONY: deploy-dev
 deploy-dev: deploy-dev/k8s.yaml
-	kubectl apply -f $<
-	kubectl delete -n kube-system pod juicefs-csi-controller-0
+	kapp deploy --app juicefs-csi-driver --file $<
 
 .PHONY: delete-dev
 delete-dev: deploy-dev/k8s.yaml
-	kubectl delete -f $<
+	kapp delete --app juicefs-csi-driver

--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -1,4 +1,3 @@
-** github.com/aws/aws-sdk-go; version 1.16.5 -- https://github.com/aws/aws-sdk-go
 ** github.com/container-storage-interface/spec; version v0.3.0 -- https://github.com/container-storage-interface/spec/
 ** github.com/golang/mock; version v1.2.0 -- https://github.com/golang/mock
 ** github.com/spf13/afero; version v1.2.1 -- https://github.com/spf13/afero
@@ -223,28 +222,6 @@ See the License for the specific language governing permissions and
 
 limitations under the License.
 
-* For github.com/aws/aws-sdk-go see also this required NOTICE:
-AWS SDK for Go
-Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
-Copyright 2014-2015 Stripe, Inc.
-* For github.com/container-storage-interface/spec see also this required
-NOTICE:
-Copyright {yyyy} {name of copyright owner}
-* For github.com/golang/mock see also this required NOTICE:
-Copyright 2010 Google Inc.
-* For github.com/spf13/afero see also this required NOTICE:
-Copyright Uknown
-* For google.golang.org/grpc see also this required NOTICE:
-Copyright [yyyy] [name of copyright owner]
-* For k8s.io/apimachinery see also this required NOTICE:
-Copyright [yyyy] [name of copyright owner]
-* For k8s.io/klog see also this required NOTICE:
-Copyright 2017 The Kubernetes Authors
-* For k8s.io/kubernetes see also this required NOTICE:
-Copyright [yyyy] [name of copyright owner]
-* For k8s.io/utils see also this required NOTICE:
-Copyright [yyyy] [name of copyright owner]
-
 -----
 
 ** github.com/stretchr/testify; version v1.3.0 -- https://github.com/stretchr/testify
@@ -254,21 +231,21 @@ Copyright (c) 2012 - 2013 Mat Ryer and Tyler Bunnell
 
 Please consider promoting this project if you find it useful.
 
-Permission is hereby granted, free of charge, to any person 
-obtaining a copy of this software and associated documentation 
-files (the "Software"), to deal in the Software without restriction, 
-including without limitation the rights to use, copy, modify, merge, 
-publish, distribute, sublicense, and/or sell copies of the Software, 
-and to permit persons to whom the Software is furnished to do so, 
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
 subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included
 in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT 
-OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
 OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM juicedata/juicefs-csi-driver:latest
-
-RUN yum install -y procps
+FROM juicedata/juicefs-csi-driver:alpine
 
 COPY juicefs-csi-driver /bin/juicefs-csi-driver
 

--- a/examples/static-provisioning-mount-options/README.md
+++ b/examples/static-provisioning-mount-options/README.md
@@ -29,12 +29,6 @@ Build the example with [kustomize](https://github.com/kubernetes-sigs/kustomize)
 kustomize build | kubectl apply -f -
 ```
 
-or apply with kubectl >= 1.14
-
-```s
-kubectl apply -k .
-```
-
 ## Check mount options are customized
 
 After the configuration is applied, verify that pod is running:
@@ -47,12 +41,9 @@ Also you can verify that mount options are customized in the mounted JuiceFS fil
 
 ```sh
 >> kubectl exec -ti juicefs-csi-node-2zz7h -c juicefs-plugin sh
-
-sh-4.2# yum install procps
-sh-4.2# ps xf
+>> ps xf
 ...
-root       342  0.0  1.1 122484 11596 ?        S    12:02   0:00 /usr/bin/python2 /sbin/mount.juicefs csi-demo /var/lib/kubelet/pods/f513c3e5-7576-11e9-a400-0aa5dd01d816/volumes/kubernetes.io~csi/juicefs/mount -o rw,cache-dir=/var/foo,cache-size=124,metacache HOSTNAME=ip-
-root       344  0.5  5.1  70632 52892 ?        S<l  12:02   0:03  \_ juicefs -mountpoint /var/lib/kubelet/pods/f513c3e5-7576-11e9-a400-0aa5dd01d816/volumes/kubernetes.io~csi/juicefs/mount -ssl -cacheDir /var/foo/csi-demo -cacheSize 124 -o fsname=JuiceFS:csi-demo,allow_oth
+   66 root      0:00 /usr/local/bin/python2 /usr/bin/juicefs mount aws-us-east-1 /jfs/aws-us-east-1 --metacache --cache-size=100 --cache-dir=/var/foo
+   68 root      0:00 {jfsmount} juicefs -mountpoint /jfs/aws-us-east-1 -ssl -cacheDir /var/foo/aws-us-east-1 -cacheSize 100 -o fsname=JuiceFS:aws-us-east-1,allow_other,nonempty -metacacheto 300 -attrcacheto 1 -entrycacheto 1 -direntrycacheto 1 -compress zstd
+...
 ```
-
-Note that `-cacheDir` is different from default value `/var/jfsCache/csi-demo` and `-cacheSize` is customized as `124`.

--- a/examples/static-provisioning-mount-options/kustomization.yaml
+++ b/examples/static-provisioning-mount-options/kustomization.yaml
@@ -5,3 +5,4 @@ bases:
 - ../static-provisioning
 patchesStrategicMerge:
 - patches.yaml
+nameSuffix: -mount-options

--- a/examples/static-provisioning/resources.yaml
+++ b/examples/static-provisioning/resources.yaml
@@ -49,6 +49,9 @@ spec:
     volumeMounts:
     - mountPath: /data
       name: data
+    resources:
+      requests:
+        cpu: 10m
   volumes:
   - name: data
     persistentVolumeClaim:


### PR DESCRIPTION
* Image size reduced from 173M to 45M
* Use `juicefs mount` instead of `mount` to Handle error `no Python available, please install it first` under alpine