### PR TITLE
Ensure JFSConfigDir is configurable

### DIFF
--- a/charts/juicefs-csi-driver/templates/controller.yaml
+++ b/charts/juicefs-csi-driver/templates/controller.yaml
@@ -129,7 +129,7 @@ spec:
           type: DirectoryOrCreate
         name: jfs-dir
       - hostPath:
-          path: /var/lib/juicefs/config
+          path: {{ .Values.jfsConfigDir }}
           type: DirectoryOrCreate
         name: jfs-root-dir
 {{- end }}

--- a/charts/juicefs-csi-driver/templates/daemonset.yaml
+++ b/charts/juicefs-csi-driver/templates/daemonset.yaml
@@ -165,7 +165,7 @@ spec:
           type: DirectoryOrCreate
         name: jfs-dir
       - hostPath:
-          path: /var/lib/juicefs/config
+          path: {{ .Values.jfsConfigDir }}
           type: DirectoryOrCreate
         name: jfs-root-dir
 {{- end }}


### PR DESCRIPTION
Fixes an issue where setting the jfsConfigDir wasn't reflected in the manifests.