### PR TITLE
Fix Helm release workflow: specify release name template from env

### DIFF
--- a/.github/workflows/cr.yaml
+++ b/.github/workflows/cr.yaml
@@ -1,1 +1,0 @@
-release-name-template: "helm-chart-{{ .Name }}-{{ .Version }}"

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -20,9 +20,7 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.1.0
+        uses: helm/chart-releaser-action@v1.2.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          config: .github/workflows/cr.yaml
-
+          CR_RELEASE_NAME_TEMPLATE: "helm-chart-{{ .Name }}-{{ .Version }}"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/149645/115354035-ca65fc80-a1eb-11eb-8a75-7785f9c1664b.png)

`cr.yaml` isn't a legal GitHub Actions workflow file, it will cause error like above image. Since Helm chart releaser [supports](https://github.com/helm/chart-releaser#configuration) set config via environment variable, so delete `cr.yaml` file and use environment variable.