### PR TITLE
fix umount

### DIFF
--- a/pkg/juicefs/pod.go
+++ b/pkg/juicefs/pod.go
@@ -137,6 +137,11 @@ func NewMountPod(podName, cmd, mountPath string, resourceRequirements corev1.Res
 					InitialDelaySeconds: 1,
 					PeriodSeconds:       1,
 				},
+				Lifecycle: &corev1.Lifecycle{
+					PreStop: &corev1.Handler{
+						Exec: &corev1.ExecAction{Command: []string{"sh", "-c", fmt.Sprintf("umount %s", mountPath)}},
+					},
+				},
 			}},
 			Volumes:  volumes,
 			NodeName: NodeName,


### PR DESCRIPTION
When replicas of deployment is greater than 1, unPublish interface will delete mount pod and than umount bind path and umount mount point. However, delete mount pod first results in " transport endpoint is not connected" when umounting. And umounting may possibly result in umount fail without feedback.

To fix the bug above, add umount cmd in mount pod preStop and delete mount pod after umount bind.