### PR TITLE
fix secret deleted when mount pod is deleted

### DIFF
--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -163,6 +163,12 @@ func (p *PodDriver) checkAnnotations(pod *corev1.Pod) error {
 				klog.Errorf("Delete pod %s error: %v", pod.Name, err)
 				return err
 			}
+			// delete related secret
+			secretName := pod.Name + "-secret"
+			klog.V(5).Infof("delete related secret of pod: %s", secretName)
+			if err := p.Client.DeleteSecret(secretName, pod.Namespace); err != nil {
+				klog.V(5).Infof("Delete secret %s error: %v", secretName, err)
+			}
 		}
 	}
 	return nil

--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -165,7 +165,7 @@ func (p *PodDriver) checkAnnotations(pod *corev1.Pod) error {
 			}
 			// delete related secret
 			secretName := pod.Name + "-secret"
-			klog.V(5).Infof("delete related secret of pod: %s", secretName)
+			klog.V(6).Infof("delete related secret of pod: %s", secretName)
 			if err := p.Client.DeleteSecret(secretName, pod.Namespace); err != nil {
 				klog.V(5).Infof("Delete secret %s error: %v", secretName, err)
 			}


### PR DESCRIPTION
fix https://github.com/juicedata/juicefs-csi-driver/issues/300

It's because secret used in mount pod set owner as mount pod. When mount pod is deleted, secret will be deleted automatically. And it's not be created again when mount pod is recreated by csi.

This pr do not set mount pod as owner of secret. And delete secret when mount pod should be deleted. 