### PR TITLE
[fix] add attach interface support for being more compatible with kubelet 1.14

### DIFF
--- a/charts/juicefs-csi-driver/templates/controller.yaml
+++ b/charts/juicefs-csi-driver/templates/controller.yaml
@@ -60,6 +60,23 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
+    {{- if semverCompare "<1.16-0" .Capabilities.KubeVersion.Version }}
+      - args:
+        - --v=5
+        - --csi-address=$(ADDRESS)
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        image: {{ printf "%s:%s" .Values.sidecars.csiAttacherImage.repository .Values.sidecars.csiAttacherImage.tag }}
+        imagePullPolicy: IfNotPresent
+        name: csi-attacher
+        resources: { }
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+      {{- end }}
       - name: csi-provisioner
         image: {{ printf "%s:%s" .Values.sidecars.csiProvisionerImage.repository .Values.sidecars.csiProvisionerImage.tag }}
         args:

--- a/charts/juicefs-csi-driver/templates/csidriver.yaml
+++ b/charts/juicefs-csi-driver/templates/csidriver.yaml
@@ -7,5 +7,9 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/resource-policy": keep
 spec:
+  {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.Version}}
   attachRequired: false
+  {{- else }}
+  attachRequired: true
+  {{- end }}
   podInfoOnMount: false

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -22,6 +22,9 @@ sidecars:
   csiProvisionerImage:
     repository: quay.io/k8scsi/csi-provisioner
     tag: "v1.6.0"
+  csiAttacherImage:
+    repository: quay.io/k8scsi/csi-attacher
+    tag: "v2.0.0"
 
 # for some environment without dns server and want to use /etc/hosts instead
 # - ip: "127.0.0.1"

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -333,5 +333,7 @@ metadata:
     app.kubernetes.io/version: master
   name: csi.juicefs.com
 spec:
+  # when kubernetes version below v1.16, attachRequired should be removed
+  # https://github.com/kubernetes/kubernetes/pull/81456
   attachRequired: false
   podInfoOnMount: false

--- a/deploy/kubernetes/k8s-v1.15/controller-patch.yaml
+++ b/deploy/kubernetes/k8s-v1.15/controller-patch.yaml
@@ -1,0 +1,24 @@
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: juicefs-csi-controller
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --v=5
+        - --csi-address=$(ADDRESS)
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        image: quay.io/k8scsi/csi-attacher:v2.0.0
+        imagePullPolicy: IfNotPresent
+        name: csi-attacher
+        resources: { }
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir

--- a/deploy/kubernetes/k8s-v1.15/kustomization.yaml
+++ b/deploy/kubernetes/k8s-v1.15/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# MUST be kube-system for pods with system-cluster-critical priorityClass
+namespace: kube-system
+resources:
+- ../base
+# when kubernetes version below v1.16, attachRequired should be true
+# https://github.com/kubernetes/kubernetes/pull/81456
+patchesJSON6902:
+- target:
+    group: storage.k8s.io
+    version: v1beta1
+    kind: CSIDriver
+    name: csi.juicefs.com
+  patch: |-
+    - op: replace
+      path: /spec/attachRequired
+      value: true
+patchesStrategicMerge:
+  - controller-patch.yaml

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -206,12 +206,16 @@ func (d *controllerService) ControllerExpandVolume(ctx context.Context, req *csi
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-// ControllerPublishVolume unimplemented
+// ControllerPublishVolume implemented
 func (d *controllerService) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
+	// to avoid hitting kubelet issue(https://github.com/kubernetes/kubernetes/pull/81456) which fixed in kubernetes v1.16
+	// add an empty response here
+	return &csi.ControllerPublishVolumeResponse{}, nil
 }
 
-// ControllerUnpublishVolume unimplemented
+// ControllerUnpublishVolume implemented
 func (d *controllerService) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
+	// to avoid hitting kubelet issue(https://github.com/kubernetes/kubernetes/pull/81456) which fixed in kubernetes v1.16
+	// add an empty response here
+	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }


### PR DESCRIPTION
An alternative way to fix csi attachable issue on kubelet when kubernetes's version is below v1.16

When I install juicefs-csi-driver in our customer's Kubernetes cluster which version is v1.14.6, I found there are lots of errors in kubelet's log and the error keeps outputting that leads to kubelet log size could be GB per day.
```
6月 10 00:17:53 node_1_16 kubelet[27805]: E0610 00:17:53.376382 27805 reconciler.go:312] operationExecutor.DetachVolume failed (controllerAttachDetachEnabled false) for volume "hadoop-v-1--48723038-data-algo-pv-16231341053439405" (UniqueName: "kubernetes.io/csi/csi.juicefs.com^hadoop-v-1--48723038-data-algo-pv-16231341053439405") on node "192.168.1.16" : DetachVolume.FindAttachablePluginBySpec failed for volume "hadoop-v-1--48723038-data-algo-pv-16231341053439405" (UniqueName: "kubernetes.io/csi/csi.juicefs.com^hadoop-v-1--48723038-data-algo-pv-16231341053439405") on node "192.168.1.16"
6月 10 00:17:53 node_1_16 kubelet[27805]: E0610 00:17:53.480314 27805 reconciler.go:312] operationExecutor.DetachVolume failed (controllerAttachDetachEnabled false) for volume "tensorflow-5-1--48723038-model-pv" (UniqueName: "kubernetes.io/csi/csi.juicefs.com^tensorflow-5-1--48723038-model-pv") on node "192.168.1.16" : DetachVolume.FindAttachablePluginBySpec failed for volume "tensorflow-5-1--48723038-model-pv" (UniqueName: "kubernetes.io/csi/csi.juicefs.com^tensorflow-5-1--48723038-model-pv") on node "192.168.1.16"
```
The log shows that error happening when Kubelet was doing volume detach. However, this is not what we expected since we have defined `attachRequired: false` in the CSIDriver object. After some code analysis work, I found Kubelet Always treats CSI volume as attachable, which means `attachRequired` is ignored in this phase.

https://github.com/kubernetes/kubernetes/blob/a34f1e483104bd51c3e9a6aec3dbbcf6301789da/pkg/kubelet/volumemanager/cache/actual_state_of_world.go#L400-L404

```
	pluginIsAttachable := false	
        if _, ok := volumePlugin.(volume.AttachableVolumePlugin); ok {		
                  pluginIsAttachable = true	
        }
```

This issue has been fixed in `https://github.com/kubernetes/kubernetes/pull/81456` and released in Kubernetes 1.16

IMHO,  Maybe we could generate an empty ControllerPublishVolume&ControllerUnpublishVolume respond to Kubelet when its version is below 1.16

Signed-off-by: 屈骏 <qujun@tiduyun.com>