### PR TITLE
bump node-driver-registar to 2.1.0

### DIFF
--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -459,14 +459,7 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/csi-plugins/csi.juicefs.com/csi.sock
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - rm /registration/csi.juicefs.com-reg.sock
+        image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
         name: node-driver-registrar
         volumeMounts:
         - mountPath: /csi

--- a/deploy/k8s_before_v1_18.yaml
+++ b/deploy/k8s_before_v1_18.yaml
@@ -459,14 +459,7 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/csi-plugins/csi.juicefs.com/csi.sock
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - rm /registration/csi.juicefs.com-reg.sock
+        image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
         name: node-driver-registrar
         volumeMounts:
         - mountPath: /csi

--- a/deploy/kubernetes/base/resources.yaml
+++ b/deploy/kubernetes/base/resources.yaml
@@ -397,7 +397,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -412,13 +412,6 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  - /bin/sh
-                  - -c
-                  - rm /registration/csi.juicefs.com-reg.sock
         - name: liveness-probe
           image: quay.io/k8scsi/livenessprobe:v1.1.0
           args:


### PR DESCRIPTION
node-driver-registar has no /bin/sh, prestop will fail; 
bump node-driver-registar to 2.1.0 which remove reg.sock before exit

refer to https://github.com/kubernetes-csi/node-driver-registrar/pull/61