### PR TITLE
Fix  the environment variables key error  of use juicefs-csi-driver in GKE

### DIFF
--- a/examples/static-provisioning-config-and-env/README.md
+++ b/examples/static-provisioning-config-and-env/README.md
@@ -29,7 +29,7 @@ The key of `configs` is the secret name, value is the path of secret being mount
 
 ```
 bucket=<bucket>
-envs={GOOGLE_CLOUD_PROJECT: "/root/.config/gcloud/application_default_credentials.json"}
+envs={GOOGLE_APPLICATION_CREDENTIALS: "/root/.config/gcloud/application_default_credentials.json"}
 configs={"gc-secret": "/root/.config/gcloud"}
 metaurl=<metaurl>
 name=<name>

--- a/examples/static-provisioning-config-and-env/README.md
+++ b/examples/static-provisioning-config-and-env/README.md
@@ -65,7 +65,7 @@ $ kubectl get po juicefs-kube-node-3-test-bucket -oyaml |grep env -A 4
     env:
     - name: JFS_FOREGROUND
       value: "1"
-    - name: GOOGLE_CLOUD_PROJECT
+    - name: GOOGLE_APPLICATION_CREDENTIALS
       value: /root/.config/gcloud/application_default_credentials.json
 ```
 

--- a/pkg/juicefs/config/setting_test.go
+++ b/pkg/juicefs/config/setting_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestParseSecret(t *testing.T) {
-	s := map[string]string{"GOOGLE_CLOUD_PROJECT": "/root/.config/gcloud/application_default_credentials.json"}
+	s := map[string]string{"GOOGLE_APPLICATION_CREDENTIALS": "/root/.config/gcloud/application_default_credentials.json"}
 	ss, _ := json.Marshal(s)
 	fmt.Println(string(ss))
 
@@ -44,7 +44,7 @@ func TestParseSecret(t *testing.T) {
 			args: args{
 				secrets: map[string]string{
 					"name": "test",
-					"envs": "GOOGLE_CLOUD_PROJECT: \"/root/.config/gcloud/application_default_credentials.json\"",
+					"envs": "GOOGLE_APPLICATION_CREDENTIALS: \"/root/.config/gcloud/application_default_credentials.json\"",
 				},
 				usePod: true,
 			},


### PR DESCRIPTION
Change the environment variables key  `GKEGOOGLE_CLOUD_PROJECT` to `GOOGLE_APPLICATION_CREDENTIALS`