### PR TITLE
add rmdir mountPath after umount

### DIFF
--- a/pkg/juicefs/mount/pod.go
+++ b/pkg/juicefs/mount/pod.go
@@ -144,7 +144,8 @@ func NewMountPod(podName, cmd, mountPath string, resourceRequirements corev1.Res
 				},
 				Lifecycle: &corev1.Lifecycle{
 					PreStop: &corev1.Handler{
-						Exec: &corev1.ExecAction{Command: []string{"sh", "-c", fmt.Sprintf("umount %s", mountPath)}},
+						Exec: &corev1.ExecAction{Command: []string{"sh", "-c", fmt.Sprintf(
+							"umount %s && rmdir %s", mountPath, mountPath)}},
 					},
 				},
 			}},


### PR DESCRIPTION
当mount pod被销毁后，清理残留的pvc目录，/var/lib/juicefs/volume/pvc-xxx