### PR TITLE
make parameters optional other than name and metaurl in chart & update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To install Helm, refer to the [Helm install guide](https://github.com/helm/helm#
 
 #### Using Helm To Deploy
 
-1. Prepare a `values.yaml` file with access information about Redis and object storage
+1. Prepare a `values.yaml` file with access information about Redis and object storage. If already formatted a volume, only `name` and `metaurl` is required.
 
 ```yaml
 storageClasses:

--- a/charts/juicefs-csi-driver/templates/storageclass.yaml
+++ b/charts/juicefs-csi-driver/templates/storageclass.yaml
@@ -13,10 +13,18 @@ data:
   {{- with $sc.backend }}
   name: {{ .name | b64enc | quote }}
   metaurl: {{ .metaurl | b64enc | quote }}
+  {{- if .storage }}
   storage: {{ .storage | b64enc | quote }}
+  {{- end }}
+  {{- if .accessKey }}
   access-key: {{ .accessKey | b64enc | quote }}
+  {{- end }}
+  {{- if .secretKey }}
   secret-key: {{ .secretKey | b64enc | quote }}
+  {{- end }}
+  {{- if .bucket }}
   bucket: {{ .bucket | b64enc | quote }}
+  {{- end }}
   {{- end }}
 ---
 apiVersion: storage.k8s.io/v1


### PR DESCRIPTION
Parameters other than name and metaurl is already optional in csi driver, make them optional in chart.
fix https://github.com/juicedata/juicefs-csi-driver/issues/86