### PR TITLE
add ceph librados build docs

### DIFF
--- a/Dockerfile.ceph
+++ b/Dockerfile.ceph
@@ -1,0 +1,52 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as builder
+
+ARG GO_ARCH=amd64
+ARG GOROOT=/usr/local/go
+ARG GOPROXY
+RUN mkdir -p ${GOROOT} && \
+    curl -fsSL https://golang.org/dl/go1.14.linux-${GO_ARCH}.tar.gz | \
+    tar -xzf - -C ${GOROOT} --strip-components=1 && \
+    ${GOROOT}/bin/go version && ${GOROOT}/bin/go env && \
+    yum -y install libcephfs-devel librados-devel librbd-devel gcc make git
+
+ENV GOROOT=${GOROOT} \
+    GOPATH=/go \
+    GOPROXY=${GOPROXY:-https://proxy.golang.org} \
+    CGO_ENABLED=1 \
+    PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
+
+WORKDIR /juicefs-csi-driver
+COPY . .
+RUN make
+
+WORKDIR /workspace
+RUN git clone --depth=1 https://github.com/juicedata/juicefs && \
+    cd juicefs && make juicefs.ceph
+
+FROM ${BASE_IMAGE}
+
+WORKDIR /app
+
+COPY --from=builder /juicefs-csi-driver/bin/juicefs-csi-driver /workspace/juicefs/juicefs.ceph /bin/
+
+RUN mv /bin/juicefs.ceph /bin/juicefs && ln -s /bin/juicefs /bin/mount.juicefs
+COPY THIRD-PARTY /
+
+RUN juicefs --version
+
+ENTRYPOINT ["/bin/juicefs-csi-driver"]

--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ When `juicefs-csi-node` is killed, existing JuiceFS volume will become inaccessi
 
 Delete the pods mounting JuiceFS volume and recreate them to recover.
 
+## Miscellaneous
+
+- [Access ceph cluster with librados](./docs/ceph.md)
+
+
+
 ## Develop
 
 See [DEVELOP](./docs/DEVELOP.md) document.

--- a/docs/ceph.md
+++ b/docs/ceph.md
@@ -1,4 +1,4 @@
-# Build CSI with librados support
+# Access ceph cluster with librados
 
 If the object storage is [Ceph](https://ceph.io/), we can access [radosgw](https://docs.ceph.com/en/latest/radosgw/) using [S3 RESTful API](https://docs.ceph.com/en/latest/radosgw/s3/) . JuiceFS support using [librados](https://docs.ceph.com/en/latest/rados/api/librados/) which radosgw is built on to access the storage, this increases the performance as it reduce the radosgw layer.
 

--- a/docs/ceph.md
+++ b/docs/ceph.md
@@ -1,0 +1,24 @@
+# Build CSI with librados support
+
+If the object storage is [Ceph](https://ceph.io/), we can access [radosgw](https://docs.ceph.com/en/latest/radosgw/) using [S3 RESTful API](https://docs.ceph.com/en/latest/radosgw/s3/) . JuiceFS support using [librados](https://docs.ceph.com/en/latest/rados/api/librados/) which radosgw is built on to access the storage, this increases the performance as it reduce the radosgw layer.
+
+
+
+## How to build
+
+We use the official [ceph/ceph](https://hub.docker.com/r/ceph/ceph) as the base image. If we want to build JuiceFS CSI from Ceph [Nautilus](https://docs.ceph.com/en/latest/releases/nautilus/) :
+
+```bash
+docker build --build-arg BASE_IMAGE=ceph/ceph:v14 -f Dockerfile.ceph -t juicefs-csi-driver:ceph-nautilus .
+```
+
+The `ceph/ceph:v14` image is the official ceph image for ceph nautilus. For other ceph release base images, see the [repository](https://hub.docker.com/r/ceph/ceph) .
+
+
+
+## How to deploy
+
+If we want to deploy JuiceFS CSI with librados support, we have to supply the configuration files in `/etc/ceph/` for JuiceFS to access ceph cluster.
+
+Use the above CSI image as our base image, add the configuration files in `/etc/ceph/` of the ceph cluster into the base image `/etc/ceph/` directory to generate a new CSI image. Use this CSI image to replace `juicedata/juicefs-csi-driver` in the [k8s.yaml](../deploy/k8s.yaml) .
+


### PR DESCRIPTION
Access [ceph](https://ceph.io/) cluster with librados in JuiceFS CSI.
1. Add a docker file `Dockerfile.ceph` for building CSI image
2. Add the doc