### PR TITLE
pass context around to control the calling chain timeout

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -71,10 +71,10 @@ func init() {
 	config.HostIp = os.Getenv("HOST_IP")
 	config.KubeletPort = os.Getenv("KUBELET_PORT")
 	jfsMountPriorityName := os.Getenv("JUICEFS_MOUNT_PRIORITY_NAME")
-	if timeout := os.Getenv("JUICEFS_CONTEXT_TIMEOUT"); timeout != "" {
+	if timeout := os.Getenv("JUICEFS_RECONCILE_TIMEOUT"); timeout != "" {
 		duration, _ := time.ParseDuration(timeout)
-		if duration > config.ContextTimeout {
-			config.ContextTimeout = duration
+		if duration > config.ReconcileTimeout {
+			config.ReconcileTimeout = duration
 		}
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,11 +19,13 @@ package main
 import (
 	"flag"
 	"fmt"
-	"k8s.io/klog"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"strings"
+	"time"
+
+	"k8s.io/klog"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -68,6 +70,13 @@ func init() {
 	config.HostIp = os.Getenv("HOST_IP")
 	config.KubeletPort = os.Getenv("KUBELET_PORT")
 	jfsMountPriorityName := os.Getenv("JUICEFS_MOUNT_PRIORITY_NAME")
+	if timeout := os.Getenv("JUICEFS_CONTEXT_TIMEOUT"); timeout != "" {
+		duration, _ := time.ParseDuration(timeout)
+		if duration > config.ContextTimeout {
+			config.ContextTimeout = duration
+		}
+	}
+
 	if jfsMountPriorityName != "" {
 		config.JFSMountPriorityName = jfsMountPriorityName
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,7 +24,6 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"strings"
-	"time"
 
 	"k8s.io/klog"
 
@@ -71,12 +70,6 @@ func init() {
 	config.HostIp = os.Getenv("HOST_IP")
 	config.KubeletPort = os.Getenv("KUBELET_PORT")
 	jfsMountPriorityName := os.Getenv("JUICEFS_MOUNT_PRIORITY_NAME")
-	if timeout := os.Getenv("JUICEFS_RECONCILE_TIMEOUT"); timeout != "" {
-		duration, _ := time.ParseDuration(timeout)
-		if duration > config.ReconcileTimeout {
-			config.ReconcileTimeout = duration
-		}
-	}
 
 	if jfsMountPriorityName != "" {
 		config.JFSMountPriorityName = jfsMountPriorityName

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net/http"
@@ -101,7 +102,7 @@ func init() {
 		klog.V(5).Infof("Can't get k8s client: %v", err)
 		os.Exit(0)
 	}
-	pod, err := k8sclient.GetPod(config.PodName, config.Namespace)
+	pod, err := k8sclient.GetPod(context.TODO(), config.PodName, config.Namespace)
 	if err != nil {
 		klog.V(5).Infof("Can't get pod %s: %v", config.PodName, err)
 		os.Exit(0)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"hash/fnv"
 	"sync"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -30,13 +31,14 @@ var (
 	Provisioner  = false // provisioner in controller
 	MountManager = false // manage mount pod in controller (only in k8s)
 
-	NodeName    = ""
-	Namespace   = ""
-	PodName     = ""
-	MountImage  = ""
-	MountLabels = ""
-	HostIp      = ""
-	KubeletPort = ""
+	NodeName       = ""
+	Namespace      = ""
+	PodName        = ""
+	MountImage     = ""
+	MountLabels    = ""
+	HostIp         = ""
+	KubeletPort    = ""
+	ContextTimeout = 15 * time.Second
 
 	CSIPod = corev1.Pod{}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,7 +38,7 @@ var (
 	MountLabels    = ""
 	HostIp         = ""
 	KubeletPort    = ""
-	ContextTimeout = 15 * time.Second
+	ContextTimeout = 1 * time.Minute
 
 	CSIPod = corev1.Pod{}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,6 @@ package config
 import (
 	"hash/fnv"
 	"sync"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -31,14 +30,13 @@ var (
 	Provisioner  = false // provisioner in controller
 	MountManager = false // manage mount pod in controller (only in k8s)
 
-	NodeName         = ""
-	Namespace        = ""
-	PodName          = ""
-	MountImage       = ""
-	MountLabels      = ""
-	HostIp           = ""
-	KubeletPort      = ""
-	ReconcileTimeout = 1 * time.Minute
+	NodeName    = ""
+	Namespace   = ""
+	PodName     = ""
+	MountImage  = ""
+	MountLabels = ""
+	HostIp      = ""
+	KubeletPort = ""
 
 	CSIPod = corev1.Pod{}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,14 +31,14 @@ var (
 	Provisioner  = false // provisioner in controller
 	MountManager = false // manage mount pod in controller (only in k8s)
 
-	NodeName       = ""
-	Namespace      = ""
-	PodName        = ""
-	MountImage     = ""
-	MountLabels    = ""
-	HostIp         = ""
-	KubeletPort    = ""
-	ContextTimeout = 1 * time.Minute
+	NodeName         = ""
+	Namespace        = ""
+	PodName          = ""
+	MountImage       = ""
+	MountLabels      = ""
+	HostIp           = ""
+	KubeletPort      = ""
+	ReconcileTimeout = 1 * time.Minute
 
 	CSIPod = corev1.Pod{}
 

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -30,6 +30,9 @@ import (
 	"k8s.io/klog"
 )
 
+const defaultContextTimeout = 10 * time.Second
+const ContextTimeoutEnv = "JFS_CONTEXT_TIMEOUT"
+
 type JfsSetting struct {
 	IsCe   bool
 	UsePod bool

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -30,9 +30,6 @@ import (
 	"k8s.io/klog"
 )
 
-const defaultContextTimeout = 10 * time.Second
-const ContextTimeoutEnv = "JFS_CONTEXT_TIMEOUT"
-
 type JfsSetting struct {
 	IsCe   bool
 	UsePod bool

--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -75,13 +75,13 @@ const (
 
 func (p *PodDriver) Run(ctx context.Context, current *corev1.Pod) error {
 	// check refs in mount pod annotation first, delete ref that target pod is not found
-	err := p.checkAnnotations(current)
+	err := p.checkAnnotations(ctx, current)
 	if apierrors.IsConflict(err) {
-		current, err = p.Client.GetPod(current.Name, current.Namespace)
+		current, err = p.Client.GetPod(ctx, current.Name, current.Namespace)
 		if err != nil {
 			return err // temporary
 		}
-		err = p.checkAnnotations(current)
+		err = p.checkAnnotations(ctx, current)
 	}
 	if err != nil {
 		klog.Errorf("check pod %s annotations err: %v", current.Name, err)
@@ -95,7 +95,7 @@ func (p *PodDriver) Run(ctx context.Context, current *corev1.Pod) error {
 
 	// resourceVersion of kubelet may be different from apiserver
 	// so we need get latest pod resourceVersion from apiserver
-	pod, err := p.Client.GetPod(current.Name, current.Namespace)
+	pod, err := p.Client.GetPod(ctx, current.Name, current.Namespace)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (p *PodDriver) getPodStatus(pod *corev1.Pod) podStatus {
 	return podPending
 }
 
-func (p *PodDriver) checkAnnotations(pod *corev1.Pod) error {
+func (p *PodDriver) checkAnnotations(ctx context.Context, pod *corev1.Pod) error {
 	// check refs in mount pod, the corresponding pod exists or not
 	lock := config.GetPodLock(pod.Name)
 	lock.Lock()
@@ -144,28 +144,28 @@ func (p *PodDriver) checkAnnotations(pod *corev1.Pod) error {
 		delete(annotation, config.DeleteDelayAtKey)
 	}
 	if len(pod.Annotations) != len(annotation) {
-		if err := util.PatchPodAnnotation(p.Client, pod, annotation); err != nil {
+		if err := util.PatchPodAnnotation(ctx, p.Client, pod, annotation); err != nil {
 			klog.Errorf("Update pod %s error: %v", pod.Name, err)
 			return err
 		}
 	}
 	if existTargets == 0 && pod.DeletionTimestamp == nil {
 		var shouldDelay bool
-		shouldDelay, err := util.ShouldDelay(pod, p.Client)
+		shouldDelay, err := util.ShouldDelay(ctx, pod, p.Client)
 		if err != nil {
 			return err
 		}
 		if !shouldDelay {
 			// if there are no refs or after delay time, delete it
 			klog.V(5).Infof("There are no refs in pod %s annotation, delete it", pod.Name)
-			if err := p.Client.DeletePod(pod); err != nil {
+			if err := p.Client.DeletePod(ctx, pod); err != nil {
 				klog.Errorf("Delete pod %s error: %v", pod.Name, err)
 				return err
 			}
 			// delete related secret
 			secretName := pod.Name + "-secret"
 			klog.V(6).Infof("delete related secret of pod: %s", secretName)
-			if err := p.Client.DeleteSecret(secretName, pod.Namespace); err != nil {
+			if err := p.Client.DeleteSecret(ctx, secretName, pod.Namespace); err != nil {
 				klog.V(5).Infof("Delete secret %s error: %v", secretName, err)
 			}
 		}
@@ -186,16 +186,16 @@ func (p *PodDriver) podErrorHandler(ctx context.Context, pod *corev1.Pod) error 
 		klog.V(5).Infof("waitUtilMount: Pod is failed because of resource.")
 		if util.IsPodHasResource(*pod) {
 			// if pod is failed because of resource, delete resource and deploy pod again.
-			_ = util.RemoveFinalizer(p.Client, pod, config.Finalizer)
+			_ = util.RemoveFinalizer(ctx, p.Client, pod, config.Finalizer)
 			klog.V(5).Infof("Delete it and deploy again with no resource.")
-			if err := p.Client.DeletePod(pod); err != nil {
+			if err := p.Client.DeletePod(ctx, pod); err != nil {
 				klog.Errorf("delete po:%s err:%v", pod.Name, err)
 				return nil
 			}
 			isDeleted := false
 			// wait pod delete for 1min
 			for i := 0; i < 120; i++ {
-				_, err := p.Client.GetPod(pod.Name, pod.Namespace)
+				_, err := p.Client.GetPod(ctx, pod.Name, pod.Namespace)
 				if err == nil {
 					klog.V(6).Infof("pod %s %s still exists wait.", pod.Name, pod.Namespace)
 					time.Sleep(time.Microsecond * 500)
@@ -222,7 +222,7 @@ func (p *PodDriver) podErrorHandler(ctx context.Context, pod *corev1.Pod) error 
 			}
 			controllerutil.AddFinalizer(newPod, config.Finalizer)
 			util.DeleteResourceOfPod(newPod)
-			_, err := p.Client.CreatePod(newPod)
+			_, err := p.Client.CreatePod(ctx, newPod)
 			if err != nil {
 				klog.Errorf("create pod:%s err:%v", pod.Name, err)
 			}
@@ -253,7 +253,7 @@ func (p *PodDriver) podDeletedHandler(ctx context.Context, pod *corev1.Pod) erro
 	}
 
 	// remove finalizer of pod
-	if err := util.RemoveFinalizer(p.Client, pod, config.Finalizer); err != nil {
+	if err := util.RemoveFinalizer(ctx, p.Client, pod, config.Finalizer); err != nil {
 		klog.Errorf("remove pod finalizer err:%v", err)
 		return err
 	}
@@ -292,7 +292,7 @@ func (p *PodDriver) podDeletedHandler(ctx context.Context, pod *corev1.Pod) erro
 			klog.Errorf("Clean mount point %s error: %v", sourcePath, err)
 		}
 		// cleanup cache if set
-		go p.CleanUpCache(pod)
+		go p.CleanUpCache(ctx, pod)
 		return nil
 	}
 
@@ -305,7 +305,7 @@ func (p *PodDriver) podDeletedHandler(ctx context.Context, pod *corev1.Pod) erro
 
 	// check pod delete
 	for i := 0; i < 120; i++ {
-		po, err := p.Client.GetPod(pod.Name, pod.Namespace)
+		po, err := p.Client.GetPod(ctx, pod.Name, pod.Namespace)
 		if err == nil && po.DeletionTimestamp != nil {
 			klog.V(6).Infof("pod %s %s is being deleted, waiting", pod.Name, pod.Namespace)
 			time.Sleep(time.Millisecond * 500)
@@ -337,7 +337,7 @@ func (p *PodDriver) podDeletedHandler(ctx context.Context, pod *corev1.Pod) erro
 				}
 				controllerutil.AddFinalizer(newPod, config.Finalizer)
 				klog.Infof("Need to create pod %s %s", pod.Name, pod.Namespace)
-				_, err = p.Client.CreatePod(newPod)
+				_, err = p.Client.CreatePod(ctx, newPod)
 				if err != nil {
 					klog.Errorf("Create pod:%s err:%v", pod.Name, err)
 				}
@@ -355,7 +355,7 @@ func (p *PodDriver) podDeletedHandler(ctx context.Context, pod *corev1.Pod) erro
 			// add exist target in annotation
 			po.Annotations[k] = v
 		}
-		if err := util.PatchPodAnnotation(p.Client, pod, annotation); err != nil {
+		if err := util.PatchPodAnnotation(ctx, p.Client, pod, annotation); err != nil {
 			klog.Errorf("Update pod %s %s error: %v", po.Name, po.Namespace, err)
 		}
 		return err
@@ -475,7 +475,7 @@ func (p *PodDriver) umountTarget(target string, count int) {
 	}
 }
 
-func (p PodDriver) CleanUpCache(pod *corev1.Pod) {
+func (p PodDriver) CleanUpCache(ctx context.Context, pod *corev1.Pod) {
 	if pod.Annotations[config.CleanCache] != "true" {
 		return
 	}
@@ -490,7 +490,7 @@ func (p PodDriver) CleanUpCache(pod *corev1.Pod) {
 	// wait for pod deleted.
 	isDeleted := false
 	for i := 0; i < 360; i++ {
-		if _, err := p.Client.GetPod(pod.Name, pod.Namespace); err != nil {
+		if _, err := p.Client.GetPod(ctx, pod.Name, pod.Namespace); err != nil {
 			if apierrors.IsNotFound(err) {
 				isDeleted = true
 				break
@@ -513,7 +513,7 @@ func (p PodDriver) CleanUpCache(pod *corev1.Pod) {
 			cacheDirs = append(cacheDirs, dir.HostPath.Path)
 		}
 	}
-	if err := podMnt.CleanCache(uuid, uniqueId, cacheDirs); err != nil {
+	if err := podMnt.CleanCache(ctx, uuid, uniqueId, cacheDirs); err != nil {
 		klog.V(5).Infof("[CleanUpCache] Cleanup cache of volume %s error %v", uniqueId, err)
 	}
 }

--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -284,7 +284,7 @@ func (p *PodDriver) podDeletedHandler(ctx context.Context, pod *corev1.Pod) erro
 		// do not need to create new one, umount
 		util.UmountPath(ctx, sourcePath)
 		// clean mount point
-		err = util.DoWithContext(ctx, func() error {
+		_, err = util.DoWithinTime(ctx, defaultCheckoutTimeout, nil, func() error {
 			klog.V(5).Infof("Clean mount point : %s", sourcePath)
 			return mount.CleanupMountPoint(sourcePath, p.SafeFormatAndMount.Interface, false)
 		})
@@ -314,7 +314,7 @@ func (p *PodDriver) podDeletedHandler(ctx context.Context, pod *corev1.Pod) erro
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				// umount mount point before recreate mount pod
-				err := util.DoWithContext(ctx, func() error {
+				_, err = util.DoWithinTime(ctx, defaultCheckoutTimeout, nil, func() error {
 					exist, _ := mount.PathExists(sourcePath)
 					if !exist {
 						return fmt.Errorf("%s not exist", sourcePath)
@@ -386,7 +386,7 @@ func (p *PodDriver) podReadyHandler(ctx context.Context, pod *corev1.Pod) error 
 		return nil
 	}
 
-	e := util.DoWithContext(ctx, func() error {
+	_, e := util.DoWithinTime(ctx, defaultCheckoutTimeout, nil, func() error {
 		_, e := os.Stat(mntPath)
 		return e
 	})

--- a/pkg/controller/pod_driver_test.go
+++ b/pkg/controller/pod_driver_test.go
@@ -19,13 +19,14 @@ package controller
 import (
 	"context"
 	"errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"os"
 	"os/exec"
 	"reflect"
 	"syscall"
 	"testing"
 	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	k8sexec "k8s.io/utils/exec"
 
@@ -755,13 +756,13 @@ func TestPodDriver_podDeletedHandler(t *testing.T) {
 			})
 			defer patch1.Reset()
 			tmpPod := copyPod(readyPod)
-			_, err := d.Client.CreatePod(tmpPod)
+			_, err := d.Client.CreatePod(context.TODO(), tmpPod)
 			if err != nil {
 				t.Fatal(err)
 			}
 			patch2 := ApplyMethod(reflect.TypeOf(tmpCmd), "CombinedOutput",
 				func(_ *exec.Cmd) ([]byte, error) {
-					err := d.Client.DeletePod(tmpPod)
+					err := d.Client.DeletePod(context.TODO(), tmpPod)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -814,7 +815,7 @@ func TestPodDriver_podDeletedHandler(t *testing.T) {
 			})
 			tmpPod := copyPod(resourceErrPod)
 			tmpPod.Annotations = nil
-			_, err := d.Client.CreatePod(tmpPod)
+			_, err := d.Client.CreatePod(context.TODO(), tmpPod)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -830,7 +831,7 @@ func TestPodDriver_podDeletedHandler(t *testing.T) {
 			tmpPod.Annotations = map[string]string{
 				"/var/lib/xxx": "/var/lib/xxx",
 			}
-			_, err := d.Client.CreatePod(tmpPod)
+			_, err := d.Client.CreatePod(context.TODO(), tmpPod)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -844,7 +845,7 @@ func TestPodDriver_podDeletedHandler(t *testing.T) {
 			})
 			tmpPod := copyPod(readyPod)
 			tmpPod.Spec.Containers = nil
-			_, err := d.Client.CreatePod(tmpPod)
+			_, err := d.Client.CreatePod(context.TODO(), tmpPod)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -862,7 +863,7 @@ func TestPodDriver_podDeletedHandler(t *testing.T) {
 			})
 			defer patch1.Reset()
 			tmpPod := copyPod(readyPod)
-			_, err := d.Client.CreatePod(tmpPod)
+			_, err := d.Client.CreatePod(context.TODO(), tmpPod)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -934,8 +935,8 @@ func TestPodDriver_podErrorHandler(t *testing.T) {
 				return false, notExistsErr
 			})
 			defer patch1.Reset()
-			_, err := d.Client.CreatePod(errorPod1)
-			defer d.Client.DeletePod(errorPod1)
+			_, err := d.Client.CreatePod(context.TODO(), errorPod1)
+			defer d.Client.DeletePod(context.TODO(), errorPod1)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -960,7 +961,7 @@ func TestPodDriver_podErrorHandler(t *testing.T) {
 			})
 			defer patch1.Reset()
 			errPod := copyPod(resourceErrPod)
-			d.Client.CreatePod(errPod)
+			d.Client.CreatePod(context.TODO(), errPod)
 			err := d.podErrorHandler(context.Background(), errPod)
 			So(err, ShouldBeNil)
 		})

--- a/pkg/controller/pod_driver_test.go
+++ b/pkg/controller/pod_driver_test.go
@@ -676,15 +676,15 @@ func TestPodDriver_podDeletedHandler(t *testing.T) {
 			})
 			defer patch2.Reset()
 			k := &k8sclient.K8sClient{}
-			patch3 := ApplyMethod(reflect.TypeOf(k), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch3 := ApplyMethod(reflect.TypeOf(k), "GetPod", func(_ *k8sclient.K8sClient, _ context.Context, podName, namespace string) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch3.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(k), "PatchPod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod, data []byte) error {
+			patch4 := ApplyMethod(reflect.TypeOf(k), "PatchPod", func(_ *k8sclient.K8sClient, _ context.Context, pod *corev1.Pod, data []byte) error {
 				return nil
 			})
 			defer patch4.Reset()
-			patch5 := ApplyMethod(reflect.TypeOf(k), "CreatePod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod) (*corev1.Pod, error) {
+			patch5 := ApplyMethod(reflect.TypeOf(k), "CreatePod", func(_ *k8sclient.K8sClient, _ context.Context, pod *corev1.Pod) (*corev1.Pod, error) {
 				return nil, nil
 			})
 			defer patch5.Reset()
@@ -716,15 +716,15 @@ func TestPodDriver_podDeletedHandler(t *testing.T) {
 			})
 			defer patch2.Reset()
 			k := &k8sclient.K8sClient{}
-			patch3 := ApplyMethod(reflect.TypeOf(k), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch3 := ApplyMethod(reflect.TypeOf(k), "GetPod", func(_ *k8sclient.K8sClient, _ context.Context, podName, namespace string) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch3.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(k), "PatchPod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod, data []byte) error {
+			patch4 := ApplyMethod(reflect.TypeOf(k), "PatchPod", func(_ *k8sclient.K8sClient, _ context.Context, pod *corev1.Pod, data []byte) error {
 				return nil
 			})
 			defer patch4.Reset()
-			patch5 := ApplyMethod(reflect.TypeOf(k), "CreatePod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod) (*corev1.Pod, error) {
+			patch5 := ApplyMethod(reflect.TypeOf(k), "CreatePod", func(_ *k8sclient.K8sClient, _ context.Context, pod *corev1.Pod) (*corev1.Pod, error) {
 				return nil, nil
 			})
 			defer patch5.Reset()
@@ -902,7 +902,7 @@ func TestPodDriver_podErrorHandler(t *testing.T) {
 		})
 		Convey("GetPod error", func() {
 			k := &k8sclient.K8sClient{}
-			patch1 := ApplyMethod(reflect.TypeOf(k), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch1 := ApplyMethod(reflect.TypeOf(k), "GetPod", func(_ *k8sclient.K8sClient, _ context.Context, podName, namespace string) (*corev1.Pod, error) {
 				return &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Finalizers: []string{jfsConfig.Finalizer},
@@ -910,11 +910,11 @@ func TestPodDriver_podErrorHandler(t *testing.T) {
 				}, nil
 			})
 			defer patch1.Reset()
-			patch2 := ApplyMethod(reflect.TypeOf(k), "PatchPod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod, data []byte) error {
+			patch2 := ApplyMethod(reflect.TypeOf(k), "PatchPod", func(_ *k8sclient.K8sClient, _ context.Context, pod *corev1.Pod, data []byte) error {
 				return errors.New("test")
 			})
 			defer patch2.Reset()
-			patch3 := ApplyMethod(reflect.TypeOf(k), "DeletePod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod) error {
+			patch3 := ApplyMethod(reflect.TypeOf(k), "DeletePod", func(_ *k8sclient.K8sClient, _ context.Context, pod *corev1.Pod) error {
 				return nil
 			})
 			defer patch3.Reset()

--- a/pkg/controller/pod_driver_test.go
+++ b/pkg/controller/pod_driver_test.go
@@ -676,15 +676,15 @@ func TestPodDriver_podDeletedHandler(t *testing.T) {
 			})
 			defer patch2.Reset()
 			k := &k8sclient.K8sClient{}
-			patch3 := ApplyMethod(reflect.TypeOf(k), "GetPod", func(_ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch3 := ApplyMethod(reflect.TypeOf(k), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch3.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(k), "PatchPod", func(_ *k8sclient.K8sClient, pod *corev1.Pod, data []byte) error {
+			patch4 := ApplyMethod(reflect.TypeOf(k), "PatchPod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod, data []byte) error {
 				return nil
 			})
 			defer patch4.Reset()
-			patch5 := ApplyMethod(reflect.TypeOf(k), "CreatePod", func(_ *k8sclient.K8sClient, pod *corev1.Pod) (*corev1.Pod, error) {
+			patch5 := ApplyMethod(reflect.TypeOf(k), "CreatePod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod) (*corev1.Pod, error) {
 				return nil, nil
 			})
 			defer patch5.Reset()
@@ -716,15 +716,15 @@ func TestPodDriver_podDeletedHandler(t *testing.T) {
 			})
 			defer patch2.Reset()
 			k := &k8sclient.K8sClient{}
-			patch3 := ApplyMethod(reflect.TypeOf(k), "GetPod", func(_ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch3 := ApplyMethod(reflect.TypeOf(k), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch3.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(k), "PatchPod", func(_ *k8sclient.K8sClient, pod *corev1.Pod, data []byte) error {
+			patch4 := ApplyMethod(reflect.TypeOf(k), "PatchPod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod, data []byte) error {
 				return nil
 			})
 			defer patch4.Reset()
-			patch5 := ApplyMethod(reflect.TypeOf(k), "CreatePod", func(_ *k8sclient.K8sClient, pod *corev1.Pod) (*corev1.Pod, error) {
+			patch5 := ApplyMethod(reflect.TypeOf(k), "CreatePod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod) (*corev1.Pod, error) {
 				return nil, nil
 			})
 			defer patch5.Reset()
@@ -902,7 +902,7 @@ func TestPodDriver_podErrorHandler(t *testing.T) {
 		})
 		Convey("GetPod error", func() {
 			k := &k8sclient.K8sClient{}
-			patch1 := ApplyMethod(reflect.TypeOf(k), "GetPod", func(_ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch1 := ApplyMethod(reflect.TypeOf(k), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
 				return &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Finalizers: []string{jfsConfig.Finalizer},
@@ -910,11 +910,11 @@ func TestPodDriver_podErrorHandler(t *testing.T) {
 				}, nil
 			})
 			defer patch1.Reset()
-			patch2 := ApplyMethod(reflect.TypeOf(k), "PatchPod", func(_ *k8sclient.K8sClient, pod *corev1.Pod, data []byte) error {
+			patch2 := ApplyMethod(reflect.TypeOf(k), "PatchPod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod, data []byte) error {
 				return errors.New("test")
 			})
 			defer patch2.Reset()
-			patch3 := ApplyMethod(reflect.TypeOf(k), "DeletePod", func(_ *k8sclient.K8sClient, pod *corev1.Pod) error {
+			patch3 := ApplyMethod(reflect.TypeOf(k), "DeletePod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod) error {
 				return nil
 			})
 			defer patch3.Reset()

--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -17,16 +17,16 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"strconv"
 	"time"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs/k8sclient"
-	"golang.org/x/net/context"
+	"k8s.io/klog"
+	k8sexec "k8s.io/utils/exec"
 	"k8s.io/utils/mount"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
-	"k8s.io/klog"
-	k8sexec "k8s.io/utils/exec"
 )
 
 type PodReconciler struct {

--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -85,7 +85,7 @@ func doReconcile(kc *kubeletClient, driver *PodDriver) {
 			if value, ok := pod.Labels[config.PodTypeKey]; !ok || value != config.PodTypeValue {
 				continue
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), config.ContextTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), config.ReconcileTimeout)
 			defer cancel()
 			err := driver.Run(ctx, pod)
 			if err != nil {

--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -17,11 +17,11 @@ limitations under the License.
 package controller
 
 import (
-	"context"
 	"strconv"
 	"time"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs/k8sclient"
+	"golang.org/x/net/context"
 	"k8s.io/utils/mount"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
@@ -85,9 +85,7 @@ func doReconcile(kc *kubeletClient, driver *PodDriver) {
 			if value, ok := pod.Labels[config.PodTypeKey]; !ok || value != config.PodTypeValue {
 				continue
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), config.ReconcileTimeout)
-			defer cancel()
-			err := driver.Run(ctx, pod)
+			err := driver.Run(context.TODO(), pod)
 			if err != nil {
 				klog.Errorf("Check pod %s: %s", pod.Name, err)
 			}

--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -85,7 +85,9 @@ func doReconcile(kc *kubeletClient, driver *PodDriver) {
 			if value, ok := pod.Labels[config.PodTypeKey]; !ok || value != config.PodTypeValue {
 				continue
 			}
-			err := driver.Run(context.Background(), pod)
+			ctx, cancel := context.WithTimeout(context.Background(), config.ContextTimeout)
+			defer cancel()
+			err := driver.Run(ctx, pod)
 			if err != nil {
 				klog.Errorf("Check pod %s: %s", pod.Name, err)
 			}

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -2,11 +2,12 @@ package driver
 
 import (
 	"context"
+	"reflect"
+
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs"
 	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs/k8sclient"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util"
-	"reflect"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -75,7 +76,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 	d.vols[req.Name] = requiredCap
 
 	// create volume
-	err := d.juicefs.JfsCreateVol(volumeId, subPath, secrets)
+	err := d.juicefs.JfsCreateVol(ctx, volumeId, subPath, secrets)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not createVol in juicefs: %v", err)
 	}
@@ -115,7 +116,7 @@ func (d *controllerService) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 	klog.V(5).Infof("DeleteVolume: Secrets contains keys %+v", reflect.ValueOf(secrets).MapKeys())
 
 	klog.V(5).Infof("DeleteVolume: Deleting volume %q", volumeID)
-	err = d.juicefs.JfsDeleteVol(volumeID, volumeID, secrets)
+	err = d.juicefs.JfsDeleteVol(ctx, volumeID, volumeID, secrets)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not delVol in juicefs: %v", err)
 	}

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -19,6 +19,10 @@ package driver
 import (
 	"context"
 	"errors"
+	"os/exec"
+	"reflect"
+	"testing"
+
 	. "github.com/agiledragon/gomonkey"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
@@ -29,9 +33,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/client-go/kubernetes/fake"
-	"os/exec"
-	"reflect"
-	"testing"
 )
 
 func TestNewControllerService(t *testing.T) {
@@ -103,7 +104,7 @@ func TestCreateVolume(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
 				mockJuicefs := mocks.NewMockInterface(mockCtl)
-				mockJuicefs.EXPECT().JfsCreateVol(volumeId, volumeId, secret).Return(nil)
+				mockJuicefs.EXPECT().JfsCreateVol(context.TODO(), volumeId, volumeId, secret).Return(nil)
 
 				juicefsDriver := controllerService{
 					juicefs: mockJuicefs,
@@ -244,7 +245,7 @@ func TestCreateVolume(t *testing.T) {
 				defer mockCtl.Finish()
 
 				mockJuicefs := mocks.NewMockInterface(mockCtl)
-				mockJuicefs.EXPECT().JfsCreateVol(volumeId, volumeId, secret).Return(errors.New("test"))
+				mockJuicefs.EXPECT().JfsCreateVol(context.TODO(), volumeId, volumeId, secret).Return(errors.New("test"))
 
 				juicefsDriver := controllerService{
 					juicefs: mockJuicefs,
@@ -290,7 +291,7 @@ func TestDeleteVolume(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
 				mockJuicefs := mocks.NewMockInterface(mockCtl)
-				mockJuicefs.EXPECT().JfsDeleteVol(volumeId, volumeId, secret).Return(nil)
+				mockJuicefs.EXPECT().JfsDeleteVol(context.TODO(), volumeId, volumeId, secret).Return(nil)
 
 				juicefsDriver := controllerService{
 					juicefs: mockJuicefs,
@@ -356,7 +357,7 @@ func TestDeleteVolume(t *testing.T) {
 				defer mockCtl.Finish()
 
 				mockJuicefs := mocks.NewMockInterface(mockCtl)
-				mockJuicefs.EXPECT().JfsDeleteVol(volumeId, volumeId, secret).Return(errors.New("test"))
+				mockJuicefs.EXPECT().JfsDeleteVol(context.TODO(), volumeId, volumeId, secret).Return(errors.New("test"))
 
 				juicefsDriver := controllerService{
 					juicefs: mockJuicefs,

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -19,13 +19,14 @@ package driver
 import (
 	"context"
 	"errors"
-	"github.com/golang/mock/gomock"
-	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs"
-	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs/mocks"
 	"os"
 	"os/exec"
 	"reflect"
 	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs"
+	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs/mocks"
 
 	. "github.com/agiledragon/gomonkey"
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -68,10 +69,10 @@ func TestNodePublishVolume(t *testing.T) {
 						defer mockCtl.Finish()
 
 						mockJfs := mocks.NewMockJfs(mockCtl)
-						mockJfs.EXPECT().CreateVol(volumeId, subPath).Return(bindSource, nil)
-						mockJfs.EXPECT().BindTarget(bindSource, targetPath).Return(nil)
+						mockJfs.EXPECT().CreateVol(context.TODO(), volumeId, subPath).Return(bindSource, nil)
+						mockJfs.EXPECT().BindTarget(context.TODO(), bindSource, targetPath).Return(nil)
 						mockJuicefs := mocks.NewMockInterface(mockCtl)
-						mockJuicefs.EXPECT().JfsMount(volumeId, targetPath, secret, volumeCtx, []string{"ro"}).Return(mockJfs, nil)
+						mockJuicefs.EXPECT().JfsMount(context.TODO(), volumeId, targetPath, secret, volumeCtx, []string{"ro"}).Return(mockJfs, nil)
 
 						juicefsDriver := &nodeService{
 							juicefs:   mockJuicefs,
@@ -114,10 +115,10 @@ func TestNodePublishVolume(t *testing.T) {
 						defer mockCtl.Finish()
 
 						mockJfs := mocks.NewMockJfs(mockCtl)
-						mockJfs.EXPECT().CreateVol(volumeId, subPath).Return(bindSource, nil)
-						mockJfs.EXPECT().BindTarget(bindSource, targetPath).Return(nil)
+						mockJfs.EXPECT().CreateVol(context.TODO(), volumeId, subPath).Return(bindSource, nil)
+						mockJfs.EXPECT().BindTarget(context.TODO(), bindSource, targetPath).Return(nil)
 						mockJuicefs := mocks.NewMockInterface(mockCtl)
-						mockJuicefs.EXPECT().JfsMount(volumeId, targetPath, secret, volumeCtx, mountOptions).Return(mockJfs, nil)
+						mockJuicefs.EXPECT().JfsMount(context.TODO(), volumeId, targetPath, secret, volumeCtx, mountOptions).Return(mockJfs, nil)
 
 						juicefsDriver := &nodeService{
 							juicefs:   mockJuicefs,
@@ -159,10 +160,10 @@ func TestNodePublishVolume(t *testing.T) {
 						defer mockCtl.Finish()
 
 						mockJfs := mocks.NewMockJfs(mockCtl)
-						mockJfs.EXPECT().CreateVol(volumeId, subPath).Return(bindSource, nil)
-						mockJfs.EXPECT().BindTarget(bindSource, targetPath).Return(nil)
+						mockJfs.EXPECT().CreateVol(context.TODO(), volumeId, subPath).Return(bindSource, nil)
+						mockJfs.EXPECT().BindTarget(context.TODO(), bindSource, targetPath).Return(nil)
 						mockJuicefs := mocks.NewMockInterface(mockCtl)
-						mockJuicefs.EXPECT().JfsMount(volumeId, targetPath, secret, volumeCtx, mountOptions).Return(mockJfs, nil)
+						mockJuicefs.EXPECT().JfsMount(context.TODO(), volumeId, targetPath, secret, volumeCtx, mountOptions).Return(mockJfs, nil)
 
 						juicefsDriver := &nodeService{
 							juicefs:   mockJuicefs,
@@ -211,7 +212,7 @@ func TestNodePublishVolume(t *testing.T) {
 
 						mockJfs := mocks.NewMockJfs(mockCtl)
 						mockJuicefs := mocks.NewMockInterface(mockCtl)
-						mockJuicefs.EXPECT().JfsMount(volumeId, targetPath, secret, volumeCtx, []string{"ro"}).Return(mockJfs, errors.New("test"))
+						mockJuicefs.EXPECT().JfsMount(context.TODO(), volumeId, targetPath, secret, volumeCtx, []string{"ro"}).Return(mockJfs, errors.New("test"))
 
 						juicefsDriver := &nodeService{
 							juicefs:   mockJuicefs,
@@ -250,9 +251,9 @@ func TestNodePublishVolume(t *testing.T) {
 						defer mockCtl.Finish()
 
 						mockJfs := mocks.NewMockJfs(mockCtl)
-						mockJfs.EXPECT().CreateVol(volumeId, subPath).Return(bindSource, errors.New("test"))
+						mockJfs.EXPECT().CreateVol(context.TODO(), volumeId, subPath).Return(bindSource, errors.New("test"))
 						mockJuicefs := mocks.NewMockInterface(mockCtl)
-						mockJuicefs.EXPECT().JfsMount(volumeId, targetPath, secret, volumeCtx, []string{"ro"}).Return(mockJfs, nil)
+						mockJuicefs.EXPECT().JfsMount(context.TODO(), volumeId, targetPath, secret, volumeCtx, []string{"ro"}).Return(mockJfs, nil)
 
 						juicefsDriver := &nodeService{
 							juicefs:   mockJuicefs,
@@ -291,10 +292,10 @@ func TestNodePublishVolume(t *testing.T) {
 						defer mockCtl.Finish()
 
 						mockJfs := mocks.NewMockJfs(mockCtl)
-						mockJfs.EXPECT().CreateVol(volumeId, subPath).Return(bindSource, nil)
-						mockJfs.EXPECT().BindTarget(bindSource, targetPath).Return(errors.New("test"))
+						mockJfs.EXPECT().CreateVol(context.TODO(), volumeId, subPath).Return(bindSource, nil)
+						mockJfs.EXPECT().BindTarget(context.TODO(), bindSource, targetPath).Return(errors.New("test"))
 						mockJuicefs := mocks.NewMockInterface(mockCtl)
-						mockJuicefs.EXPECT().JfsMount(volumeId, targetPath, secret, volumeCtx, []string{"ro"}).Return(mockJfs, nil)
+						mockJuicefs.EXPECT().JfsMount(context.TODO(), volumeId, targetPath, secret, volumeCtx, []string{"ro"}).Return(mockJfs, nil)
 
 						juicefsDriver := &nodeService{
 							juicefs:   mockJuicefs,
@@ -451,7 +452,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 			defer mockCtl.Finish()
 
 			mockJuicefs := mocks.NewMockInterface(mockCtl)
-			mockJuicefs.EXPECT().JfsUnmount(volumeId, targetPath).Return(nil)
+			mockJuicefs.EXPECT().JfsUnmount(context.TODO(), volumeId, targetPath).Return(nil)
 
 			juicefsDriver := &nodeService{
 				juicefs:   mockJuicefs,
@@ -477,7 +478,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 			defer mockCtl.Finish()
 
 			mockJuicefs := mocks.NewMockInterface(mockCtl)
-			mockJuicefs.EXPECT().JfsUnmount(volumeId, targetPath).Return(errors.New("test"))
+			mockJuicefs.EXPECT().JfsUnmount(context.TODO(), volumeId, targetPath).Return(errors.New("test"))
 
 			juicefsDriver := &nodeService{
 				juicefs:   mockJuicefs,

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/util"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -549,7 +550,10 @@ func (j *juicefs) AuthFs(ctx context.Context, secrets map[string]string, setting
 	authCmd.SetEnv(envs)
 	res, err := authCmd.CombinedOutput()
 	klog.Infof("Auth output is %s", res)
-	return string(res), err
+	if err != nil {
+		return "", errors.Wrap(err, "execute auth command")
+	}
+	return string(res), nil
 }
 
 // MountFs mounts JuiceFS with idempotency
@@ -679,5 +683,8 @@ func (j *juicefs) ceFormat(ctx context.Context, secrets map[string]string, noUpd
 	formatCmd.SetEnv(envs)
 	res, err := formatCmd.CombinedOutput()
 	klog.Infof("Format output is %s", res)
-	return string(res), err
+	if err != nil {
+		return "", errors.Wrap(err, "execute format command")
+	}
+	return string(res), nil
 }

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -550,7 +550,11 @@ func (j *juicefs) AuthFs(ctx context.Context, secrets map[string]string, setting
 		envs = append(envs, fmt.Sprintf("%s=%s", key, val))
 	}
 	authCmd.SetEnv(envs)
-	res, err := authCmd.CombinedOutput()
+	var res []byte
+	_, err := util.DoWithinTime(ctx, 5*time.Second, nil, func() (err error) {
+		res, err = authCmd.CombinedOutput()
+		return
+	})
 	klog.Infof("Auth output is %s", res)
 	if err != nil {
 		klog.Infof("Auth error: %v", err)
@@ -684,7 +688,11 @@ func (j *juicefs) ceFormat(ctx context.Context, secrets map[string]string, noUpd
 		envs = append(envs, "JFS_NO_CHECK_OBJECT_STORAGE=1")
 	}
 	formatCmd.SetEnv(envs)
-	res, err := formatCmd.CombinedOutput()
+	var res []byte
+	_, err := util.DoWithinTime(ctx, 5*time.Second, nil, func() (err error) {
+		res, err = formatCmd.CombinedOutput()
+		return
+	})
 	klog.Infof("Format output is %s", res)
 	if err != nil {
 		klog.Infof("Format error: %v", err)

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -378,7 +378,8 @@ func (j *juicefs) JfsUnmount(ctx context.Context, volumeId, mountPath string) er
 				delete(j.CacheDirMaps, uniqueId)
 
 				klog.V(5).Infof("Cleanup cache of volume %s in node %s", uniqueId, config.NodeName)
-				go j.processMount.CleanCache(ctx, uuid, uniqueId, cacheDirs)
+				// clean cache should be done even when top context timeout
+				go j.processMount.CleanCache(context.TODO(), uuid, uniqueId, cacheDirs)
 			}()
 		}
 		return err

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -46,8 +46,6 @@ import (
 	"k8s.io/utils/mount"
 )
 
-const defaultCheckTimeout = 2 * time.Second
-
 // Interface of juicefs provider
 type Interface interface {
 	mount.Interface

--- a/pkg/juicefs/juicefs_test.go
+++ b/pkg/juicefs/juicefs_test.go
@@ -313,11 +313,11 @@ func Test_juicefs_JfsMount(t *testing.T) {
 			patch2 := ApplyMethod(reflect.TypeOf(jf), "Upgrade", func(_ *juicefs) {
 			})
 			defer patch2.Reset()
-			patch3 := ApplyMethod(reflect.TypeOf(jf), "AuthFs", func(_ context.Context, _ *juicefs, secrets map[string]string, setting *config.JfsSetting) (string, error) {
+			patch3 := ApplyMethod(reflect.TypeOf(jf), "AuthFs", func(_ *juicefs, _ context.Context, secrets map[string]string, setting *config.JfsSetting) (string, error) {
 				return "", nil
 			})
 			defer patch3.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ context.Context, _ *juicefs, jfsSetting *config.JfsSetting) (string, error) {
+			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, _ context.Context, jfsSetting *config.JfsSetting) (string, error) {
 				return "", nil
 			})
 			defer patch4.Reset()
@@ -348,11 +348,11 @@ func Test_juicefs_JfsMount(t *testing.T) {
 				return []byte(""), nil
 			})
 			defer patch3.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ context.Context, _ *juicefs, jfsSetting *config.JfsSetting) (string, error) {
+			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, _ context.Context, jfsSetting *config.JfsSetting) (string, error) {
 				return "", nil
 			})
 			defer patch4.Reset()
-			patch5 := ApplyMethod(reflect.TypeOf(jf), "GetJfsVolUUID", func(_ context.Context, _ *juicefs, name string) (string, error) {
+			patch5 := ApplyMethod(reflect.TypeOf(jf), "GetJfsVolUUID", func(_ *juicefs, _ context.Context, name string) (string, error) {
 				return "test", nil
 			})
 			defer patch5.Reset()
@@ -390,7 +390,7 @@ func Test_juicefs_JfsMount(t *testing.T) {
 			jf := &juicefs{}
 			patch2 := ApplyMethod(reflect.TypeOf(jf), "Upgrade", func(_ *juicefs) {})
 			defer patch2.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ context.Context, _ *juicefs, jfsSetting *config.JfsSetting) (string, error) {
+			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, _ context.Context, jfsSetting *config.JfsSetting) (string, error) {
 				return "", nil
 			})
 			defer patch4.Reset()
@@ -412,11 +412,11 @@ func Test_juicefs_JfsMount(t *testing.T) {
 			jf := &juicefs{}
 			patch2 := ApplyMethod(reflect.TypeOf(jf), "Upgrade", func(_ *juicefs) {})
 			defer patch2.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ context.Context, _ *juicefs, jfsSetting *config.JfsSetting) (string, error) {
+			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, _ context.Context, jfsSetting *config.JfsSetting) (string, error) {
 				return "", errors.New("test")
 			})
 			defer patch4.Reset()
-			patch5 := ApplyMethod(reflect.TypeOf(jf), "GetJfsVolUUID", func(_ context.Context, _ *juicefs, name string) (string, error) {
+			patch5 := ApplyMethod(reflect.TypeOf(jf), "GetJfsVolUUID", func(_ *juicefs, _ context.Context, name string) (string, error) {
 				return "test", nil
 			})
 			defer patch5.Reset()
@@ -446,11 +446,11 @@ func Test_juicefs_JfsMount(t *testing.T) {
 				return []byte(""), nil
 			})
 			defer patch3.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ context.Context, _ *juicefs, jfsSetting *config.JfsSetting) (string, error) {
+			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, _ context.Context, jfsSetting *config.JfsSetting) (string, error) {
 				return "", nil
 			})
 			defer patch4.Reset()
-			patch5 := ApplyMethod(reflect.TypeOf(jf), "GetJfsVolUUID", func(_ context.Context, _ *juicefs, name string) (string, error) {
+			patch5 := ApplyMethod(reflect.TypeOf(jf), "GetJfsVolUUID", func(_ *juicefs, _ context.Context, name string) (string, error) {
 				return "test", nil
 			})
 			defer patch5.Reset()

--- a/pkg/juicefs/juicefs_test.go
+++ b/pkg/juicefs/juicefs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package juicefs
 
 import (
+	"context"
 	"errors"
 	"io/fs"
 	"os"
@@ -59,7 +60,7 @@ func Test_jfs_CreateVol(t *testing.T) {
 			j := jfs{
 				MountPath: "/mountPath",
 			}
-			got, err := j.CreateVol("", "subPath")
+			got, err := j.CreateVol(context.TODO(), "", "subPath")
 			So(err, ShouldBeNil)
 			So(got, ShouldEqual, "/mountPath/subPath")
 		})
@@ -72,7 +73,7 @@ func Test_jfs_CreateVol(t *testing.T) {
 			j := jfs{
 				MountPath: "/mountPath",
 			}
-			got, err := j.CreateVol("", "subPath")
+			got, err := j.CreateVol(context.TODO(), "", "subPath")
 			So(err, ShouldNotBeNil)
 			So(got, ShouldEqual, "")
 			srvErr, ok := status.FromError(err)
@@ -96,7 +97,7 @@ func Test_jfs_CreateVol(t *testing.T) {
 			j := jfs{
 				MountPath: "/mountPath",
 			}
-			got, err := j.CreateVol("", "subPath")
+			got, err := j.CreateVol(context.TODO(), "", "subPath")
 			So(err, ShouldNotBeNil)
 			So(got, ShouldEqual, "")
 			srvErr, ok := status.FromError(err)
@@ -124,7 +125,7 @@ func Test_jfs_CreateVol(t *testing.T) {
 			j := jfs{
 				MountPath: "/mountPath",
 			}
-			got, err := j.CreateVol("", "subPath")
+			got, err := j.CreateVol(context.TODO(), "", "subPath")
 			So(err, ShouldNotBeNil)
 			So(got, ShouldEqual, "")
 			srvErr, ok := status.FromError(err)
@@ -172,7 +173,7 @@ func Test_jfs_BindTarget(t *testing.T) {
 					},
 				},
 			}
-			err := j.BindTarget(mountPath, target)
+			err := j.BindTarget(context.TODO(), mountPath, target)
 			So(err, ShouldBeNil)
 		})
 		Convey("test already bind", func() {
@@ -215,7 +216,7 @@ func Test_jfs_BindTarget(t *testing.T) {
 					},
 				},
 			}
-			err := j.BindTarget(mountPath, target)
+			err := j.BindTarget(context.TODO(), mountPath, target)
 			So(err, ShouldBeNil)
 		})
 		Convey("test bind other path", func() {
@@ -263,7 +264,7 @@ func Test_jfs_BindTarget(t *testing.T) {
 					},
 				},
 			}
-			err := j.BindTarget(mountPath, target)
+			err := j.BindTarget(context.TODO(), mountPath, target)
 			So(err, ShouldBeNil)
 		})
 	})
@@ -326,7 +327,7 @@ func Test_juicefs_JfsMount(t *testing.T) {
 				SafeFormatAndMount: mount.SafeFormatAndMount{},
 				K8sClient:          nil,
 			}
-			_, err := jfs.JfsMount(volumeId, targetPath, secret, map[string]string{}, []string{})
+			_, err := jfs.JfsMount(context.TODO(), volumeId, targetPath, secret, map[string]string{}, []string{})
 			So(err, ShouldBeNil)
 		})
 		Convey("ce normal", func() {
@@ -364,7 +365,7 @@ func Test_juicefs_JfsMount(t *testing.T) {
 				},
 				K8sClient: nil,
 			}
-			_, err := jfs.JfsMount(volumeId, targetPath, secret, map[string]string{}, []string{})
+			_, err := jfs.JfsMount(context.TODO(), volumeId, targetPath, secret, map[string]string{}, []string{})
 			So(err, ShouldBeNil)
 		})
 		Convey("parse err", func() {
@@ -377,7 +378,7 @@ func Test_juicefs_JfsMount(t *testing.T) {
 				SafeFormatAndMount: mount.SafeFormatAndMount{},
 				K8sClient:          nil,
 			}
-			_, err := jfs.JfsMount(volumeId, targetPath, secret, map[string]string{}, []string{})
+			_, err := jfs.JfsMount(context.TODO(), volumeId, targetPath, secret, map[string]string{}, []string{})
 			So(err, ShouldNotBeNil)
 		})
 		Convey("ee no token", func() {
@@ -401,7 +402,7 @@ func Test_juicefs_JfsMount(t *testing.T) {
 				SafeFormatAndMount: mount.SafeFormatAndMount{},
 				K8sClient:          nil,
 			}
-			_, err := jfs.JfsMount(volumeId, targetPath, secret, map[string]string{}, []string{})
+			_, err := jfs.JfsMount(context.TODO(), volumeId, targetPath, secret, map[string]string{}, []string{})
 			So(err, ShouldBeNil)
 		})
 		Convey("mountFs err", func() {
@@ -429,7 +430,7 @@ func Test_juicefs_JfsMount(t *testing.T) {
 				SafeFormatAndMount: mount.SafeFormatAndMount{},
 				K8sClient:          nil,
 			}
-			_, err := jfs.JfsMount(volumeId, targetPath, secret, map[string]string{}, []string{})
+			_, err := jfs.JfsMount(context.TODO(), volumeId, targetPath, secret, map[string]string{}, []string{})
 			So(err, ShouldNotBeNil)
 		})
 		Convey("ce no bucket", func() {
@@ -466,7 +467,7 @@ func Test_juicefs_JfsMount(t *testing.T) {
 				},
 				K8sClient: nil,
 			}
-			_, err := jfs.JfsMount(volumeId, targetPath, secret, map[string]string{}, []string{})
+			_, err := jfs.JfsMount(context.TODO(), volumeId, targetPath, secret, map[string]string{}, []string{})
 			So(err, ShouldBeNil)
 		})
 		Convey("ce format error", func() {
@@ -482,7 +483,7 @@ func Test_juicefs_JfsMount(t *testing.T) {
 				},
 				K8sClient: nil,
 			}
-			_, err := jfs.JfsMount(volumeId, targetPath, secret, map[string]string{}, []string{})
+			_, err := jfs.JfsMount(context.TODO(), volumeId, targetPath, secret, map[string]string{}, []string{})
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -513,7 +514,7 @@ func Test_juicefs_JfsUnmount(t *testing.T) {
 					Exec:      k8sexec.New(),
 				}),
 			}
-			err := jfs.JfsUnmount("test", targetPath)
+			err := jfs.JfsUnmount(context.TODO(), "test", targetPath)
 			So(err, ShouldBeNil)
 		})
 		Convey("unmount error", func() {
@@ -540,7 +541,7 @@ func Test_juicefs_JfsUnmount(t *testing.T) {
 					Exec:      k8sexec.New(),
 				}),
 			}
-			err := jfs.JfsUnmount("test", targetPath)
+			err := jfs.JfsUnmount(context.TODO(), "test", targetPath)
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -562,7 +563,7 @@ func Test_juicefs_CleanupMountPoint(t *testing.T) {
 				},
 				K8sClient: nil,
 			}
-			err := jfs.JfsCleanupMountPoint(targetPath)
+			err := jfs.JfsCleanupMountPoint(context.TODO(), targetPath)
 			So(err, ShouldBeNil)
 		})
 	})
@@ -598,7 +599,7 @@ func Test_juicefs_AuthFs(t *testing.T) {
 			}
 			setting, err := config.ParseSetting(nil, map[string]string{}, []string{}, true)
 			So(err, ShouldBeNil)
-			_, err = jfs.AuthFs(secrets, setting)
+			_, err = jfs.AuthFs(context.TODO(), secrets, setting)
 			So(err, ShouldBeNil)
 		})
 		Convey("secret nil", func() {
@@ -609,7 +610,7 @@ func Test_juicefs_AuthFs(t *testing.T) {
 				},
 				K8sClient: nil,
 			}
-			_, err := jfs.AuthFs(nil, nil)
+			_, err := jfs.AuthFs(context.TODO(), nil, nil)
 			So(err, ShouldNotBeNil)
 		})
 		Convey("secret no name", func() {
@@ -621,7 +622,7 @@ func Test_juicefs_AuthFs(t *testing.T) {
 				},
 				K8sClient: nil,
 			}
-			_, err := jfs.AuthFs(secret, nil)
+			_, err := jfs.AuthFs(context.TODO(), secret, nil)
 			So(err, ShouldNotBeNil)
 		})
 		Convey("secret no bucket", func() {
@@ -644,7 +645,7 @@ func Test_juicefs_AuthFs(t *testing.T) {
 			}
 			setting, err := config.ParseSetting(nil, map[string]string{}, []string{}, true)
 			So(err, ShouldBeNil)
-			_, err = jfs.AuthFs(secrets, setting)
+			_, err = jfs.AuthFs(context.TODO(), secrets, setting)
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -688,7 +689,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 					Exec:      k8sexec.New(),
 				}),
 			}
-			_, e := jfs.MountFs(jfsSetting)
+			_, e := jfs.MountFs(context.TODO(), jfsSetting)
 			So(e, ShouldBeNil)
 		})
 		Convey("not MountPoint err", func() {
@@ -716,7 +717,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 					Exec:      k8sexec.New(),
 				}),
 			}
-			_, e := jfs.MountFs(jfsSetting)
+			_, e := jfs.MountFs(context.TODO(), jfsSetting)
 			So(e, ShouldNotBeNil)
 		})
 		Convey("add ref err", func() {
@@ -743,7 +744,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 			mockMount := mocks.NewMockInterface(mockCtl)
 			//mockMount.EXPECT().IsLikelyNotMountPoint(mountPath).Return(false, nil)
 			mockMnt := mntmock.NewMockMntInterface(mockCtl)
-			mockMnt.EXPECT().JMount(jfsSetting).Return(errors.New("test"))
+			mockMnt.EXPECT().JMount(context.TODO(), jfsSetting).Return(errors.New("test"))
 
 			jfs := juicefs{
 				SafeFormatAndMount: mount.SafeFormatAndMount{
@@ -753,7 +754,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 				K8sClient: &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
 				podMount:  mockMnt,
 			}
-			_, e := jfs.MountFs(jfsSetting)
+			_, e := jfs.MountFs(context.TODO(), jfsSetting)
 			So(e, ShouldNotBeNil)
 		})
 		Convey("jmount err", func() {
@@ -779,7 +780,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 			mockMount := mocks.NewMockInterface(mockCtl)
 			//mockMount.EXPECT().IsLikelyNotMountPoint(mountPath).Return(true, nil)
 			mockMnt := mntmock.NewMockMntInterface(mockCtl)
-			mockMnt.EXPECT().JMount(jfsSetting).Return(errors.New("test"))
+			mockMnt.EXPECT().JMount(context.TODO(), jfsSetting).Return(errors.New("test"))
 
 			jfs := juicefs{
 				SafeFormatAndMount: mount.SafeFormatAndMount{
@@ -789,7 +790,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 				K8sClient:    &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
 				processMount: mockMnt,
 			}
-			_, e := jfs.MountFs(jfsSetting)
+			_, e := jfs.MountFs(context.TODO(), jfsSetting)
 			So(e, ShouldNotBeNil)
 		})
 		Convey("jmount", func() {
@@ -815,7 +816,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 			mockMount := mocks.NewMockInterface(mockCtl)
 			//mockMount.EXPECT().IsLikelyNotMountPoint(mountPath).Return(true, nil)
 			mockMnt := mntmock.NewMockMntInterface(mockCtl)
-			mockMnt.EXPECT().JMount(jfsSetting).Return(nil)
+			mockMnt.EXPECT().JMount(context.TODO(), jfsSetting).Return(nil)
 
 			jfs := juicefs{
 				SafeFormatAndMount: mount.SafeFormatAndMount{
@@ -825,7 +826,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 				K8sClient:    &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
 				processMount: mockMnt,
 			}
-			_, e := jfs.MountFs(jfsSetting)
+			_, e := jfs.MountFs(context.TODO(), jfsSetting)
 			So(e, ShouldBeNil)
 		})
 		Convey("not exist jmount err", func() {
@@ -850,7 +851,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 
 			mockMount := mocks.NewMockInterface(mockCtl)
 			mockMnt := mntmock.NewMockMntInterface(mockCtl)
-			mockMnt.EXPECT().JMount(jfsSetting).Return(errors.New("test"))
+			mockMnt.EXPECT().JMount(context.TODO(), jfsSetting).Return(errors.New("test"))
 
 			jfs := juicefs{
 				SafeFormatAndMount: mount.SafeFormatAndMount{
@@ -860,7 +861,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 				K8sClient:    &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
 				processMount: mockMnt,
 			}
-			_, e := jfs.MountFs(jfsSetting)
+			_, e := jfs.MountFs(context.TODO(), jfsSetting)
 			So(e, ShouldNotBeNil)
 		})
 		Convey("not exist", func() {
@@ -885,7 +886,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 
 			mockMount := mocks.NewMockInterface(mockCtl)
 			mockMnt := mntmock.NewMockMntInterface(mockCtl)
-			mockMnt.EXPECT().JMount(jfsSetting).Return(nil)
+			mockMnt.EXPECT().JMount(context.TODO(), jfsSetting).Return(nil)
 
 			jfs := juicefs{
 				SafeFormatAndMount: mount.SafeFormatAndMount{
@@ -895,7 +896,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 				K8sClient:    &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
 				processMount: mockMnt,
 			}
-			_, e := jfs.MountFs(jfsSetting)
+			_, e := jfs.MountFs(context.TODO(), jfsSetting)
 			So(e, ShouldBeNil)
 		})
 	})
@@ -959,7 +960,7 @@ func Test_juicefs_ceFormat(t *testing.T) {
 			}
 			setting, err := config.ParseSetting(secret, map[string]string{}, []string{}, true)
 			So(err, ShouldBeNil)
-			_, err = jfs.ceFormat(secret, true, setting)
+			_, err = jfs.ceFormat(context.TODO(), secret, true, setting)
 			So(err, ShouldBeNil)
 		})
 		Convey("no name", func() {
@@ -980,7 +981,7 @@ func Test_juicefs_ceFormat(t *testing.T) {
 				},
 				K8sClient: nil,
 			}
-			_, err := jfs.ceFormat(secret, true, nil)
+			_, err := jfs.ceFormat(context.TODO(), secret, true, nil)
 			So(err, ShouldNotBeNil)
 		})
 		Convey("no metaurl", func() {
@@ -1003,7 +1004,7 @@ func Test_juicefs_ceFormat(t *testing.T) {
 			}
 			setting, err := config.ParseSetting(secret, map[string]string{}, []string{}, true)
 			So(err, ShouldBeNil)
-			_, err = jfs.ceFormat(secret, true, setting)
+			_, err = jfs.ceFormat(context.TODO(), secret, true, setting)
 			So(err, ShouldNotBeNil)
 		})
 		Convey("nil secret", func() {
@@ -1014,7 +1015,7 @@ func Test_juicefs_ceFormat(t *testing.T) {
 				},
 				K8sClient: nil,
 			}
-			_, err := jfs.ceFormat(nil, true, nil)
+			_, err := jfs.ceFormat(context.TODO(), nil, true, nil)
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -1060,7 +1061,7 @@ func Test_juicefs_getVolumeUUID(t *testing.T) {
 				K8sClient:          nil,
 				processMount:       podmount.NewProcessMount(*mounter),
 			}
-			id, err := jfs.GetJfsVolUUID("test")
+			id, err := jfs.GetJfsVolUUID(context.TODO(), "test")
 			So(err, ShouldBeNil)
 			So(id, ShouldEqual, "e267db92-051d-4214-b1aa-e97bf61bff1a")
 		})
@@ -1080,7 +1081,7 @@ func Test_juicefs_getVolumeUUID(t *testing.T) {
 				K8sClient:          nil,
 				processMount:       podmount.NewProcessMount(*mounter),
 			}
-			_, err := jfs.GetJfsVolUUID("test")
+			_, err := jfs.GetJfsVolUUID(context.TODO(), "test")
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -1152,7 +1153,7 @@ func Test_juicefs_ceFormat_format_in_pod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			j := &juicefs{}
-			got, err := j.ceFormat(tt.args.secrets, tt.args.noUpdate, tt.args.setting)
+			got, err := j.ceFormat(context.TODO(), tt.args.secrets, tt.args.noUpdate, tt.args.setting)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ceFormat() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/juicefs/juicefs_test.go
+++ b/pkg/juicefs/juicefs_test.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	. "github.com/agiledragon/gomonkey"
 	"github.com/golang/mock/gomock"
@@ -712,7 +713,9 @@ func Test_juicefs_MountFs(t *testing.T) {
 					Exec:      k8sexec.New(),
 				}),
 			}
-			_, e := jfs.MountFs(context.TODO(), jfsSetting)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			_, e := jfs.MountFs(ctx, jfsSetting)
 			So(e, ShouldNotBeNil)
 		})
 		Convey("add ref err", func() {

--- a/pkg/juicefs/juicefs_test.go
+++ b/pkg/juicefs/juicefs_test.go
@@ -311,14 +311,13 @@ func Test_juicefs_JfsMount(t *testing.T) {
 
 			jf := &juicefs{}
 			patch2 := ApplyMethod(reflect.TypeOf(jf), "Upgrade", func(_ *juicefs) {
-				return
 			})
 			defer patch2.Reset()
-			patch3 := ApplyMethod(reflect.TypeOf(jf), "AuthFs", func(_ *juicefs, secrets map[string]string, setting *config.JfsSetting) (string, error) {
+			patch3 := ApplyMethod(reflect.TypeOf(jf), "AuthFs", func(_ context.Context, _ *juicefs, secrets map[string]string, setting *config.JfsSetting) (string, error) {
 				return "", nil
 			})
 			defer patch3.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, jfsSetting *config.JfsSetting) (string, error) {
+			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ context.Context, _ *juicefs, jfsSetting *config.JfsSetting) (string, error) {
 				return "", nil
 			})
 			defer patch4.Reset()
@@ -349,11 +348,11 @@ func Test_juicefs_JfsMount(t *testing.T) {
 				return []byte(""), nil
 			})
 			defer patch3.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, jfsSetting *config.JfsSetting) (string, error) {
+			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ context.Context, _ *juicefs, jfsSetting *config.JfsSetting) (string, error) {
 				return "", nil
 			})
 			defer patch4.Reset()
-			patch5 := ApplyMethod(reflect.TypeOf(jf), "GetJfsVolUUID", func(_ *juicefs, name string) (string, error) {
+			patch5 := ApplyMethod(reflect.TypeOf(jf), "GetJfsVolUUID", func(_ context.Context, _ *juicefs, name string) (string, error) {
 				return "test", nil
 			})
 			defer patch5.Reset()
@@ -389,11 +388,9 @@ func Test_juicefs_JfsMount(t *testing.T) {
 			}
 
 			jf := &juicefs{}
-			patch2 := ApplyMethod(reflect.TypeOf(jf), "Upgrade", func(_ *juicefs) {
-				return
-			})
+			patch2 := ApplyMethod(reflect.TypeOf(jf), "Upgrade", func(_ *juicefs) {})
 			defer patch2.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, jfsSetting *config.JfsSetting) (string, error) {
+			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ context.Context, _ *juicefs, jfsSetting *config.JfsSetting) (string, error) {
 				return "", nil
 			})
 			defer patch4.Reset()
@@ -413,15 +410,13 @@ func Test_juicefs_JfsMount(t *testing.T) {
 			}
 
 			jf := &juicefs{}
-			patch2 := ApplyMethod(reflect.TypeOf(jf), "Upgrade", func(_ *juicefs) {
-				return
-			})
+			patch2 := ApplyMethod(reflect.TypeOf(jf), "Upgrade", func(_ *juicefs) {})
 			defer patch2.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, jfsSetting *config.JfsSetting) (string, error) {
+			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ context.Context, _ *juicefs, jfsSetting *config.JfsSetting) (string, error) {
 				return "", errors.New("test")
 			})
 			defer patch4.Reset()
-			patch5 := ApplyMethod(reflect.TypeOf(jf), "GetJfsVolUUID", func(_ *juicefs, name string) (string, error) {
+			patch5 := ApplyMethod(reflect.TypeOf(jf), "GetJfsVolUUID", func(_ context.Context, _ *juicefs, name string) (string, error) {
 				return "test", nil
 			})
 			defer patch5.Reset()
@@ -451,11 +446,11 @@ func Test_juicefs_JfsMount(t *testing.T) {
 				return []byte(""), nil
 			})
 			defer patch3.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, jfsSetting *config.JfsSetting) (string, error) {
+			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ context.Context, _ *juicefs, jfsSetting *config.JfsSetting) (string, error) {
 				return "", nil
 			})
 			defer patch4.Reset()
-			patch5 := ApplyMethod(reflect.TypeOf(jf), "GetJfsVolUUID", func(_ *juicefs, name string) (string, error) {
+			patch5 := ApplyMethod(reflect.TypeOf(jf), "GetJfsVolUUID", func(_ context.Context, _ *juicefs, name string) (string, error) {
 				return "test", nil
 			})
 			defer patch5.Reset()

--- a/pkg/juicefs/k8sclient/client_test.go
+++ b/pkg/juicefs/k8sclient/client_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package k8sclient
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -100,7 +101,7 @@ func TestK8sClient_CreatePod(t *testing.T) {
 			k := &K8sClient{
 				Interface: fake.NewSimpleClientset(),
 			}
-			got, err := k.CreatePod(tt.args.pod)
+			got, err := k.CreatePod(context.TODO(), tt.args.pod)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CreatePod() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -151,9 +152,9 @@ func TestK8sClient_GetPod(t *testing.T) {
 				Interface: fake.NewSimpleClientset(),
 			}
 			if tt.pod != nil {
-				_, _ = k.CreatePod(tt.pod)
+				_, _ = k.CreatePod(context.TODO(), tt.pod)
 			}
-			got, err := k.GetPod(tt.args.podName, tt.args.namespace)
+			got, err := k.GetPod(context.TODO(), tt.args.podName, tt.args.namespace)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CreatePod() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -213,20 +214,20 @@ func TestK8sClient_PatchPod(t *testing.T) {
 				Interface: fake.NewSimpleClientset(),
 			}
 			if tt.pod != nil {
-				_, _ = k.CreatePod(tt.pod)
+				_, _ = k.CreatePod(context.TODO(), tt.pod)
 			}
 			data, err := json.Marshal([]PatchMapValue{tt.args.data})
 			if err != nil {
 				t.Errorf("Parse json error: %v", err)
 				return
 			}
-			err = k.PatchPod(tt.args.pod, data)
+			err = k.PatchPod(context.TODO(), tt.args.pod, data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("PatchPod() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if tt.pod != nil {
-				got, _ := k.GetPod(tt.pod.Name, tt.pod.Namespace)
+				got, _ := k.GetPod(context.TODO(), tt.pod.Name, tt.pod.Namespace)
 				if !reflect.DeepEqual(got, tt.want) {
 					t.Errorf("PatchPod() got = %v, want %v", got, tt.want)
 				}
@@ -281,15 +282,15 @@ func TestK8sClient_UpdatePod(t *testing.T) {
 				Interface: fake.NewSimpleClientset(),
 			}
 			if tt.pod != nil {
-				_, _ = k.CreatePod(tt.pod)
+				_, _ = k.CreatePod(context.TODO(), tt.pod)
 			}
-			err := k.UpdatePod(tt.args.pod)
+			err := k.UpdatePod(context.TODO(), tt.args.pod)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("UpdatePod() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if tt.pod != nil {
-				got, _ := k.GetPod(tt.pod.Name, tt.pod.Namespace)
+				got, _ := k.GetPod(context.TODO(), tt.pod.Name, tt.pod.Namespace)
 				if !reflect.DeepEqual(got, tt.want) {
 					t.Errorf("UpdatePod() got = %v, want %v", got, tt.want)
 				}
@@ -329,15 +330,15 @@ func TestK8sClient_DeletePod(t *testing.T) {
 				Interface: fake.NewSimpleClientset(),
 			}
 			if tt.pod != nil {
-				_, _ = k.CreatePod(tt.pod)
+				_, _ = k.CreatePod(context.TODO(), tt.pod)
 			}
-			err := k.DeletePod(tt.args.pod)
+			err := k.DeletePod(context.TODO(), tt.args.pod)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DeletePod() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if tt.pod != nil {
-				got, err := k.GetPod(tt.pod.Name, tt.pod.Namespace)
+				got, err := k.GetPod(context.TODO(), tt.pod.Name, tt.pod.Namespace)
 				if err == nil || got != nil {
 					t.Errorf("DeletePod() error = %v, got %v", err, got)
 					return

--- a/pkg/juicefs/mocks/mock_jfs.go
+++ b/pkg/juicefs/mocks/mock_jfs.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -34,32 +35,32 @@ func (m *MockJfs) EXPECT() *MockJfsMockRecorder {
 }
 
 // BindTarget mocks base method.
-func (m *MockJfs) BindTarget(arg0, arg1 string) error {
+func (m *MockJfs) BindTarget(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BindTarget", arg0, arg1)
+	ret := m.ctrl.Call(m, "BindTarget", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // BindTarget indicates an expected call of BindTarget.
-func (mr *MockJfsMockRecorder) BindTarget(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockJfsMockRecorder) BindTarget(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BindTarget", reflect.TypeOf((*MockJfs)(nil).BindTarget), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BindTarget", reflect.TypeOf((*MockJfs)(nil).BindTarget), arg0, arg1, arg2)
 }
 
 // CreateVol mocks base method.
-func (m *MockJfs) CreateVol(arg0, arg1 string) (string, error) {
+func (m *MockJfs) CreateVol(arg0 context.Context, arg1, arg2 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateVol", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateVol", arg0, arg1, arg2)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateVol indicates an expected call of CreateVol.
-func (mr *MockJfsMockRecorder) CreateVol(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockJfsMockRecorder) CreateVol(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVol", reflect.TypeOf((*MockJfs)(nil).CreateVol), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVol", reflect.TypeOf((*MockJfs)(nil).CreateVol), arg0, arg1, arg2)
 }
 
 // GetBasePath mocks base method.

--- a/pkg/juicefs/mocks/mock_juicefs.go
+++ b/pkg/juicefs/mocks/mock_juicefs.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -36,18 +37,18 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // GetJfsVolUUID mocks base method.
-func (m *MockInterface) GetJfsVolUUID(arg0 string) (string, error) {
+func (m *MockInterface) GetJfsVolUUID(arg0 context.Context, arg1 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetJfsVolUUID", arg0)
+	ret := m.ctrl.Call(m, "GetJfsVolUUID", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetJfsVolUUID indicates an expected call of GetJfsVolUUID.
-func (mr *MockInterfaceMockRecorder) GetJfsVolUUID(arg0 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) GetJfsVolUUID(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJfsVolUUID", reflect.TypeOf((*MockInterface)(nil).GetJfsVolUUID), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJfsVolUUID", reflect.TypeOf((*MockInterface)(nil).GetJfsVolUUID), arg0, arg1)
 }
 
 // GetMountRefs mocks base method.
@@ -81,74 +82,74 @@ func (mr *MockInterfaceMockRecorder) IsLikelyNotMountPoint(arg0 interface{}) *go
 }
 
 // JfsCleanupMountPoint mocks base method.
-func (m *MockInterface) JfsCleanupMountPoint(arg0 string) error {
+func (m *MockInterface) JfsCleanupMountPoint(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JfsCleanupMountPoint", arg0)
+	ret := m.ctrl.Call(m, "JfsCleanupMountPoint", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // JfsCleanupMountPoint indicates an expected call of JfsCleanupMountPoint.
-func (mr *MockInterfaceMockRecorder) JfsCleanupMountPoint(arg0 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) JfsCleanupMountPoint(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JfsCleanupMountPoint", reflect.TypeOf((*MockInterface)(nil).JfsCleanupMountPoint), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JfsCleanupMountPoint", reflect.TypeOf((*MockInterface)(nil).JfsCleanupMountPoint), arg0, arg1)
 }
 
 // JfsCreateVol mocks base method.
-func (m *MockInterface) JfsCreateVol(arg0, arg1 string, arg2 map[string]string) error {
+func (m *MockInterface) JfsCreateVol(arg0 context.Context, arg1, arg2 string, arg3 map[string]string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JfsCreateVol", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "JfsCreateVol", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // JfsCreateVol indicates an expected call of JfsCreateVol.
-func (mr *MockInterfaceMockRecorder) JfsCreateVol(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) JfsCreateVol(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JfsCreateVol", reflect.TypeOf((*MockInterface)(nil).JfsCreateVol), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JfsCreateVol", reflect.TypeOf((*MockInterface)(nil).JfsCreateVol), arg0, arg1, arg2, arg3)
 }
 
 // JfsDeleteVol mocks base method.
-func (m *MockInterface) JfsDeleteVol(arg0, arg1 string, arg2 map[string]string) error {
+func (m *MockInterface) JfsDeleteVol(arg0 context.Context, arg1, arg2 string, arg3 map[string]string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JfsDeleteVol", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "JfsDeleteVol", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // JfsDeleteVol indicates an expected call of JfsDeleteVol.
-func (mr *MockInterfaceMockRecorder) JfsDeleteVol(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) JfsDeleteVol(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JfsDeleteVol", reflect.TypeOf((*MockInterface)(nil).JfsDeleteVol), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JfsDeleteVol", reflect.TypeOf((*MockInterface)(nil).JfsDeleteVol), arg0, arg1, arg2, arg3)
 }
 
 // JfsMount mocks base method.
-func (m *MockInterface) JfsMount(arg0, arg1 string, arg2, arg3 map[string]string, arg4 []string) (juicefs.Jfs, error) {
+func (m *MockInterface) JfsMount(arg0 context.Context, arg1, arg2 string, arg3, arg4 map[string]string, arg5 []string) (juicefs.Jfs, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JfsMount", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "JfsMount", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(juicefs.Jfs)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // JfsMount indicates an expected call of JfsMount.
-func (mr *MockInterfaceMockRecorder) JfsMount(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) JfsMount(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JfsMount", reflect.TypeOf((*MockInterface)(nil).JfsMount), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JfsMount", reflect.TypeOf((*MockInterface)(nil).JfsMount), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // JfsUnmount mocks base method.
-func (m *MockInterface) JfsUnmount(arg0, arg1 string) error {
+func (m *MockInterface) JfsUnmount(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JfsUnmount", arg0, arg1)
+	ret := m.ctrl.Call(m, "JfsUnmount", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // JfsUnmount indicates an expected call of JfsUnmount.
-func (mr *MockInterfaceMockRecorder) JfsUnmount(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) JfsUnmount(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JfsUnmount", reflect.TypeOf((*MockInterface)(nil).JfsUnmount), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JfsUnmount", reflect.TypeOf((*MockInterface)(nil).JfsUnmount), arg0, arg1, arg2)
 }
 
 // List mocks base method.

--- a/pkg/juicefs/mount/interface.go
+++ b/pkg/juicefs/mount/interface.go
@@ -17,18 +17,20 @@ limitations under the License.
 package mount
 
 import (
+	"context"
+
 	jfsConfig "github.com/juicedata/juicefs-csi-driver/pkg/config"
 	k8sMount "k8s.io/utils/mount"
 )
 
 type MntInterface interface {
 	k8sMount.Interface
-	JMount(jfsSetting *jfsConfig.JfsSetting) error
-	JCreateVolume(jfsSetting *jfsConfig.JfsSetting) error
-	JDeleteVolume(jfsSetting *jfsConfig.JfsSetting) error
-	GetMountRef(target, podName string) (int, error) // podName is only used by podMount
-	UmountTarget(target, podName string) error       // podName is only used by podMount
-	JUmount(target, podName string) error            // podName is only used by podMount
-	AddRefOfMount(target string, podName string) error
-	CleanCache(id string, volumeId string, cacheDirs []string) error
+	JMount(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) error
+	JCreateVolume(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) error
+	JDeleteVolume(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) error
+	GetMountRef(ctx context.Context, target, podName string) (int, error) // podName is only used by podMount
+	UmountTarget(ctx context.Context, target, podName string) error       // podName is only used by podMount
+	JUmount(ctx context.Context, target, podName string) error            // podName is only used by podMount
+	AddRefOfMount(ctx context.Context, target string, podName string) error
+	CleanCache(ctx context.Context, id string, volumeId string, cacheDirs []string) error
 }

--- a/pkg/juicefs/mount/mocks/mock_mnt.go
+++ b/pkg/juicefs/mount/mocks/mock_mnt.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -36,46 +37,46 @@ func (m *MockMntInterface) EXPECT() *MockMntInterfaceMockRecorder {
 }
 
 // AddRefOfMount mocks base method.
-func (m *MockMntInterface) AddRefOfMount(arg0, arg1 string) error {
+func (m *MockMntInterface) AddRefOfMount(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddRefOfMount", arg0, arg1)
+	ret := m.ctrl.Call(m, "AddRefOfMount", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddRefOfMount indicates an expected call of AddRefOfMount.
-func (mr *MockMntInterfaceMockRecorder) AddRefOfMount(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMntInterfaceMockRecorder) AddRefOfMount(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRefOfMount", reflect.TypeOf((*MockMntInterface)(nil).AddRefOfMount), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRefOfMount", reflect.TypeOf((*MockMntInterface)(nil).AddRefOfMount), arg0, arg1, arg2)
 }
 
 // CleanCache mocks base method.
-func (m *MockMntInterface) CleanCache(arg0, arg1 string, arg2 []string) error {
+func (m *MockMntInterface) CleanCache(arg0 context.Context, arg1, arg2 string, arg3 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CleanCache", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CleanCache", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CleanCache indicates an expected call of CleanCache.
-func (mr *MockMntInterfaceMockRecorder) CleanCache(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMntInterfaceMockRecorder) CleanCache(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanCache", reflect.TypeOf((*MockMntInterface)(nil).CleanCache), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanCache", reflect.TypeOf((*MockMntInterface)(nil).CleanCache), arg0, arg1, arg2, arg3)
 }
 
 // GetMountRef mocks base method.
-func (m *MockMntInterface) GetMountRef(arg0, arg1 string) (int, error) {
+func (m *MockMntInterface) GetMountRef(arg0 context.Context, arg1, arg2 string) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMountRef", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetMountRef", arg0, arg1, arg2)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMountRef indicates an expected call of GetMountRef.
-func (mr *MockMntInterfaceMockRecorder) GetMountRef(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMntInterfaceMockRecorder) GetMountRef(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMountRef", reflect.TypeOf((*MockMntInterface)(nil).GetMountRef), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMountRef", reflect.TypeOf((*MockMntInterface)(nil).GetMountRef), arg0, arg1, arg2)
 }
 
 // GetMountRefs mocks base method.
@@ -109,59 +110,59 @@ func (mr *MockMntInterfaceMockRecorder) IsLikelyNotMountPoint(arg0 interface{}) 
 }
 
 // JCreateVolume mocks base method.
-func (m *MockMntInterface) JCreateVolume(arg0 *config.JfsSetting) error {
+func (m *MockMntInterface) JCreateVolume(arg0 context.Context, arg1 *config.JfsSetting) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JCreateVolume", arg0)
+	ret := m.ctrl.Call(m, "JCreateVolume", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // JCreateVolume indicates an expected call of JCreateVolume.
-func (mr *MockMntInterfaceMockRecorder) JCreateVolume(arg0 interface{}) *gomock.Call {
+func (mr *MockMntInterfaceMockRecorder) JCreateVolume(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JCreateVolume", reflect.TypeOf((*MockMntInterface)(nil).JCreateVolume), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JCreateVolume", reflect.TypeOf((*MockMntInterface)(nil).JCreateVolume), arg0, arg1)
 }
 
 // JDeleteVolume mocks base method.
-func (m *MockMntInterface) JDeleteVolume(arg0 *config.JfsSetting) error {
+func (m *MockMntInterface) JDeleteVolume(arg0 context.Context, arg1 *config.JfsSetting) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JDeleteVolume", arg0)
+	ret := m.ctrl.Call(m, "JDeleteVolume", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // JDeleteVolume indicates an expected call of JDeleteVolume.
-func (mr *MockMntInterfaceMockRecorder) JDeleteVolume(arg0 interface{}) *gomock.Call {
+func (mr *MockMntInterfaceMockRecorder) JDeleteVolume(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JDeleteVolume", reflect.TypeOf((*MockMntInterface)(nil).JDeleteVolume), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JDeleteVolume", reflect.TypeOf((*MockMntInterface)(nil).JDeleteVolume), arg0, arg1)
 }
 
 // JMount mocks base method.
-func (m *MockMntInterface) JMount(arg0 *config.JfsSetting) error {
+func (m *MockMntInterface) JMount(arg0 context.Context, arg1 *config.JfsSetting) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JMount", arg0)
+	ret := m.ctrl.Call(m, "JMount", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // JMount indicates an expected call of JMount.
-func (mr *MockMntInterfaceMockRecorder) JMount(arg0 interface{}) *gomock.Call {
+func (mr *MockMntInterfaceMockRecorder) JMount(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JMount", reflect.TypeOf((*MockMntInterface)(nil).JMount), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JMount", reflect.TypeOf((*MockMntInterface)(nil).JMount), arg0, arg1)
 }
 
 // JUmount mocks base method.
-func (m *MockMntInterface) JUmount(arg0, arg1 string) error {
+func (m *MockMntInterface) JUmount(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JUmount", arg0, arg1)
+	ret := m.ctrl.Call(m, "JUmount", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // JUmount indicates an expected call of JUmount.
-func (mr *MockMntInterfaceMockRecorder) JUmount(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMntInterfaceMockRecorder) JUmount(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JUmount", reflect.TypeOf((*MockMntInterface)(nil).JUmount), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JUmount", reflect.TypeOf((*MockMntInterface)(nil).JUmount), arg0, arg1, arg2)
 }
 
 // List mocks base method.
@@ -208,17 +209,17 @@ func (mr *MockMntInterfaceMockRecorder) MountSensitive(arg0, arg1, arg2, arg3, a
 }
 
 // UmountTarget mocks base method.
-func (m *MockMntInterface) UmountTarget(arg0, arg1 string) error {
+func (m *MockMntInterface) UmountTarget(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UmountTarget", arg0, arg1)
+	ret := m.ctrl.Call(m, "UmountTarget", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UmountTarget indicates an expected call of UmountTarget.
-func (mr *MockMntInterfaceMockRecorder) UmountTarget(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMntInterfaceMockRecorder) UmountTarget(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UmountTarget", reflect.TypeOf((*MockMntInterface)(nil).UmountTarget), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UmountTarget", reflect.TypeOf((*MockMntInterface)(nil).UmountTarget), arg0, arg1, arg2)
 }
 
 // Unmount mocks base method.

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -287,7 +287,7 @@ func (p *PodMount) createOrAddRef(ctx context.Context, jfsSetting *jfsConfig.Jfs
 	r := builder.NewBuilder(jfsSetting)
 	secret := r.NewSecret()
 	key := util.GetReferenceKey(jfsSetting.TargetPath)
-	for {
+	for i := 0; i < 120; i++ {
 		// wait for old pod deleted
 		oldPod, err := p.K8sClient.GetPod(ctx, podName, jfsConfig.Namespace)
 		if err == nil && oldPod.DeletionTimestamp != nil {
@@ -322,6 +322,7 @@ func (p *PodMount) createOrAddRef(ctx context.Context, jfsSetting *jfsConfig.Jfs
 		}
 		return podName, p.AddRefOfMount(ctx, jfsSetting.TargetPath, podName)
 	}
+	return podName, fmt.Errorf("mount %v failed: mount pod %s has been deleting", jfsSetting.VolumeId, podName)
 }
 
 func (p *PodMount) waitUtilMountReady(ctx context.Context, jfsSetting *jfsConfig.JfsSetting, podName string) error {

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -357,15 +357,12 @@ func (p *PodMount) waitUtilMountReady(ctx context.Context, jfsSetting *jfsConfig
 
 func (p *PodMount) waitUtilJobCompleted(ctx context.Context, jobName string) error {
 	// Wait until the job is completed
-	for {
+	for i := 0; i < 120; i++ {
 		job, err := p.K8sClient.GetJob(ctx, jobName, jfsConfig.Namespace)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				klog.Infof("waitUtilJobCompleted: Job %s is completed and been recycled", jobName)
 				return nil
-			}
-			if k8serrors.IsTimeout(err) {
-				break
 			}
 			return fmt.Errorf("waitUtilJobCompleted: Get job %v failed: %v", jobName, err)
 		}

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -57,16 +57,16 @@ func NewPodMount(client *k8sclient.K8sClient, mounter k8sMount.SafeFormatAndMoun
 	return &PodMount{mounter, client}
 }
 
-func (p *PodMount) JMount(jfsSetting *jfsConfig.JfsSetting) error {
-	podName, err := p.createOrAddRef(jfsSetting)
+func (p *PodMount) JMount(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) error {
+	podName, err := p.createOrAddRef(ctx, jfsSetting)
 	if err != nil {
 		return err
 	}
-	return p.waitUtilMountReady(jfsSetting, podName)
+	return p.waitUtilMountReady(ctx, jfsSetting, podName)
 }
 
-func (p *PodMount) GetMountRef(target, podName string) (int, error) {
-	pod, err := p.K8sClient.GetPod(podName, jfsConfig.Namespace)
+func (p *PodMount) GetMountRef(ctx context.Context, target, podName string) (int, error) {
+	pod, err := p.K8sClient.GetPod(ctx, podName, jfsConfig.Namespace)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return 0, nil
@@ -77,7 +77,7 @@ func (p *PodMount) GetMountRef(target, podName string) (int, error) {
 	return GetRef(pod), nil
 }
 
-func (p *PodMount) UmountTarget(target, podName string) error {
+func (p *PodMount) UmountTarget(ctx context.Context, target, podName string) error {
 	// targetPath may be mount bind many times when mount point recovered.
 	// umount until it's not mounted.
 	klog.V(5).Infof("JfsUnmount: umount %s", target)
@@ -115,7 +115,7 @@ func (p *PodMount) UmountTarget(target, podName string) error {
 		klog.V(5).Infof("JUmount: Mount pod of target %s not exists.", target)
 		return nil
 	}
-	pod, err := p.K8sClient.GetPod(podName, jfsConfig.Namespace)
+	pod, err := p.K8sClient.GetPod(ctx, podName, jfsConfig.Namespace)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		klog.Errorf("JUmount: Get pod %s err: %v", podName, err)
 		return err
@@ -131,7 +131,7 @@ func (p *PodMount) UmountTarget(target, podName string) error {
 	klog.V(6).Infof("JUmount: Target %v hash of target %v", target, key)
 
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		po, err := p.K8sClient.GetPod(pod.Name, pod.Namespace)
+		po, err := p.K8sClient.GetPod(ctx, pod.Name, pod.Namespace)
 		if err != nil {
 			return err
 		}
@@ -141,7 +141,7 @@ func (p *PodMount) UmountTarget(target, podName string) error {
 			return nil
 		}
 		delete(annotation, key)
-		return util.PatchPodAnnotation(p.K8sClient, pod, annotation)
+		return util.PatchPodAnnotation(ctx, p.K8sClient, pod, annotation)
 	})
 	if err != nil {
 		klog.Errorf("JUmount: Remove ref of target %s err: %v", target, err)
@@ -150,10 +150,9 @@ func (p *PodMount) UmountTarget(target, podName string) error {
 	return nil
 }
 
-func (p *PodMount) JUmount(target, podName string) error {
-
+func (p *PodMount) JUmount(ctx context.Context, target, podName string) error {
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		po, err := p.K8sClient.GetPod(podName, jfsConfig.Namespace)
+		po, err := p.K8sClient.GetPod(ctx, podName, jfsConfig.Namespace)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				return nil
@@ -168,14 +167,14 @@ func (p *PodMount) JUmount(target, podName string) error {
 		}
 
 		var shouldDelay bool
-		shouldDelay, err = util.ShouldDelay(po, p.K8sClient)
+		shouldDelay, err = util.ShouldDelay(ctx, po, p.K8sClient)
 		if err != nil {
 			return err
 		}
 		if !shouldDelay {
 			// do not set delay delete, delete it now
 			klog.V(5).Infof("JUmount: pod %s has no juicefs- refs. delete it.", podName)
-			if err := p.K8sClient.DeletePod(po); err != nil {
+			if err := p.K8sClient.DeletePod(ctx, po); err != nil {
 				klog.V(5).Infof("JUmount: Delete pod %s error: %v", podName, err)
 				return err
 			}
@@ -183,7 +182,7 @@ func (p *PodMount) JUmount(target, podName string) error {
 			// delete related secret
 			secretName := po.Name + "-secret"
 			klog.V(5).Infof("JUmount: delete related secret of pod %s: %s", podName, secretName)
-			if err := p.K8sClient.DeleteSecret(secretName, po.Namespace); err != nil {
+			if err := p.K8sClient.DeleteSecret(ctx, secretName, po.Namespace); err != nil {
 				// do not return err if delete secret failed
 				klog.V(5).Infof("JUmount: Delete secret %s error: %v", secretName, err)
 			}
@@ -194,14 +193,14 @@ func (p *PodMount) JUmount(target, podName string) error {
 	return err
 }
 
-func (p *PodMount) JCreateVolume(jfsSetting *jfsConfig.JfsSetting) error {
+func (p *PodMount) JCreateVolume(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) error {
 	var exist *batchv1.Job
 	r := builder.NewBuilder(jfsSetting)
 	job := r.NewJobForCreateVolume()
-	exist, err := p.K8sClient.GetJob(job.Name, job.Namespace)
+	exist, err := p.K8sClient.GetJob(ctx, job.Name, job.Namespace)
 	if err != nil && k8serrors.IsNotFound(err) {
 		klog.V(5).Infof("JCreateVolume: create job %s", job.Name)
-		exist, err = p.K8sClient.CreateJob(job)
+		exist, err = p.K8sClient.CreateJob(ctx, job)
 		if err != nil {
 			klog.Errorf("JCreateVolume: create job %s err: %v", job.Name, err)
 			return err
@@ -213,27 +212,27 @@ func (p *PodMount) JCreateVolume(jfsSetting *jfsConfig.JfsSetting) error {
 	}
 	secret := r.NewSecret()
 	builder.SetJobAsOwner(&secret, *exist)
-	if err := p.createOrUpdateSecret(&secret); err != nil {
+	if err := p.createOrUpdateSecret(ctx, &secret); err != nil {
 		return err
 	}
-	err = p.waitUtilJobCompleted(job.Name)
+	err = p.waitUtilJobCompleted(ctx, job.Name)
 	if err != nil {
 		// fall back if err
-		if e := p.K8sClient.DeleteJob(job.Name, job.Namespace); e != nil {
+		if e := p.K8sClient.DeleteJob(ctx, job.Name, job.Namespace); e != nil {
 			klog.Errorf("JCreateVolume: delete job %s error: %v", job.Name, e)
 		}
 	}
 	return err
 }
 
-func (p *PodMount) JDeleteVolume(jfsSetting *jfsConfig.JfsSetting) error {
+func (p *PodMount) JDeleteVolume(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) error {
 	var exist *batchv1.Job
 	r := builder.NewBuilder(jfsSetting)
 	job := r.NewJobForDeleteVolume()
-	exist, err := p.K8sClient.GetJob(job.Name, job.Namespace)
+	exist, err := p.K8sClient.GetJob(ctx, job.Name, job.Namespace)
 	if err != nil && k8serrors.IsNotFound(err) {
 		klog.V(5).Infof("JDeleteVolume: create job %s", job.Name)
-		exist, err = p.K8sClient.CreateJob(job)
+		exist, err = p.K8sClient.CreateJob(ctx, job)
 		if err != nil {
 			klog.Errorf("JDeleteVolume: create job %s err: %v", job.Name, err)
 			return err
@@ -245,20 +244,20 @@ func (p *PodMount) JDeleteVolume(jfsSetting *jfsConfig.JfsSetting) error {
 	}
 	secret := r.NewSecret()
 	builder.SetJobAsOwner(&secret, *exist)
-	if err := p.createOrUpdateSecret(&secret); err != nil {
+	if err := p.createOrUpdateSecret(ctx, &secret); err != nil {
 		return err
 	}
-	err = p.waitUtilJobCompleted(job.Name)
+	err = p.waitUtilJobCompleted(ctx, job.Name)
 	if err != nil {
 		// fall back if err
-		if e := p.K8sClient.DeleteJob(job.Name, job.Namespace); e != nil {
+		if e := p.K8sClient.DeleteJob(ctx, job.Name, job.Namespace); e != nil {
 			klog.Errorf("JDeleteVolume: delete job %s error: %v", job.Name, e)
 		}
 	}
 	return err
 }
 
-func (p *PodMount) createOrAddRef(jfsSetting *jfsConfig.JfsSetting) (podName string, err error) {
+func (p *PodMount) createOrAddRef(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) (podName string, err error) {
 	hashVal, err := GenHashOfSetting(*jfsSetting)
 	if err != nil {
 		klog.Errorf("Generate hash of jfsSetting error: %v", err)
@@ -271,7 +270,7 @@ func (p *PodMount) createOrAddRef(jfsSetting *jfsConfig.JfsSetting) (podName str
 		jfsConfig.PodJuiceHashLabelKey: hashVal,
 	}}
 	fieldSelector := &fields.Set{"spec.nodeName": jfsConfig.NodeName}
-	pods, err := p.K8sClient.ListPod(jfsConfig.Namespace, labelSelector, fieldSelector)
+	pods, err := p.K8sClient.ListPod(ctx, jfsConfig.Namespace, labelSelector, fieldSelector)
 	if err != nil {
 		klog.Errorf("List pods of uniqueId %s and hash %s error: %v", jfsSetting.UniqueId, hashVal, err)
 		return "", err
@@ -293,7 +292,7 @@ func (p *PodMount) createOrAddRef(jfsSetting *jfsConfig.JfsSetting) (podName str
 	key := util.GetReferenceKey(jfsSetting.TargetPath)
 	for i := 0; i < 120; i++ {
 		// wait for old pod deleted
-		oldPod, err := p.K8sClient.GetPod(podName, jfsConfig.Namespace)
+		oldPod, err := p.K8sClient.GetPod(ctx, podName, jfsConfig.Namespace)
 		if err == nil && oldPod.DeletionTimestamp != nil {
 			klog.V(6).Infof("createOrAddRef: wait for old mount pod deleted.")
 			time.Sleep(time.Millisecond * 500)
@@ -305,11 +304,11 @@ func (p *PodMount) createOrAddRef(jfsSetting *jfsConfig.JfsSetting) (podName str
 				newPod := r.NewMountPod(podName)
 				newPod.Annotations[key] = jfsSetting.TargetPath
 				newPod.Labels[jfsConfig.PodJuiceHashLabelKey] = hashVal
-				_, err := p.K8sClient.CreatePod(newPod)
+				_, err := p.K8sClient.CreatePod(ctx, newPod)
 				if err != nil {
 					klog.Errorf("createOrAddRef: Create pod %s err: %v", podName, err)
 				}
-				if err := p.createOrUpdateSecret(&secret); err != nil {
+				if err := p.createOrUpdateSecret(ctx, &secret); err != nil {
 					return "", err
 				}
 				return podName, err
@@ -319,18 +318,16 @@ func (p *PodMount) createOrAddRef(jfsSetting *jfsConfig.JfsSetting) (podName str
 			return "", err
 		}
 		// pod exist, add refs
-		if err := p.createOrUpdateSecret(&secret); err != nil {
+		if err := p.createOrUpdateSecret(ctx, &secret); err != nil {
 			return "", err
 		}
-		return podName, p.AddRefOfMount(jfsSetting.TargetPath, podName)
+		return podName, p.AddRefOfMount(ctx, jfsSetting.TargetPath, podName)
 	}
 	return podName, status.Errorf(codes.Internal, "Mount %v failed: mount pod %s has been deleting for 1 min", jfsSetting.VolumeId, podName)
 }
 
-func (p *PodMount) waitUtilMountReady(jfsSetting *jfsConfig.JfsSetting, podName string) error {
+func (p *PodMount) waitUtilMountReady(ctx context.Context, jfsSetting *jfsConfig.JfsSetting, podName string) error {
 	// Wait until the mount point is ready
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*1)
-	defer cancel()
 	for {
 		var finfo os.FileInfo
 		if err := util.DoWithContext(ctx, func() (err error) {
@@ -356,7 +353,7 @@ func (p *PodMount) waitUtilMountReady(jfsSetting *jfsConfig.JfsSetting, podName 
 		time.Sleep(time.Millisecond * 500)
 	}
 	// mountpoint not ready, get mount pod log for detail
-	log, err := p.getErrContainerLog(podName)
+	log, err := p.getErrContainerLog(ctx, podName)
 	if err != nil {
 		klog.Errorf("Get pod %s log error %v", podName, err)
 		return status.Errorf(codes.Internal, "Mount %v at %v failed: mount isn't ready in 30 seconds", util.StripPasswd(jfsSetting.Source), jfsSetting.MountPath)
@@ -364,10 +361,10 @@ func (p *PodMount) waitUtilMountReady(jfsSetting *jfsConfig.JfsSetting, podName 
 	return status.Errorf(codes.Internal, "Mount %v at %v failed: %v", util.StripPasswd(jfsSetting.Source), jfsSetting.MountPath, log)
 }
 
-func (p *PodMount) waitUtilJobCompleted(jobName string) error {
+func (p *PodMount) waitUtilJobCompleted(ctx context.Context, jobName string) error {
 	// Wait until the job is completed
 	for i := 0; i < 120; i++ {
-		job, err := p.K8sClient.GetJob(jobName, jfsConfig.Namespace)
+		job, err := p.K8sClient.GetJob(ctx, jobName, jfsConfig.Namespace)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				klog.Infof("waitUtilJobCompleted: Job %s is completed and been recycled", jobName)
@@ -381,7 +378,7 @@ func (p *PodMount) waitUtilJobCompleted(jobName string) error {
 		}
 		time.Sleep(time.Millisecond * 500)
 	}
-	pods, err := p.K8sClient.ListPod(jfsConfig.Namespace, &metav1.LabelSelector{
+	pods, err := p.K8sClient.ListPod(ctx, jfsConfig.Namespace, &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"job-name": jobName,
 		},
@@ -389,20 +386,20 @@ func (p *PodMount) waitUtilJobCompleted(jobName string) error {
 	if err != nil || len(pods) != 1 {
 		return status.Errorf(codes.Internal, "waitUtilJobCompleted: get pod from job %s error %v", jobName, err)
 	}
-	log, err := p.getNotCompleteCnLog(pods[0].Name)
+	log, err := p.getNotCompleteCnLog(ctx, pods[0].Name)
 	if err != nil {
 		return status.Errorf(codes.Internal, "waitUtilJobCompleted: get pod %s log error %v", pods[0].Name, err)
 	}
 	return status.Errorf(codes.Internal, "waitUtilJobCompleted: job %s isn't completed in 1 min: %v", jobName, log)
 }
 
-func (p *PodMount) AddRefOfMount(target string, podName string) error {
+func (p *PodMount) AddRefOfMount(ctx context.Context, target string, podName string) error {
 	klog.V(5).Infof("addRefOfMount: Add target ref in mount pod. mount pod: [%s], target: [%s]", podName, target)
 	// add volumeId ref in pod annotation
 	key := util.GetReferenceKey(target)
 
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		exist, err := p.K8sClient.GetPod(podName, jfsConfig.Namespace)
+		exist, err := p.K8sClient.GetPod(ctx, podName, jfsConfig.Namespace)
 		if err != nil {
 			return err
 		}
@@ -420,7 +417,7 @@ func (p *PodMount) AddRefOfMount(target string, podName string) error {
 		annotation[key] = target
 		// delete deleteDelayAt when there ars refs
 		delete(annotation, jfsConfig.DeleteDelayAtKey)
-		return util.PatchPodAnnotation(p.K8sClient, exist, annotation)
+		return util.PatchPodAnnotation(ctx, p.K8sClient, exist, annotation)
 	})
 	if err != nil {
 		klog.Errorf("addRefOfMount: Add target ref in mount pod %s error: %v", podName, err)
@@ -429,7 +426,7 @@ func (p *PodMount) AddRefOfMount(target string, podName string) error {
 	return nil
 }
 
-func (p *PodMount) CleanCache(id string, volumeId string, cacheDirs []string) error {
+func (p *PodMount) CleanCache(ctx context.Context, id string, volumeId string, cacheDirs []string) error {
 	jfsSetting := &jfsConfig.JfsSetting{
 		VolumeId:  volumeId,
 		CacheDirs: cacheDirs,
@@ -438,34 +435,34 @@ func (p *PodMount) CleanCache(id string, volumeId string, cacheDirs []string) er
 	r := builder.NewBuilder(jfsSetting)
 	job := r.NewJobForCleanCache()
 	klog.V(6).Infof("Clean cache job: %v", job)
-	_, err := p.K8sClient.GetJob(job.Name, job.Namespace)
+	_, err := p.K8sClient.GetJob(ctx, job.Name, job.Namespace)
 	if err != nil && k8serrors.IsNotFound(err) {
 		klog.V(5).Infof("CleanCache: create job %s", job.Name)
-		_, err = p.K8sClient.CreateJob(job)
+		_, err = p.K8sClient.CreateJob(ctx, job)
 	}
 	if err != nil {
 		klog.Errorf("CleanCache: get or create job %s err: %s", job.Name, err)
 		return err
 	}
-	err = p.waitUtilJobCompleted(job.Name)
+	err = p.waitUtilJobCompleted(ctx, job.Name)
 	if err != nil {
 		klog.Errorf("CleanCache: wait for job completed err and fall back to delete job\n %v", err)
 		// fall back if err
-		if e := p.K8sClient.DeleteJob(job.Name, job.Namespace); e != nil {
+		if e := p.K8sClient.DeleteJob(ctx, job.Name, job.Namespace); e != nil {
 			klog.Errorf("CleanCache: delete job %s error: %v", job.Name, e)
 		}
 	}
 	return nil
 }
 
-func (p *PodMount) createOrUpdateSecret(secret *corev1.Secret) error {
+func (p *PodMount) createOrUpdateSecret(ctx context.Context, secret *corev1.Secret) error {
 	klog.V(5).Infof("createOrUpdateSecret: %s, %s", secret.Name, secret.Namespace)
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		oldSecret, err := p.K8sClient.GetSecret(secret.Name, jfsConfig.Namespace)
+		oldSecret, err := p.K8sClient.GetSecret(ctx, secret.Name, jfsConfig.Namespace)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				// secret not exist, create
-				_, err := p.K8sClient.CreateSecret(secret)
+				_, err := p.K8sClient.CreateSecret(ctx, secret)
 				return err
 			}
 			// unexpected err
@@ -473,7 +470,7 @@ func (p *PodMount) createOrUpdateSecret(secret *corev1.Secret) error {
 		}
 
 		oldSecret.StringData = secret.StringData
-		return p.K8sClient.UpdateSecret(oldSecret)
+		return p.K8sClient.UpdateSecret(ctx, oldSecret)
 	})
 	if err != nil {
 		klog.Errorf("createOrUpdateSecret: secret %s: %v", secret.Name, err)
@@ -482,40 +479,40 @@ func (p *PodMount) createOrUpdateSecret(secret *corev1.Secret) error {
 	return nil
 }
 
-func (p *PodMount) getErrContainerLog(podName string) (log string, err error) {
-	pod, err := p.K8sClient.GetPod(podName, jfsConfig.Namespace)
+func (p *PodMount) getErrContainerLog(ctx context.Context, podName string) (log string, err error) {
+	pod, err := p.K8sClient.GetPod(ctx, podName, jfsConfig.Namespace)
 	if err != nil {
 		return
 	}
 	for _, cn := range pod.Status.InitContainerStatuses {
 		if !cn.Ready {
-			log, err = p.K8sClient.GetPodLog(pod.Name, pod.Namespace, cn.Name)
+			log, err = p.K8sClient.GetPodLog(ctx, pod.Name, pod.Namespace, cn.Name)
 			return
 		}
 	}
 	for _, cn := range pod.Status.ContainerStatuses {
 		if !cn.Ready {
-			log, err = p.K8sClient.GetPodLog(pod.Name, pod.Namespace, cn.Name)
+			log, err = p.K8sClient.GetPodLog(ctx, pod.Name, pod.Namespace, cn.Name)
 			return
 		}
 	}
 	return
 }
 
-func (p *PodMount) getNotCompleteCnLog(podName string) (log string, err error) {
-	pod, err := p.K8sClient.GetPod(podName, jfsConfig.Namespace)
+func (p *PodMount) getNotCompleteCnLog(ctx context.Context, podName string) (log string, err error) {
+	pod, err := p.K8sClient.GetPod(ctx, podName, jfsConfig.Namespace)
 	if err != nil {
 		return
 	}
 	for _, cn := range pod.Status.InitContainerStatuses {
 		if cn.State.Terminated == nil || cn.State.Terminated.Reason != "Completed" {
-			log, err = p.K8sClient.GetPodLog(pod.Name, pod.Namespace, cn.Name)
+			log, err = p.K8sClient.GetPodLog(ctx, pod.Name, pod.Namespace, cn.Name)
 			return
 		}
 	}
 	for _, cn := range pod.Status.ContainerStatuses {
 		if cn.State.Terminated == nil || cn.State.Terminated.Reason != "Completed" {
-			log, err = p.K8sClient.GetPodLog(pod.Name, pod.Namespace, cn.Name)
+			log, err = p.K8sClient.GetPodLog(ctx, pod.Name, pod.Namespace, cn.Name)
 			return
 		}
 	}

--- a/pkg/juicefs/mount/pod_mount_test.go
+++ b/pkg/juicefs/mount/pod_mount_test.go
@@ -229,7 +229,7 @@ func TestAddRefOfMountWithMock(t *testing.T) {
 	Convey("Test AddRefOfMount", t, func() {
 		Convey("get pod error", func() {
 			client := &k8sclient.K8sClient{}
-			patch1 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch1 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch1.Reset()
@@ -337,7 +337,7 @@ func TestJUmountWithMock(t *testing.T) {
 			})
 			defer patch1.Reset()
 			client := &k8sclient.K8sClient{}
-			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch2.Reset()
@@ -403,7 +403,7 @@ func TestJUmountWithMock(t *testing.T) {
 		})
 		Convey("pod delete error", func() {
 			client := &k8sclient.K8sClient{}
-			patch1 := ApplyMethod(reflect.TypeOf(client), "DeletePod", func(_ *k8sclient.K8sClient, pod *corev1.Pod) error {
+			patch1 := ApplyMethod(reflect.TypeOf(client), "DeletePod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod) error {
 				return errors.New("test")
 			})
 			defer patch1.Reset()
@@ -436,7 +436,7 @@ func TestUmountTarget(t *testing.T) {
 			})
 			defer patch1.Reset()
 			client := &k8sclient.K8sClient{}
-			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch2.Reset()
@@ -490,7 +490,7 @@ func TestUmountTarget(t *testing.T) {
 		})
 		Convey("pod update error", func() {
 			client := &k8sclient.K8sClient{}
-			patch1 := ApplyMethod(reflect.TypeOf(client), "PatchPod", func(_ *k8sclient.K8sClient, pod *corev1.Pod, data []byte) error {
+			patch1 := ApplyMethod(reflect.TypeOf(client), "PatchPod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod, data []byte) error {
 				return errors.New("test")
 			})
 			defer patch1.Reset()
@@ -625,11 +625,11 @@ func TestWaitUntilMountWithMock(t *testing.T) {
 				return true
 			})
 			defer patch1.Reset()
-			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch2.Reset()
-			patch3 := ApplyMethod(reflect.TypeOf(client), "CreatePod", func(_ *k8sclient.K8sClient, pod *corev1.Pod) (*corev1.Pod, error) {
+			patch3 := ApplyMethod(reflect.TypeOf(client), "CreatePod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch3.Reset()
@@ -657,7 +657,7 @@ func TestJMount(t *testing.T) {
 				return false
 			})
 			defer patch1.Reset()
-			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch2.Reset()

--- a/pkg/juicefs/mount/pod_mount_test.go
+++ b/pkg/juicefs/mount/pod_mount_test.go
@@ -17,13 +17,15 @@ limitations under the License.
 package mount
 
 import (
+	"context"
 	"errors"
-	"github.com/juicedata/juicefs-csi-driver/pkg/driver/mocks"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"os"
 	"os/exec"
 	"reflect"
 	"testing"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/driver/mocks"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	. "github.com/agiledragon/gomonkey"
 	. "github.com/smartystreets/goconvey/convey"
@@ -203,8 +205,8 @@ func TestAddRefOfMount(t *testing.T) {
 				K8sClient:          &k8sclient.K8sClient{Interface: fakeClientSet},
 			}
 			key := util.GetReferenceKey(tt.args.target)
-			_, _ = p.K8sClient.CreatePod(tt.args.pod)
-			old, err := p.K8sClient.GetPod(tt.args.pod.Name, jfsConfig.Namespace)
+			_, _ = p.K8sClient.CreatePod(context.TODO(), tt.args.pod)
+			old, err := p.K8sClient.GetPod(context.TODO(), tt.args.pod.Name, jfsConfig.Namespace)
 			if err != nil {
 				t.Errorf("Can't get pod: %v", tt.args.pod.Name)
 			}
@@ -212,10 +214,10 @@ func TestAddRefOfMount(t *testing.T) {
 				old.Annotations = make(map[string]string)
 			}
 			old.Annotations[key] = tt.args.target
-			if err := p.AddRefOfMount(tt.args.target, tt.args.pod.Name); (err != nil) != tt.wantErr {
+			if err := p.AddRefOfMount(context.TODO(), tt.args.target, tt.args.pod.Name); (err != nil) != tt.wantErr {
 				t.Errorf("AddRefOfMount() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			newPod, _ := p.K8sClient.GetPod(tt.args.pod.Name, jfsConfig.Namespace)
+			newPod, _ := p.K8sClient.GetPod(context.TODO(), tt.args.pod.Name, jfsConfig.Namespace)
 			if !reflect.DeepEqual(newPod.Annotations, old.Annotations) {
 				t.Errorf("addRefOfMount err, wanted: %v, got: %v", old.Annotations, newPod.Annotations)
 			}
@@ -234,7 +236,7 @@ func TestAddRefOfMountWithMock(t *testing.T) {
 			p := &PodMount{
 				K8sClient: &k8sclient.K8sClient{Interface: fake.NewSimpleClientset()},
 			}
-			err := p.AddRefOfMount("test-target", "test-pod")
+			err := p.AddRefOfMount(context.TODO(), "test-target", "test-pod")
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -314,12 +316,12 @@ func TestJUmount(t *testing.T) {
 				},
 			}
 			if tt.pod != nil {
-				_, _ = p.K8sClient.CreatePod(tt.pod)
+				_, _ = p.K8sClient.CreatePod(context.TODO(), tt.pod)
 			}
-			if err := p.JUmount(tt.args.target, tt.args.podName); (err != nil) != tt.wantErr {
+			if err := p.JUmount(context.TODO(), tt.args.target, tt.args.podName); (err != nil) != tt.wantErr {
 				t.Errorf("JUmount() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			got, _ := p.K8sClient.GetPod(tt.args.podName, jfsConfig.Namespace)
+			got, _ := p.K8sClient.GetPod(context.TODO(), tt.args.podName, jfsConfig.Namespace)
 			if tt.wantPodDeleted && got != nil {
 				t.Errorf("JUmount() got: %v, wanted pod deleted: %v", got, tt.wantPodDeleted)
 			}
@@ -344,7 +346,7 @@ func TestJUmountWithMock(t *testing.T) {
 				Interface: mount.New(""),
 				Exec:      k8sexec.New(),
 			})
-			err := p.JUmount("/test", "ttt")
+			err := p.JUmount(context.TODO(), "/test", "ttt")
 			So(err, ShouldNotBeNil)
 		})
 		Convey("pod hasRef", func() {
@@ -361,7 +363,7 @@ func TestJUmountWithMock(t *testing.T) {
 				},
 			}
 			podName := GenPodNameByUniqueId("ttt", true)
-			p.K8sClient.CreatePod(&corev1.Pod{
+			p.K8sClient.CreatePod(context.TODO(), &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      podName,
 					Namespace: jfsConfig.Namespace,
@@ -370,7 +372,7 @@ func TestJUmountWithMock(t *testing.T) {
 					},
 				},
 			})
-			err := p.JUmount("/test", podName)
+			err := p.JUmount(context.TODO(), "/test", podName)
 			So(err, ShouldBeNil)
 		})
 		Convey("pod conflict", func() {
@@ -387,7 +389,7 @@ func TestJUmountWithMock(t *testing.T) {
 				},
 			}
 			podName := GenPodNameByUniqueId("ttt", true)
-			p.K8sClient.CreatePod(&corev1.Pod{
+			p.K8sClient.CreatePod(context.TODO(), &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      podName,
 					Namespace: jfsConfig.Namespace,
@@ -396,7 +398,7 @@ func TestJUmountWithMock(t *testing.T) {
 					},
 				},
 			})
-			err := p.JUmount("/test", podName)
+			err := p.JUmount(context.TODO(), "/test", podName)
 			So(err, ShouldBeNil)
 		})
 		Convey("pod delete error", func() {
@@ -414,13 +416,13 @@ func TestJUmountWithMock(t *testing.T) {
 				},
 			}
 			podName := GenPodNameByUniqueId("ttt", true)
-			p.K8sClient.CreatePod(&corev1.Pod{
+			p.K8sClient.CreatePod(context.TODO(), &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      podName,
 					Namespace: jfsConfig.Namespace,
 				},
 			})
-			err := p.JUmount("/test", podName)
+			err := p.JUmount(context.TODO(), "/test", podName)
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -452,7 +454,7 @@ func TestUmountTarget(t *testing.T) {
 				Interface: mount.New(""),
 				Exec:      k8sexec.New(),
 			})
-			err := p.UmountTarget("/test", "ttt")
+			err := p.UmountTarget(context.TODO(), "/test", "ttt")
 			So(err, ShouldNotBeNil)
 		})
 		Convey("pod conflict", func() {
@@ -474,7 +476,7 @@ func TestUmountTarget(t *testing.T) {
 				},
 			}
 			podName := GenPodNameByUniqueId("ttt", true)
-			p.K8sClient.CreatePod(&corev1.Pod{
+			p.K8sClient.CreatePod(context.TODO(), &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      podName,
 					Namespace: jfsConfig.Namespace,
@@ -483,7 +485,7 @@ func TestUmountTarget(t *testing.T) {
 					},
 				},
 			})
-			err := p.UmountTarget("/test", podName)
+			err := p.UmountTarget(context.TODO(), "/test", podName)
 			So(err, ShouldBeNil)
 		})
 		Convey("pod update error", func() {
@@ -510,7 +512,7 @@ func TestUmountTarget(t *testing.T) {
 				},
 			}
 			podName := GenPodNameByUniqueId("aaa", true)
-			p.K8sClient.CreatePod(&corev1.Pod{
+			p.K8sClient.CreatePod(context.TODO(), &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      podName,
 					Namespace: jfsConfig.Namespace,
@@ -519,7 +521,7 @@ func TestUmountTarget(t *testing.T) {
 					},
 				},
 			})
-			err := p.UmountTarget("/test", podName)
+			err := p.UmountTarget(context.TODO(), "/test", podName)
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -601,13 +603,13 @@ func TestWaitUntilMount(t *testing.T) {
 					jfsConfig.PodUniqueIdLabelKey:  tt.args.jfsSetting.UniqueId,
 					jfsConfig.PodJuiceHashLabelKey: hashVal,
 				}
-				_, _ = p.K8sClient.CreatePod(tt.pod)
+				_, _ = p.K8sClient.CreatePod(context.TODO(), tt.pod)
 			}
-			podName, err := p.createOrAddRef(tt.args.jfsSetting)
+			podName, err := p.createOrAddRef(context.TODO(), tt.args.jfsSetting)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createOrAddRef() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			newPod, _ := p.K8sClient.GetPod(podName, jfsConfig.Namespace)
+			newPod, _ := p.K8sClient.GetPod(context.TODO(), podName, jfsConfig.Namespace)
 			if newPod == nil || !reflect.DeepEqual(newPod.Annotations, tt.wantAnno) {
 				t.Errorf("waitUntilMount() got = %v, wantAnnotation = %v", newPod.Annotations, tt.wantAnno)
 			}
@@ -641,7 +643,7 @@ func TestWaitUntilMountWithMock(t *testing.T) {
 				SafeFormatAndMount: mount.SafeFormatAndMount{},
 				K8sClient:          &k8sclient.K8sClient{Interface: fakeClient},
 			}
-			_, err := p.createOrAddRef(&jfsConfig.JfsSetting{Storage: "ttt"})
+			_, err := p.createOrAddRef(context.TODO(), &jfsConfig.JfsSetting{Storage: "ttt"})
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -669,7 +671,7 @@ func TestJMount(t *testing.T) {
 				Interface: mount.New(""),
 				Exec:      k8sexec.New(),
 			})
-			err := p.JMount(&jfsConfig.JfsSetting{Storage: "ttt"})
+			err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{Storage: "ttt"})
 			So(err, ShouldNotBeNil)
 		})
 	})

--- a/pkg/juicefs/mount/pod_mount_test.go
+++ b/pkg/juicefs/mount/pod_mount_test.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/driver/mocks"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -236,7 +237,9 @@ func TestAddRefOfMountWithMock(t *testing.T) {
 			p := &PodMount{
 				K8sClient: &k8sclient.K8sClient{Interface: fake.NewSimpleClientset()},
 			}
-			err := p.AddRefOfMount(context.TODO(), "test-target", "test-pod")
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			err := p.AddRefOfMount(ctx, "test-target", "test-pod")
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -346,7 +349,9 @@ func TestJUmountWithMock(t *testing.T) {
 				Interface: mount.New(""),
 				Exec:      k8sexec.New(),
 			})
-			err := p.JUmount(context.TODO(), "/test", "ttt")
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			err := p.JUmount(ctx, "/test", "ttt")
 			So(err, ShouldNotBeNil)
 		})
 		Convey("pod hasRef", func() {
@@ -422,7 +427,9 @@ func TestJUmountWithMock(t *testing.T) {
 					Namespace: jfsConfig.Namespace,
 				},
 			})
-			err := p.JUmount(context.TODO(), "/test", podName)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			err := p.JUmount(ctx, "/test", podName)
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -454,7 +461,9 @@ func TestUmountTarget(t *testing.T) {
 				Interface: mount.New(""),
 				Exec:      k8sexec.New(),
 			})
-			err := p.UmountTarget(context.TODO(), "/test", "ttt")
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			err := p.UmountTarget(ctx, "/test", "ttt")
 			So(err, ShouldNotBeNil)
 		})
 		Convey("pod conflict", func() {
@@ -521,7 +530,9 @@ func TestUmountTarget(t *testing.T) {
 					},
 				},
 			})
-			err := p.UmountTarget(context.TODO(), "/test", podName)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			err := p.UmountTarget(ctx, "/test", podName)
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -643,7 +654,9 @@ func TestWaitUntilMountWithMock(t *testing.T) {
 				SafeFormatAndMount: mount.SafeFormatAndMount{},
 				K8sClient:          &k8sclient.K8sClient{Interface: fakeClient},
 			}
-			_, err := p.createOrAddRef(context.TODO(), &jfsConfig.JfsSetting{Storage: "ttt"})
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			_, err := p.createOrAddRef(ctx, &jfsConfig.JfsSetting{Storage: "ttt"})
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -671,7 +684,9 @@ func TestJMount(t *testing.T) {
 				Interface: mount.New(""),
 				Exec:      k8sexec.New(),
 			})
-			err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{Storage: "ttt"})
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			err := p.JMount(ctx, &jfsConfig.JfsSetting{Storage: "ttt"})
 			So(err, ShouldNotBeNil)
 		})
 	})

--- a/pkg/juicefs/mount/pod_mount_test.go
+++ b/pkg/juicefs/mount/pod_mount_test.go
@@ -229,7 +229,7 @@ func TestAddRefOfMountWithMock(t *testing.T) {
 	Convey("Test AddRefOfMount", t, func() {
 		Convey("get pod error", func() {
 			client := &k8sclient.K8sClient{}
-			patch1 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch1 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ *k8sclient.K8sClient, _ context.Context, podName, namespace string) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch1.Reset()
@@ -337,7 +337,7 @@ func TestJUmountWithMock(t *testing.T) {
 			})
 			defer patch1.Reset()
 			client := &k8sclient.K8sClient{}
-			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ *k8sclient.K8sClient, _ context.Context, podName, namespace string) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch2.Reset()
@@ -403,7 +403,7 @@ func TestJUmountWithMock(t *testing.T) {
 		})
 		Convey("pod delete error", func() {
 			client := &k8sclient.K8sClient{}
-			patch1 := ApplyMethod(reflect.TypeOf(client), "DeletePod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod) error {
+			patch1 := ApplyMethod(reflect.TypeOf(client), "DeletePod", func(_ *k8sclient.K8sClient, _ context.Context, pod *corev1.Pod) error {
 				return errors.New("test")
 			})
 			defer patch1.Reset()
@@ -436,7 +436,7 @@ func TestUmountTarget(t *testing.T) {
 			})
 			defer patch1.Reset()
 			client := &k8sclient.K8sClient{}
-			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ *k8sclient.K8sClient, _ context.Context, podName, namespace string) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch2.Reset()
@@ -490,7 +490,7 @@ func TestUmountTarget(t *testing.T) {
 		})
 		Convey("pod update error", func() {
 			client := &k8sclient.K8sClient{}
-			patch1 := ApplyMethod(reflect.TypeOf(client), "PatchPod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod, data []byte) error {
+			patch1 := ApplyMethod(reflect.TypeOf(client), "PatchPod", func(_ *k8sclient.K8sClient, _ context.Context, pod *corev1.Pod, data []byte) error {
 				return errors.New("test")
 			})
 			defer patch1.Reset()
@@ -625,11 +625,11 @@ func TestWaitUntilMountWithMock(t *testing.T) {
 				return true
 			})
 			defer patch1.Reset()
-			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ *k8sclient.K8sClient, _ context.Context, podName, namespace string) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch2.Reset()
-			patch3 := ApplyMethod(reflect.TypeOf(client), "CreatePod", func(_ context.Context, _ *k8sclient.K8sClient, pod *corev1.Pod) (*corev1.Pod, error) {
+			patch3 := ApplyMethod(reflect.TypeOf(client), "CreatePod", func(_ *k8sclient.K8sClient, _ context.Context, pod *corev1.Pod) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch3.Reset()
@@ -657,7 +657,7 @@ func TestJMount(t *testing.T) {
 				return false
 			})
 			defer patch1.Reset()
-			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ context.Context, _ *k8sclient.K8sClient, podName, namespace string) (*corev1.Pod, error) {
+			patch2 := ApplyMethod(reflect.TypeOf(client), "GetPod", func(_ *k8sclient.K8sClient, _ context.Context, podName, namespace string) (*corev1.Pod, error) {
 				return nil, errors.New("test")
 			})
 			defer patch2.Reset()

--- a/pkg/juicefs/mount/process_mount.go
+++ b/pkg/juicefs/mount/process_mount.go
@@ -191,9 +191,11 @@ func (p *ProcessMount) JMount(ctx context.Context, jfsSetting *jfsConfig.JfsSett
 	go func() { _ = mntCmd.Run() }()
 	// Wait until the mount point is ready
 
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 	for {
 		var finfo os.FileInfo
-		if err := util.DoWithContext(ctx, func() (err error) {
+		if err := util.DoWithContext(waitCtx, func() (err error) {
 			finfo, err = os.Stat(jfsSetting.MountPath)
 			return err
 		}); err != nil {

--- a/pkg/juicefs/mount/process_mount_test.go
+++ b/pkg/juicefs/mount/process_mount_test.go
@@ -17,7 +17,14 @@ limitations under the License.
 package mount
 
 import (
+	"context"
 	"errors"
+	"os"
+	"os/exec"
+	"reflect"
+	"syscall"
+	"testing"
+
 	. "github.com/agiledragon/gomonkey"
 	"github.com/golang/mock/gomock"
 	"github.com/juicedata/juicefs-csi-driver/pkg/driver/mocks"
@@ -25,11 +32,6 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	k8sexec "k8s.io/utils/exec"
 	k8sMount "k8s.io/utils/mount"
-	"os"
-	"os/exec"
-	"reflect"
-	"syscall"
-	"testing"
 
 	jfsConfig "github.com/juicedata/juicefs-csi-driver/pkg/config"
 )
@@ -98,7 +100,7 @@ func TestProcessMount_JUmount(t *testing.T) {
 			p := &ProcessMount{
 				SafeFormatAndMount: *mounter,
 			}
-			if err := p.JUmount(targetPath, podName); err != nil {
+			if err := p.JUmount(context.TODO(), targetPath, podName); err != nil {
 				t.Errorf("JUmount() error = %v", err)
 			}
 		})
@@ -110,7 +112,7 @@ func TestProcessMount_JUmount(t *testing.T) {
 			p := &ProcessMount{
 				SafeFormatAndMount: k8sMount.SafeFormatAndMount{},
 			}
-			if err := p.JUmount(targetPath, podName); err == nil {
+			if err := p.JUmount(context.TODO(), targetPath, podName); err == nil {
 				t.Errorf("JUmount() error = %v", err)
 			}
 		})
@@ -140,7 +142,7 @@ func TestProcessMount_JUmount(t *testing.T) {
 			p := &ProcessMount{
 				SafeFormatAndMount: *mounter,
 			}
-			if err := p.JUmount(targetPath, podName); err == nil {
+			if err := p.JUmount(context.TODO(), targetPath, podName); err == nil {
 				t.Errorf("JUmount() error = %v", err)
 			}
 		})
@@ -171,7 +173,7 @@ func TestProcessMount_JMount(t *testing.T) {
 				p := &ProcessMount{
 					SafeFormatAndMount: *mounter,
 				}
-				if err := p.JMount(&jfsConfig.JfsSetting{
+				if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
 					Source:    eeSource,
 					VolumeId:  volumeId,
 					MountPath: targetPath,
@@ -199,7 +201,7 @@ func TestProcessMount_JMount(t *testing.T) {
 				p := &ProcessMount{
 					SafeFormatAndMount: *mounter,
 				}
-				if err := p.JMount(&jfsConfig.JfsSetting{
+				if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
 					Source:    eeSource,
 					VolumeId:  volumeId,
 					MountPath: targetPath,
@@ -252,7 +254,7 @@ func TestProcessMount_JMount(t *testing.T) {
 						p := &ProcessMount{
 							SafeFormatAndMount: *mounter,
 						}
-						if err := p.JMount(&jfsConfig.JfsSetting{
+						if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							Storage:   "ceph",
 							VolumeId:  volumeId,
@@ -293,7 +295,7 @@ func TestProcessMount_JMount(t *testing.T) {
 						p := &ProcessMount{
 							SafeFormatAndMount: *mounter,
 						}
-						if err := p.JMount(&jfsConfig.JfsSetting{
+						if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							Storage:   "ceph",
 							VolumeId:  volumeId,
@@ -334,7 +336,7 @@ func TestProcessMount_JMount(t *testing.T) {
 						p := &ProcessMount{
 							SafeFormatAndMount: *mounter,
 						}
-						if err := p.JMount(&jfsConfig.JfsSetting{
+						if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
 							Source: ceSource, Storage: "ceph",
 							VolumeId:  volumeId,
 							MountPath: targetPath,
@@ -351,7 +353,7 @@ func TestProcessMount_JMount(t *testing.T) {
 						p := &ProcessMount{
 							SafeFormatAndMount: k8sMount.SafeFormatAndMount{},
 						}
-						if err := p.JMount(&jfsConfig.JfsSetting{
+						if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							VolumeId:  volumeId,
 							MountPath: targetPath,
@@ -371,7 +373,7 @@ func TestProcessMount_JMount(t *testing.T) {
 						p := &ProcessMount{
 							SafeFormatAndMount: k8sMount.SafeFormatAndMount{},
 						}
-						if err := p.JMount(&jfsConfig.JfsSetting{
+						if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							VolumeId:  volumeId,
 							MountPath: targetPath,
@@ -396,7 +398,7 @@ func TestProcessMount_JMount(t *testing.T) {
 						p := &ProcessMount{
 							SafeFormatAndMount: *mounter,
 						}
-						if err := p.JMount(&jfsConfig.JfsSetting{
+						if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							VolumeId:  volumeId,
 							MountPath: targetPath,
@@ -422,7 +424,7 @@ func TestProcessMount_JMount(t *testing.T) {
 						p := &ProcessMount{
 							SafeFormatAndMount: *mounter,
 						}
-						if err := p.JMount(&jfsConfig.JfsSetting{
+						if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							VolumeId:  volumeId,
 							MountPath: targetPath,

--- a/pkg/juicefs/mount/process_mount_test.go
+++ b/pkg/juicefs/mount/process_mount_test.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"syscall"
 	"testing"
+	"time"
 
 	. "github.com/agiledragon/gomonkey"
 	"github.com/golang/mock/gomock"
@@ -112,7 +113,9 @@ func TestProcessMount_JUmount(t *testing.T) {
 			p := &ProcessMount{
 				SafeFormatAndMount: k8sMount.SafeFormatAndMount{},
 			}
-			if err := p.JUmount(context.TODO(), targetPath, podName); err == nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := p.JUmount(ctx, targetPath, podName); err == nil {
 				t.Errorf("JUmount() error = %v", err)
 			}
 		})
@@ -142,7 +145,9 @@ func TestProcessMount_JUmount(t *testing.T) {
 			p := &ProcessMount{
 				SafeFormatAndMount: *mounter,
 			}
-			if err := p.JUmount(context.TODO(), targetPath, podName); err == nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := p.JUmount(ctx, targetPath, podName); err == nil {
 				t.Errorf("JUmount() error = %v", err)
 			}
 		})
@@ -201,7 +206,9 @@ func TestProcessMount_JMount(t *testing.T) {
 				p := &ProcessMount{
 					SafeFormatAndMount: *mounter,
 				}
-				if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				if err := p.JMount(ctx, &jfsConfig.JfsSetting{
 					Source:    eeSource,
 					VolumeId:  volumeId,
 					MountPath: targetPath,
@@ -295,7 +302,9 @@ func TestProcessMount_JMount(t *testing.T) {
 						p := &ProcessMount{
 							SafeFormatAndMount: *mounter,
 						}
-						if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
+						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+						defer cancel()
+						if err := p.JMount(ctx, &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							Storage:   "ceph",
 							VolumeId:  volumeId,
@@ -336,7 +345,9 @@ func TestProcessMount_JMount(t *testing.T) {
 						p := &ProcessMount{
 							SafeFormatAndMount: *mounter,
 						}
-						if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
+						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+						defer cancel()
+						if err := p.JMount(ctx, &jfsConfig.JfsSetting{
 							Source: ceSource, Storage: "ceph",
 							VolumeId:  volumeId,
 							MountPath: targetPath,
@@ -353,7 +364,9 @@ func TestProcessMount_JMount(t *testing.T) {
 						p := &ProcessMount{
 							SafeFormatAndMount: k8sMount.SafeFormatAndMount{},
 						}
-						if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
+						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+						defer cancel()
+						if err := p.JMount(ctx, &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							VolumeId:  volumeId,
 							MountPath: targetPath,
@@ -373,7 +386,9 @@ func TestProcessMount_JMount(t *testing.T) {
 						p := &ProcessMount{
 							SafeFormatAndMount: k8sMount.SafeFormatAndMount{},
 						}
-						if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
+						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+						defer cancel()
+						if err := p.JMount(ctx, &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							VolumeId:  volumeId,
 							MountPath: targetPath,
@@ -398,7 +413,9 @@ func TestProcessMount_JMount(t *testing.T) {
 						p := &ProcessMount{
 							SafeFormatAndMount: *mounter,
 						}
-						if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
+						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+						defer cancel()
+						if err := p.JMount(ctx, &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							VolumeId:  volumeId,
 							MountPath: targetPath,
@@ -424,7 +441,10 @@ func TestProcessMount_JMount(t *testing.T) {
 						p := &ProcessMount{
 							SafeFormatAndMount: *mounter,
 						}
-						if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
+
+						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+						defer cancel()
+						if err := p.JMount(ctx, &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							VolumeId:  volumeId,
 							MountPath: targetPath,

--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -17,12 +17,14 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs/k8sclient"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
-	"strings"
 )
 
 func IsPodReady(pod *corev1.Pod) bool {
@@ -102,7 +104,7 @@ func GetMountPathOfPod(pod corev1.Pod) (string, string, error) {
 	return sourcePath, volumeId, nil
 }
 
-func RemoveFinalizer(client *k8sclient.K8sClient, pod *corev1.Pod, finalizer string) error {
+func RemoveFinalizer(ctx context.Context, client *k8sclient.K8sClient, pod *corev1.Pod, finalizer string) error {
 	f := pod.GetFinalizers()
 	for i := 0; i < len(f); i++ {
 		if f[i] == finalizer {
@@ -120,7 +122,7 @@ func RemoveFinalizer(client *k8sclient.K8sClient, pod *corev1.Pod, finalizer str
 		klog.Errorf("Parse json error: %v", err)
 		return err
 	}
-	if err := client.PatchPod(pod, payloadBytes); err != nil {
+	if err := client.PatchPod(ctx, pod, payloadBytes); err != nil {
 		klog.Errorf("Patch pod err:%v", err)
 		return err
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -290,7 +290,7 @@ func GetTime(str string) (time.Time, error) {
 	return time.Parse("2006-01-02 15:04:05", str)
 }
 
-func ShouldDelay(pod *corev1.Pod, Client *k8s.K8sClient) (shouldDelay bool, err error) {
+func ShouldDelay(ctx context.Context, pod *corev1.Pod, Client *k8s.K8sClient) (shouldDelay bool, err error) {
 	delayStr, delayExist := pod.Annotations[config.DeleteDelayTimeKey]
 	if !delayExist {
 		// not set delete delay
@@ -305,7 +305,7 @@ func ShouldDelay(pod *corev1.Pod, Client *k8s.K8sClient) (shouldDelay bool, err 
 			return false, nil
 		}
 		pod.Annotations[config.DeleteDelayAtKey] = d
-		if err := PatchPodAnnotation(Client, pod, pod.Annotations); err != nil {
+		if err := PatchPodAnnotation(ctx, Client, pod, pod.Annotations); err != nil {
 			klog.Errorf("delayDelete: Update pod %s error: %v", pod.Name, err)
 			return true, err
 		}
@@ -342,7 +342,7 @@ func StripPasswd(uri string) string {
 	return uri[:sp+3+cp] + ":****" + uri[p:]
 }
 
-func PatchPodAnnotation(client *k8s.K8sClient, pod *corev1.Pod, annotation map[string]string) error {
+func PatchPodAnnotation(ctx context.Context, client *k8s.K8sClient, pod *corev1.Pod, annotation map[string]string) error {
 	payload := []k8s.PatchMapValue{{
 		Op:    "replace",
 		Path:  "/metadata/annotations",
@@ -353,7 +353,7 @@ func PatchPodAnnotation(client *k8s.K8sClient, pod *corev1.Pod, annotation map[s
 		klog.Errorf("Parse json error: %v", err)
 		return err
 	}
-	if err := client.PatchPod(pod, payloadBytes); err != nil {
+	if err := client.PatchPod(ctx, pod, payloadBytes); err != nil {
 		klog.Errorf("Patch pod %s error: %v", pod.Name, err)
 		return err
 	}

--- a/tests/sanity/fake_juicefs_provider.go
+++ b/tests/sanity/fake_juicefs_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sanity
 
 import (
+	"context"
 	"path/filepath"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs"
@@ -33,19 +34,19 @@ type fakeJfsProvider struct {
 	fs map[string]fakeJfs
 }
 
-func (j *fakeJfsProvider) GetJfsVolUUID(name string) (string, error) {
+func (j *fakeJfsProvider) GetJfsVolUUID(ctx context.Context, name string) (string, error) {
 	return "", nil
 }
 
-func (j *fakeJfsProvider) JfsCreateVol(volumeID string, subPath string, secrets map[string]string) error {
+func (j *fakeJfsProvider) JfsCreateVol(ctx context.Context, volumeID string, subPath string, secrets map[string]string) error {
 	return nil
 }
 
-func (j *fakeJfsProvider) JfsDeleteVol(volumeID string, target string, secrets map[string]string) error {
+func (j *fakeJfsProvider) JfsDeleteVol(ctx context.Context, volumeID string, target string, secrets map[string]string) error {
 	return nil
 }
 
-func (j *fakeJfsProvider) JfsMount(volumeID string, target string, secrets, volCtx map[string]string, options []string) (juicefs.Jfs, error) {
+func (j *fakeJfsProvider) JfsMount(ctx context.Context, volumeID string, target string, secrets, volCtx map[string]string, options []string) (juicefs.Jfs, error) {
 	jfsName := "fake"
 	fs, ok := j.fs[jfsName]
 
@@ -62,11 +63,11 @@ func (j *fakeJfsProvider) JfsMount(volumeID string, target string, secrets, volC
 	return &fs, nil
 }
 
-func (j *fakeJfsProvider) JfsCleanupMountPoint(mountPath string) error {
+func (j *fakeJfsProvider) JfsCleanupMountPoint(ctx context.Context, mountPath string) error {
 	return nil
 }
 
-func (j *fakeJfsProvider) JfsUnmount(volumeId, mountPath string) error {
+func (j *fakeJfsProvider) JfsUnmount(ctx context.Context, volumeId, mountPath string) error {
 	return nil
 }
 
@@ -80,7 +81,7 @@ func newFakeJfsProvider() *fakeJfsProvider {
 	}
 }
 
-func (fs *fakeJfs) CreateVol(name, subPath string) (string, error) {
+func (fs *fakeJfs) CreateVol(ctx context.Context, name, subPath string) (string, error) {
 	_, ok := fs.volumes[name]
 
 	if !ok {
@@ -96,6 +97,6 @@ func (fs *fakeJfs) GetBasePath() string {
 	return fs.basePath
 }
 
-func (fs *fakeJfs) BindTarget(bindSource, target string) error {
+func (fs *fakeJfs) BindTarget(ctx context.Context, bindSource, target string) error {
 	return nil
 }


### PR DESCRIPTION
Split from #409

Currently, the top context isn't passed around, which may cause dead goroutine in kubelet or controller-runtime.

