### PR TITLE
Add common labels to `deploy/k8s.yaml`

### DIFF
--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -95,7 +95,10 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    juicefs-csi-driver: master
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/version: master
   name: juicefs-csi-controller
   namespace: kube-system
 spec:
@@ -103,13 +106,15 @@ spec:
   selector:
     matchLabels:
       app: juicefs-csi-controller
-      juicefs-csi-driver: master
+      app.kubernetes.io/name: juicefs-csi-driver
+      app.kubernetes.io/instance: juicefs-csi-driver
   serviceName: juicefs-csi-controller
   template:
     metadata:
       labels:
         app: juicefs-csi-controller
-        juicefs-csi-driver: master
+        app.kubernetes.io/name: juicefs-csi-driver
+        app.kubernetes.io/instance: juicefs-csi-driver
     spec:
       containers:
       - args:
@@ -121,6 +126,7 @@ spec:
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         image: juicedata/juicefs-csi-driver
+        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -188,19 +194,24 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    juicefs-csi-driver: master
+    app.kubernetes.io/component: node
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/version: master
   name: juicefs-csi-node
   namespace: kube-system
 spec:
   selector:
     matchLabels:
       app: juicefs-csi-node
-      juicefs-csi-driver: master
+      app.kubernetes.io/name: juicefs-csi-driver
+      app.kubernetes.io/instance: juicefs-csi-driver
   template:
     metadata:
       labels:
         app: juicefs-csi-node
-        juicefs-csi-driver: master
+        app.kubernetes.io/name: juicefs-csi-driver
+        app.kubernetes.io/instance: juicefs-csi-driver
     spec:
       containers:
       - args:
@@ -212,6 +223,7 @@ spec:
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
         image: juicedata/juicefs-csi-driver
+        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
           httpGet:

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    juicefs-csi-driver: master
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
   name: juicefs-csi-controller-sa
   namespace: kube-system
 ---
@@ -11,7 +13,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    juicefs-csi-driver: master
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
   name: juicefs-external-provisioner-role
 rules:
 - apiGroups:
@@ -80,7 +84,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    juicefs-csi-driver: master
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
   name: juicefs-csi-provisioner-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -96,8 +102,8 @@ kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/name: juicefs-csi-driver
     app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
     app.kubernetes.io/version: master
   name: juicefs-csi-controller
   namespace: kube-system
@@ -106,15 +112,17 @@ spec:
   selector:
     matchLabels:
       app: juicefs-csi-controller
-      app.kubernetes.io/name: juicefs-csi-driver
       app.kubernetes.io/instance: juicefs-csi-driver
+      app.kubernetes.io/name: juicefs-csi-driver
+      app.kubernetes.io/version: master
   serviceName: juicefs-csi-controller
   template:
     metadata:
       labels:
         app: juicefs-csi-controller
-        app.kubernetes.io/name: juicefs-csi-driver
         app.kubernetes.io/instance: juicefs-csi-driver
+        app.kubernetes.io/name: juicefs-csi-driver
+        app.kubernetes.io/version: master
     spec:
       containers:
       - args:
@@ -195,8 +203,8 @@ kind: DaemonSet
 metadata:
   labels:
     app.kubernetes.io/component: node
-    app.kubernetes.io/name: juicefs-csi-driver
     app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
     app.kubernetes.io/version: master
   name: juicefs-csi-node
   namespace: kube-system
@@ -204,14 +212,16 @@ spec:
   selector:
     matchLabels:
       app: juicefs-csi-node
-      app.kubernetes.io/name: juicefs-csi-driver
       app.kubernetes.io/instance: juicefs-csi-driver
+      app.kubernetes.io/name: juicefs-csi-driver
+      app.kubernetes.io/version: master
   template:
     metadata:
       labels:
         app: juicefs-csi-node
-        app.kubernetes.io/name: juicefs-csi-driver
         app.kubernetes.io/instance: juicefs-csi-driver
+        app.kubernetes.io/name: juicefs-csi-driver
+        app.kubernetes.io/version: master
     spec:
       containers:
       - args:
@@ -318,7 +328,9 @@ apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
   labels:
-    juicefs-csi-driver: master
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
   name: csi.juicefs.com
 spec:
   attachRequired: false

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -5,6 +5,8 @@ namespace: kube-system
 resources:
 - resources.yaml
 commonLabels:
-  juicefs-csi-driver: master
+  app.kubernetes.io/name: juicefs-csi-driver
+  app.kubernetes.io/instance: juicefs-csi-driver
+  app.kubernetes.io/version: master
 patches:
 - container-resources.yaml

--- a/deploy/kubernetes/base/resources.yaml
+++ b/deploy/kubernetes/base/resources.yaml
@@ -114,17 +114,26 @@ apiVersion: apps/v1
 metadata:
   name: juicefs-csi-controller
   namespace: kube-system
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/version: master
 spec:
   serviceName: juicefs-csi-controller
   selector:
     matchLabels:
       app: juicefs-csi-controller
+      app.kubernetes.io/name: juicefs-csi-driver
+      app.kubernetes.io/instance: juicefs-csi-driver
   replicas: 1
   volumeClaimTemplates: []
   template:
     metadata:
       labels:
         app: juicefs-csi-controller
+        app.kubernetes.io/name: juicefs-csi-driver
+        app.kubernetes.io/instance: juicefs-csi-driver
     spec:
       serviceAccount: juicefs-csi-controller-sa
       priorityClassName: system-cluster-critical
@@ -134,6 +143,7 @@ spec:
       containers:
         - name: juicefs-plugin
           image: juicedata/juicefs-csi-driver
+          imagePullPolicy: Always
           args :
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
@@ -199,14 +209,23 @@ apiVersion: apps/v1
 metadata:
   name: juicefs-csi-node
   namespace: kube-system
+  labels:
+    app.kubernetes.io/component: node
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/version: master
 spec:
   selector:
     matchLabels:
       app: juicefs-csi-node
+      app.kubernetes.io/name: juicefs-csi-driver
+      app.kubernetes.io/instance: juicefs-csi-driver
   template:
     metadata:
       labels:
         app: juicefs-csi-node
+        app.kubernetes.io/name: juicefs-csi-driver
+        app.kubernetes.io/instance: juicefs-csi-driver
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -219,6 +238,7 @@ spec:
           securityContext:
             privileged: true
           image: juicedata/juicefs-csi-driver
+          imagePullPolicy: Always
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr

--- a/deploy/kubernetes/base/resources.yaml
+++ b/deploy/kubernetes/base/resources.yaml
@@ -121,16 +121,12 @@ spec:
   selector:
     matchLabels:
       app: juicefs-csi-controller
-      app.kubernetes.io/name: juicefs-csi-driver
-      app.kubernetes.io/instance: juicefs-csi-driver
   replicas: 1
   volumeClaimTemplates: []
   template:
     metadata:
       labels:
         app: juicefs-csi-controller
-        app.kubernetes.io/name: juicefs-csi-driver
-        app.kubernetes.io/instance: juicefs-csi-driver
     spec:
       serviceAccount: juicefs-csi-controller-sa
       priorityClassName: system-cluster-critical
@@ -212,14 +208,10 @@ spec:
   selector:
     matchLabels:
       app: juicefs-csi-node
-      app.kubernetes.io/name: juicefs-csi-driver
-      app.kubernetes.io/instance: juicefs-csi-driver
   template:
     metadata:
       labels:
         app: juicefs-csi-node
-        app.kubernetes.io/name: juicefs-csi-driver
-        app.kubernetes.io/instance: juicefs-csi-driver
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/deploy/kubernetes/base/resources.yaml
+++ b/deploy/kubernetes/base/resources.yaml
@@ -116,9 +116,6 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/name: juicefs-csi-driver
-    app.kubernetes.io/instance: juicefs-csi-driver
-    app.kubernetes.io/version: master
 spec:
   serviceName: juicefs-csi-controller
   selector:
@@ -211,9 +208,6 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/component: node
-    app.kubernetes.io/name: juicefs-csi-driver
-    app.kubernetes.io/instance: juicefs-csi-driver
-    app.kubernetes.io/version: master
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
- Add common labels to `deploy/k8s.yaml`, be consistent with [Helm chart](https://github.com/juicedata/juicefs-csi-driver/blob/50c1ca8faa9ebc315cc534108a28dd3431113e2e/charts/juicefs-csi-driver/templates/_helpers.tpl#L33-L51).
- Update `imagePullPolicy` to `Always` of `juicedata/juicefs-csi-driver` image