### PR TITLE
add support for --no-update option for AuthFs

### DIFF
--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -206,7 +206,8 @@ func (j *juicefs) AuthFs(secrets map[string]string) ([]byte, error) {
 			if _, err := os.Stat(confPath); os.IsNotExist(err) {
 				err = ioutil.WriteFile(confPath, []byte(secrets["initconfig"]), 0644)
 				if err != nil {
-					klog.V(5).Infof("Create config file: %q failed", confPath)
+					return nil, status.Errorf(codes.Internal,
+						"Create config file %q failed: %v", confPath, err)
 				}
 				klog.V(5).Infof("Create config file: %q success", confPath)
 			}

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -3,6 +3,7 @@ package juicefs
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -189,6 +190,26 @@ func (j *juicefs) AuthFs(secrets map[string]string) ([]byte, error) {
 		if !isOptional[k] || secrets[k] != "" {
 			args = append(args, fmt.Sprintf("--%s=%s", k, secrets[k]))
 			argsStripped = append(argsStripped, fmt.Sprintf("--%s=[secret]", k))
+		}
+	}
+	if v, ok := os.LookupEnv("JFS_NO_UPDATE_CONFIG"); ok && v == "enabled" {
+		args = append(args, "--no-update")
+		argsStripped = append(argsStripped, "--no-update")
+
+		if secrets["bucket"] == "" {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"bucket argument is required when --no-update option is provided")
+		}
+		if secrets["initconfig"] != "" {
+			conf := secrets["name"] + ".conf"
+			confPath := filepath.Join("/root/.juicefs", conf)
+			if _, err := os.Stat(confPath); os.IsNotExist(err) {
+				err = ioutil.WriteFile(confPath, []byte(secrets["initconfig"]), 0644)
+				if err != nil {
+					klog.V(5).Infof("Create config file: %q failed", confPath)
+				}
+				klog.V(5).Infof("Create config file: %q success", confPath)
+			}
 		}
 	}
 	klog.V(5).Infof("AuthFs: cmd %q, args %#v", cliPath, argsStripped)


### PR DESCRIPTION
The `juicefs.py` now has a `--no-update` option. When sub command `auth` and `mount` with this option, it would only use local config(not update config from `CFG_URL`). The `mount` sub command can use `mountOptions` to support this.

This PR use `secret` to transfer initial local config looks a little bit strange...

