### PR TITLE
foregroud mount in goroutine

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -14,6 +14,6 @@
 
 FROM juicedata/juicefs-csi-driver:latest
 
-COPY juicefs-csi-driver /bin/
+COPY juicefs-csi-driver /bin/juicefs-csi-driver
 
 ENTRYPOINT ["/bin/juicefs-csi-driver"]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -14,6 +14,6 @@
 
 FROM juicedata/juicefs-csi-driver:latest
 
-COPY juicefs-csi-driver juicefs /bin/
+COPY juicefs-csi-driver /bin/
 
 ENTRYPOINT ["/bin/juicefs-csi-driver"]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -14,6 +14,6 @@
 
 FROM juicedata/juicefs-csi-driver:latest
 
-COPY juicefs-csi-driver /bin/juicefs-csi-driver
+COPY juicefs-csi-driver juicefs /bin/
 
 ENTRYPOINT ["/bin/juicefs-csi-driver"]

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	k8s.io/apimachinery v0.0.0-20190416092415-3370b4aef5d6 // indirect
 	k8s.io/klog v0.1.0
 	k8s.io/kubernetes v1.13.1
-	k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7 // indirect
+	k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7
 )
 
 go 1.13

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -410,7 +410,7 @@ func (j *juicefs) ceMount(source string, mountPath string, fsType string, option
 	mntCmd.Env = envs
 	mntCmd.Stderr = os.Stderr
 	mntCmd.Stdout = os.Stdout
-	go mntCmd.Run()
+	go func() { _ = mntCmd.Run() }()
 	// Wait until the mount point is ready
 	for i := 0; i < 30; i++ {
 		finfo, err := os.Stat(mountPath)

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -16,7 +16,6 @@ import (
 	"google.golang.org/grpc/status"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/util/mount"
-	k8sexec "k8s.io/utils/exec"
 )
 
 const (
@@ -406,9 +405,11 @@ func (j *juicefs) ceMount(source string, mountPath string, fsType string, option
 		klog.V(5).Infof("Unmount %v", mountPath)
 	}
 
-	environ := append(syscall.Environ(), "JFS_FOREGROUND=1")
-	mntCmd := k8sexec.New().Command(ceMountPath, mountArgs...)
-	mntCmd.SetEnv(environ)
+	envs := append(syscall.Environ(), "JFS_FOREGROUND=1")
+	mntCmd := exec.Command(ceMountPath, mountArgs...)
+	mntCmd.Env = envs
+	mntCmd.Stderr = os.Stderr
+	mntCmd.Stdout = os.Stdout
 	go mntCmd.Run()
 	// Wait until the mount point is ready
 	for i := 0; i < 30; i++ {


### PR DESCRIPTION
1. Output JuiceFS mount log to csi driver's stderr which can be read by `kubectl logs`
2. As mounted foreground, each mount process has a goroutine `wait` it to stop, so when the process exit (`unmount`), no zombie process exists (previous version has this problem as the juicefs csi driver has no `init` capability).