### PR TITLE
change default health port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ profile.cov
 Secret-*
 secret*
 /deploy-dev/
+.idea

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -282,8 +282,14 @@ spec:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
-        - --csi-address=/csi/csi.sock
+        - --csi-address=$(ADDRESS)
         - --connection-timeout=3s
+        - --health-port=$(HEALTH_PORT)
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: HEALTH_PORT
+          value: 9808
         image: quay.io/k8scsi/livenessprobe:v1.1.0
         name: liveness-probe
         volumeMounts:
@@ -381,8 +387,14 @@ spec:
         - mountPath: /registration
           name: registration-dir
       - args:
-        - --csi-address=/csi/csi.sock
+        - --csi-address=$(ADDRESS)
         - --connection-timeout=3s
+        - --health-port=$(HEALTH_PORT)
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: HEALTH_PORT
+          value: 9808
         image: quay.io/k8scsi/livenessprobe:v1.1.0
         name: liveness-probe
         volumeMounts:

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -227,7 +227,7 @@ spec:
           timeoutSeconds: 3
         name: juicefs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9909
           name: healthz
           protocol: TCP
         resources:
@@ -289,7 +289,7 @@ spec:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: HEALTH_PORT
-          value: 9808
+          value: "9909"
         image: quay.io/k8scsi/livenessprobe:v1.1.0
         name: liveness-probe
         volumeMounts:
@@ -343,7 +343,7 @@ spec:
           timeoutSeconds: 3
         name: juicefs-plugin
         ports:
-        - containerPort: 9808
+        - containerPort: 9909
           name: healthz
           protocol: TCP
         resources:
@@ -394,7 +394,7 @@ spec:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: HEALTH_PORT
-          value: 9808
+          value: "9909"
         image: quay.io/k8scsi/livenessprobe:v1.1.0
         name: liveness-probe
         volumeMounts:


### PR DESCRIPTION
CSI [livenessprobe](https://github.com/kubernetes-csi/livenessprobe) use `9808` as the [default health port](https://github.com/kubernetes-csi/livenessprobe/blob/5b6184e012e50f46fb0b9db2d13e45bd569719b8/cmd/livenessprobe/main.go#L39), usually the CSI driver use `hostNetwork: true` . 

To avoid port conflict with other CSI driver, we change the health port to `9909`, and if the port is also be used, we can change it by replacing an available port in the *YAML* .