### PR TITLE
Remove external-attacher sidecar from csi controller

### DIFF
--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -15,11 +15,6 @@ A Helm chart for JuiceFS CSI Driver
 | backend.secretKey | string | `""` |  |
 | backend.storage | string | `""` |  |
 | controller.affinity | object | Hard node and soft zone anti-affinity | Affinity for gateway pods. Passed through `tpl` and, thus, to be configured as string |
-| controller.attacher.pullPolicy | string | `"IfNotPresent"` |  |
-| controller.attacher.registry | string | `"quay.io"` | The Docker registry |
-| controller.attacher.repository | string | `"k8scsi/csi-attacher"` | Docker image repository |
-| controller.attacher.resources | object | `{}` | Resource requests and limits for the gateway |
-| controller.attacher.tag | string | `"v1.1.0"` | Overrides the image tag whose default is the chart's appVersion |
 | controller.enabled | bool | `true` |  |
 | controller.livenessComponent.pullPolicy | string | `"IfNotPresent"` |  |
 | controller.livenessComponent.registry | string | `"quay.io"` | The Docker registry |

--- a/deploy/chart/templates/controller/_helpers.tpl
+++ b/deploy/chart/templates/controller/_helpers.tpl
@@ -22,20 +22,6 @@ app.kubernetes.io/component: controller
 {{- end }}
 
 {{/*
-attacherRole fullname
-*/}}
-{{- define "juicefs-csi.attacherRole" -}}
-{{ include "juicefs-csi.fullname" . }}-attach-role
-{{- end }}
-
-{{/*
-attacherRoleBinding fullname
-*/}}
-{{- define "juicefs-csi.attacherRoleBinding" -}}
-{{ include "juicefs-csi.fullname" . }}-attach-role-binding
-{{- end }}
-
-{{/*
 provisionerRole fullname
 */}}
 {{- define "juicefs-csi.provisionerRole" -}}

--- a/deploy/chart/templates/controller/clusterrole.yaml
+++ b/deploy/chart/templates/controller/clusterrole.yaml
@@ -1,45 +1,4 @@
 {{- if and .Values.controller.enabled .Values.serviceAccount.create }}
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    {{- include "juicefs-csi.labels" . | nindent 4 }}
-  name: {{ include "juicefs-csi.attacherRole" . }}
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - csi.storage.k8s.io
-  resources:
-  - csinodeinfos
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - volumeattachments
-  verbs:
-  - get
-  - list
-  - watch
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -109,21 +68,6 @@ rules:
   verbs:
   - get
   - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    {{- include "juicefs-csi.labels" . | nindent 4 }}
-  name: {{ include "juicefs-csi.attacherRoleBinding" . }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "juicefs-csi.attacherRole" . }}
-subjects:
-- kind: ServiceAccount
-  name: {{ include "juicefs-csi.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/chart/templates/controller/deployment.yaml
+++ b/deploy/chart/templates/controller/deployment.yaml
@@ -67,20 +67,6 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=$(ADDRESS)
-        - --v=5
-        env:
-        - name: ADDRESS
-          value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: "{{ .Values.controller.attacher.registry }}/{{ .Values.controller.attacher.repository }}:{{ .Values.controller.attacher.tag }}"
-        imagePullPolicy: {{ .Values.controller.attacher.pullPolicy }}
-        name: csi-attacher
-        resources:
-          {{- toYaml .Values.controller.attacher.resources | nindent 12 }}
-        volumeMounts:
-        - mountPath: /var/lib/csi/sockets/pluginproxy/
-          name: socket-dir
-      - args:
-        - --csi-address=$(ADDRESS)
         - --health-port=$(HEALTH_PORT)
         env:
         - name: ADDRESS

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -30,16 +30,6 @@ controller:
   pullPolicy: IfNotPresent
   # -- Resource requests and limits for the gateway
   sresources: {}
-  attacher:
-    # -- The Docker registry
-    registry: quay.io
-    # -- Docker image repository
-    repository: k8scsi/csi-attacher
-    # -- Overrides the image tag whose default is the chart's appVersion
-    tag: v1.1.0
-    pullPolicy: IfNotPresent
-    # -- Resource requests and limits for the gateway
-    resources: {}
   livenessComponent:
     # -- The Docker registry
     registry: quay.io

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -12,48 +12,6 @@ kind: ClusterRole
 metadata:
   labels:
     juicefs-csi-driver: master
-  name: juicefs-external-attacher-role
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumes
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - csi.storage.k8s.io
-  resources:
-  - csinodeinfos
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - volumeattachments
-  verbs:
-  - get
-  - list
-  - watch
-  - update
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    juicefs-csi-driver: master
   name: juicefs-external-provisioner-role
 rules:
 - apiGroups:
@@ -117,21 +75,6 @@ rules:
   verbs:
   - get
   - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    juicefs-csi-driver: master
-  name: juicefs-csi-attacher-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: juicefs-external-attacher-role
-subjects:
-- kind: ServiceAccount
-  name: juicefs-csi-controller-sa
-  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -215,17 +158,6 @@ spec:
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
         image: quay.io/k8scsi/csi-provisioner:v1.6.0
         name: csi-provisioner
-        volumeMounts:
-        - mountPath: /var/lib/csi/sockets/pluginproxy/
-          name: socket-dir
-      - args:
-        - --csi-address=$(ADDRESS)
-        - --v=5
-        env:
-        - name: ADDRESS
-          value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: quay.io/k8scsi/csi-attacher:v1.1.0
-        name: csi-attacher
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -346,8 +278,8 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
-      hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:
       - key: CriticalAddonsOnly

--- a/deploy/kubernetes/base/resources.yaml
+++ b/deploy/kubernetes/base/resources.yaml
@@ -49,41 +49,6 @@ roleRef:
   name: juicefs-external-provisioner-role
   apiGroup: rbac.authorization.k8s.io
 
----
-
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: juicefs-external-attacher-role
-rules:
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["csi.storage.k8s.io"]
-    resources: ["csinodeinfos"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
-
----
-
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: juicefs-csi-attacher-binding
-subjects:
-  - kind: ServiceAccount
-    name: juicefs-csi-controller-sa
-    namespace: kube-system
-roleRef:
-  kind: ClusterRole
-  name: juicefs-external-attacher-role
-  apiGroup: rbac.authorization.k8s.io
-
 # ---
 # # TODO(yujunz): support snapshot
 # kind: ClusterRole
@@ -211,29 +176,6 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
-        - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.1.0
-          args:
-            - --csi-address=$(ADDRESS)
-            - --v=5
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-        # # TODO(yujunz) support snapshot
-        # - name: csi-snapshotter
-        #   image: quay.io/k8scsi/csi-snapshotter:v1.1.0
-        #   args:
-        #     - --csi-address=$(ADDRESS)
-        #     - --connection-timeout=15s
-        #   env:
-        #     - name: ADDRESS
-        #       value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        #   volumeMounts:
-        #     - name: socket-dir
-        #       mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
           image: quay.io/k8scsi/livenessprobe:v1.1.0
           args:


### PR DESCRIPTION
The `Attach/Detach` of JuiceFS volumes are skipped by setting `attachRequired: false` in [CSIDriver Object](https://kubernetes-csi.github.io/docs/csi-driver-object.html), we don't need an external-attacher sidecar as documented on [Skip Kubernetes Attach and Detach](https://kubernetes-csi.github.io/docs/skip-attach.html).