### PR TITLE
add TARGETARCH env in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,12 +140,8 @@ image-release-check:
 	echo JUICEFS_RELEASE_CHECK_VERSION=$(JUICEFS_RELEASE_CHECK_VERSION)
 	docker build --build-arg JUICEFS_CSI_REPO_REF=master \
         --build-arg JUICEFS_REPO_REF=$(JUICEFS_RELEASE_CHECK_VERSION) \
-<<<<<<< HEAD
 		--build-arg TARGETARCH=$(TARGETARCH) \
-=======
-		--build-arg TARGETARCH=amd64 \
 		--build-arg JFSCHAN=$(JFS_CHAN) \
->>>>>>> master
 		--build-arg=JFS_AUTO_UPGRADE=disabled \
 		-t $(IMAGE):$(DEV_TAG) -f Dockerfile .
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@
 # limitations under the License.
 #
 IMAGE=juicedata/juicefs-csi-driver
-REGISTRY=docker.io
+REGISTRY?=docker.io
+TARGETARCH?=amd64
 VERSION=$(shell git describe --tags --match 'v*' --always --dirty)
 GIT_BRANCH?=$(shell git rev-parse --abbrev-ref HEAD)
 GIT_COMMIT?=$(shell git rev-parse HEAD)
@@ -52,7 +53,7 @@ test-sanity:
 .PHONY: image-nightly
 image-nightly:
 	# Build image with newest juicefs-csi-driver and juicefs
-	docker build --build-arg TARGETARCH=amd64 -t $(IMAGE):nightly .
+	docker build --build-arg TARGETARCH=$(TARGETARCH) -t $(IMAGE):nightly .
 
 .PHONY: push
 push-nightly:
@@ -70,7 +71,7 @@ image-latest:
 	docker build --build-arg JUICEFS_CSI_REPO_REF=$(JUICEFS_CSI_LATEST_VERSION) \
 		--build-arg JUICEFS_REPO_REF=$(JUICEFS_LATEST_VERSION) \
 		--build-arg JFS_AUTO_UPGRADE=disabled \
-		--build-arg TARGETARCH=amd64 \
+		--build-arg TARGETARCH=$(TARGETARCH) \
 		-t $(IMAGE):latest -f Dockerfile .
 
 .PHONY: push-latest
@@ -80,7 +81,7 @@ push-latest:
 
 .PHONY: image-branch
 image-branch:
-	docker build --build-arg TARGETARCH=amd64 -t $(IMAGE):$(GIT_BRANCH) -f Dockerfile .
+	docker build --build-arg TARGETARCH=$(TARGETARCH) -t $(IMAGE):$(GIT_BRANCH) -f Dockerfile .
 
 .PHONY: push-branch
 push-branch:
@@ -117,7 +118,7 @@ uninstall: deploy/k8s.yaml
 .PHONY: image-dev
 image-dev: juicefs-csi-driver
 	docker pull $(IMAGE):nightly
-	docker build --build-arg TARGETARCH=amd64 -t $(IMAGE):$(DEV_TAG) -f dev.Dockerfile bin
+	docker build --build-arg TARGETARCH=$(TARGETARCH) -t $(IMAGE):$(DEV_TAG) -f dev.Dockerfile bin
 
 .PHONY: push-dev
 push-dev:
@@ -138,7 +139,7 @@ image-release-check:
 	echo JUICEFS_RELEASE_CHECK_VERSION=$(JUICEFS_RELEASE_CHECK_VERSION)
 	docker build --build-arg JUICEFS_CSI_REPO_REF=master \
         --build-arg JUICEFS_REPO_REF=$(JUICEFS_RELEASE_CHECK_VERSION) \
-		--build-arg TARGETARCH=amd64 \
+		--build-arg TARGETARCH=$(TARGETARCH) \
 		--build-arg=JFS_AUTO_UPGRADE=disabled \
 		-t $(IMAGE):$(DEV_TAG) -f Dockerfile .
 


### PR DESCRIPTION
Signed-off-by: xixi <i@hexilee.me>

Some target in Makefile cannot work on arm64, so I add an env variable for developer to choose target architecture.