### PR TITLE
change csidriver apiversion for old kubernetes version

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The following sections are Kubernetes specific. If you are a Kubernetes user, us
 
 ### Kubernetes Version Compatibility
 
-JuiceFS CSI Driver is compatible with Kubernetes **v1.13+**
+JuiceFS CSI Driver is compatible with Kubernetes **v1.14+**
 
 Container Images
 

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -369,7 +369,7 @@ spec:
           type: Directory
         name: device-dir
 ---
-apiVersion: storage.k8s.io/v1
+apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
   labels:

--- a/deploy/kubernetes/base/resources.yaml
+++ b/deploy/kubernetes/base/resources.yaml
@@ -136,7 +136,7 @@ roleRef:
 
 ---
 kind: CSIDriver
-apiVersion: storage.k8s.io/v1
+apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: csi.juicefs.com
 spec:


### PR DESCRIPTION
Related issue: #60 

As Kubernetes 1.13, the CSIDriver is not [enabled by default](https://kubernetes-csi.github.io/docs/csi-driver-object.html#enabling-csidriver-on-kubernetes), and the `apiVersion` is `storage.k8s.io/v1alpha1`, since version 1.14, the `apiVersion` is `storage.k8s.io/v1beta1` and [is not deprecated](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#csidriver-v1beta1-storage-k8s-io) on Kubernetes 1.20(currently the newest version), we change the compatibility from 1.14+ for simplicity.

If we must use Kubernetes 1.13, first [enable CSIDriver](https://kubernetes-csi.github.io/docs/csi-driver-object.html#enabling-csidriver-on-kubernetes), then change the `apiVersion` of `CSIDriver` from `storage.k8s.io/v1beta1` to `storage.k8s.io/v1alpha1` in `deploy/k8s.yaml`.