### PR TITLE
fix Basic/README.md create secret script

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -23,10 +23,10 @@ Then create secret for access in Kubernetes.
 
 ```sh
 kubectl -n default create secret generic juicefs-secret \
-    --from-literal=name=<NAME>
+    --from-literal=name=<NAME> \
     --from-literal=metaurl=redis://[:<PASSWORD>]@<HOST>:6379[/<DB>] \
-    --from-literal=storage=s3
-    --from-literal=bucket=https://<BUCKET>.s3.<REGION>.amazonaws.com
+    --from-literal=storage=s3 \
+    --from-literal=bucket=https://<BUCKET>.s3.<REGION>.amazonaws.com \
     --from-literal=access-key=<ACCESS_KEY> \
     --from-literal=secret-key=<SECRET_KEY>
 


### PR DESCRIPTION
fix create secret script not working.

old logic 

```
...
secret/juicefs-secret created
zsh: no such file or directory: --from-literal=metaurl=redis://jXXXXXXXXXX.com
zsh: no such file or directory: --from-literal=bucket=https://jXXXXXXXXXX.s3.xxxxx.amazonaws.com
zsh: command not found: --from-literal=access-key=AKIAXXXXXXXXXXXX

``` 