### PR TITLE
add cert builder for webhook

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -77,6 +77,9 @@ const (
 	PublishSecretName          = "csi.storage.k8s.io/provisioner-secret-name"
 	PublishSecretNamespace     = "csi.storage.k8s.io/provisioner-secret-namespace"
 
+	// webhook
+	WebhookName = "juicefs-admission-webhook"
+
 	// config in pv
 	mountPodCpuLimitKey    = "juicefs/mount-cpu-limit"
 	mountPodMemLimitKey    = "juicefs/mount-memory-limit"

--- a/pkg/controller/cert_controller.go
+++ b/pkg/controller/cert_controller.go
@@ -1,0 +1,42 @@
+/*
+ Copyright 2022 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/util"
+	"github.com/juicedata/juicefs-csi-driver/pkg/webhook/cert"
+)
+
+type WebhookReconciler struct {
+	CertBuilder *cert.CertificateBuilder
+	WebhookName string
+	CaCert      []byte
+}
+
+func (r *WebhookReconciler) Reconcile(context.Context, ctrl.Request) (ctrl.Result, error) {
+	// patch ca of MutatingWebhookConfiguration
+	err := r.CertBuilder.PatchCABundle(r.WebhookName, r.CaCert)
+	if err != nil {
+		return util.RequeueAfterInterval(10 * time.Second)
+	}
+	return util.NoRequeue()
+}

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -24,6 +24,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -258,4 +259,20 @@ func (k *K8sClient) GetPersistentVolume(ctx context.Context, pvName string) (*co
 		return nil, err
 	}
 	return mntPod, nil
+}
+
+func (k *K8sClient) GetAdmissionWebhookConfig(ctx context.Context, name string) (*admissionv1.MutatingWebhookConfiguration, error) {
+	klog.V(6).Infof("Get admission webhook %s", name)
+	wh, err := k.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		klog.V(6).Infof("Can't get admission webhook %s: %v", name, err)
+		return nil, err
+	}
+	return wh, nil
+}
+
+func (k *K8sClient) PatchAdmissionWebhookConfig(ctx context.Context, whName string, data []byte) error {
+	klog.V(6).Infof("Update admission webhook %v", whName)
+	_, err := k.AdmissionregistrationV1().MutatingWebhookConfigurations().Patch(ctx, whName, types.MergePatchType, data, metav1.PatchOptions{})
+	return err
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -36,6 +36,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 	k8s "github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
@@ -419,4 +420,33 @@ func UmountPath(ctx context.Context, sourcePath string) {
 			}
 		}
 	}
+}
+
+// NoRequeue returns the result of a reconcile invocation and no err
+// The Object will requeue immediately
+func NoRequeue() (ctrl.Result, error) {
+	return RequeueIfError(nil)
+}
+
+// RequeueAfterInterval returns the result of a reconcile invocation with a given requeue interval and no err
+// The Object will requeue after the given requeue interval
+func RequeueAfterInterval(interval time.Duration) (ctrl.Result, error) {
+	return ctrl.Result{RequeueAfter: interval}, nil
+}
+
+// RequeueIfError returns the result of a reconciler invocation and the err
+// The Object will requeue immediately whether the err is nil or not
+func RequeueIfError(err error) (ctrl.Result, error) {
+	return ctrl.Result{}, err
+}
+
+// Check if the key has the expected value
+func CheckExpectValue(m map[string]string, key string, targetValue string) bool {
+	if len(m) == 0 {
+		return false
+	}
+	if v, ok := m[key]; ok {
+		return v == targetValue
+	}
+	return false
 }

--- a/pkg/webhook/cert/cert.go
+++ b/pkg/webhook/cert/cert.go
@@ -1,0 +1,84 @@
+/*
+ Copyright 2022 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cert
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"time"
+)
+
+// Artifacts hosts a private key, its corresponding serving certificate and
+// the CA certificate that signs the serving certificate.
+type Artifacts struct {
+	// PEM encoded private key
+	Key []byte
+	// PEM encoded serving certificate
+	Cert []byte
+	// PEM encoded CA private key
+	CAKey []byte
+	// PEM encoded CA certificate
+	CACert []byte
+	// Resource version of the certs
+	ResourceVersion string
+}
+
+// CertGenerator is an interface to provision the serving certificate.
+type CertGenerator interface {
+	// Generate returns a Artifacts struct.
+	Generate(CommonName string) (*Artifacts, error)
+	// SetCA sets the PEM-encoded CA private key and CA cert for signing the generated serving cert.
+	SetCA(caKey, caCert []byte)
+}
+
+// ValidCACert think cert and key are valid if they meet the following requirements:
+// - key and cert are valid pair
+// - caCert is the root ca of cert
+// - cert is for dnsName
+// - cert won't expire before time
+func ValidCACert(key, cert, caCert []byte, dnsName string, time time.Time) bool {
+	if len(key) == 0 || len(cert) == 0 || len(caCert) == 0 {
+		return false
+	}
+	// Verify key and cert are valid pair
+	_, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return false
+	}
+
+	// Verify cert is valid for at least 1 year.
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caCert) {
+		return false
+	}
+	block, _ := pem.Decode(cert)
+	if block == nil {
+		return false
+	}
+	c, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return false
+	}
+	ops := x509.VerifyOptions{
+		DNSName:     dnsName,
+		Roots:       pool,
+		CurrentTime: time,
+	}
+	_, err = c.Verify(ops)
+	return err == nil
+}

--- a/pkg/webhook/cert/cert_writer.go
+++ b/pkg/webhook/cert/cert_writer.go
@@ -1,0 +1,136 @@
+/*
+ Copyright 2022 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cert
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog"
+)
+
+const (
+	// CAKeyName is the name of the CA private key
+	CAKeyName = "ca-key.pem"
+	// CACertName is the name of the CA certificate
+	CACertName = "ca-cert.pem"
+	// ServerKeyName is the name of the server private key
+	ServerKeyName  = "key.pem"
+	ServerKeyName2 = "tls.key"
+	// ServerCertName is the name of the serving certificate
+	ServerCertName  = "cert.pem"
+	ServerCertName2 = "tls.crt"
+)
+
+// CertWriter provides method to handle webhooks.
+type CertWriter interface {
+	// EnsureCert provisions the cert for the webhookClientConfig.
+	EnsureCert(dnsName string) (*Artifacts, bool, error)
+}
+
+// handleCommon ensures the given webhook has a proper certificate.
+// It uses the given certReadWriter to read and (or) write the certificate.
+func handleCommon(dnsName string, ch certReadWriter) (*Artifacts, bool, error) {
+	if len(dnsName) == 0 {
+		return nil, false, errors.New("dnsName should not be empty")
+	}
+	if ch == nil {
+		return nil, false, errors.New("certReaderWriter should not be nil")
+	}
+
+	certs, changed, err := createIfNotExists(ch)
+	if err != nil {
+		return nil, changed, err
+	}
+
+	// Recreate the cert if it's invalid.
+	valid := validCert(certs, dnsName)
+	if !valid {
+		klog.Info("cert is invalid or expiring, regenerating a new one")
+		certs, err = ch.overwrite(certs.ResourceVersion)
+		if err != nil {
+			return nil, false, err
+		}
+		changed = true
+	}
+	return certs, changed, nil
+}
+
+func createIfNotExists(ch certReadWriter) (*Artifacts, bool, error) {
+	// Try to read first
+	certs, err := ch.read()
+	if apierrors.IsNotFound(err) {
+		// Create if not exists
+		certs, err = ch.write()
+		switch {
+		// This may happen if there is another racer.
+		case apierrors.IsAlreadyExists(err):
+			certs, err = ch.read()
+			return certs, true, err
+		default:
+			return certs, true, err
+		}
+	}
+	return certs, false, err
+}
+
+// certReadWriter provides methods for reading and writing certificates.
+type certReadWriter interface {
+	// read a webhook name and returns the certs for it.
+	read() (*Artifacts, error)
+	// write the certs and return the certs it wrote.
+	write() (*Artifacts, error)
+	// overwrite the existing certs and return the certs it wrote.
+	overwrite(resourceVersion string) (*Artifacts, error)
+}
+
+func validCert(certs *Artifacts, dnsName string) bool {
+	if certs == nil || certs.Cert == nil || certs.Key == nil || certs.CACert == nil {
+		return false
+	}
+
+	// Verify key and cert are valid pair
+	_, err := tls.X509KeyPair(certs.Cert, certs.Key)
+	if err != nil {
+		return false
+	}
+
+	// Verify cert is good for desired DNS name and signed by CA and will be valid for desired period of time.
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(certs.CACert) {
+		return false
+	}
+	block, _ := pem.Decode(certs.Cert)
+	if block == nil {
+		return false
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return false
+	}
+	ops := x509.VerifyOptions{
+		DNSName:     dnsName,
+		Roots:       pool,
+		CurrentTime: time.Now().AddDate(0, 6, 0),
+	}
+	_, err = cert.Verify(ops)
+	return err == nil
+}

--- a/pkg/webhook/cert/certificate_builder.go
+++ b/pkg/webhook/cert/certificate_builder.go
@@ -1,0 +1,121 @@
+/*
+ Copyright 2022 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cert
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	v1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/config"
+	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+)
+
+const (
+	CertSecretName = "juicefs-csi-webhook-certs"
+)
+
+type CertificateBuilder struct {
+	Client *k8sclient.K8sClient
+}
+
+func NewCertificateBuilder(c *k8sclient.K8sClient) *CertificateBuilder {
+	ch := &CertificateBuilder{Client: c}
+	return ch
+}
+
+// BuildOrSyncCABundle use service name and namespace to generate webhook certs
+// or sync the certs from the secret
+func (c *CertificateBuilder) BuildOrSyncCABundle(svcName, cerPath string) ([]byte, error) {
+	klog.Info("start generate certificate", "service", svcName, "namespace", config.Namespace, "cert dir", cerPath)
+
+	certs, err := c.genCA(config.Namespace, svcName, cerPath)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return certs.CACert, nil
+}
+
+// genCA generate the caBundle and store it in secret and local path
+func (c *CertificateBuilder) genCA(ns, svc, certPath string) (*Artifacts, error) {
+	certWriter, err := NewSecretCertWriter(SecretCertWriterOptions{
+		Client: c.Client,
+		Secret: &types.NamespacedName{Namespace: ns, Name: CertSecretName},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to new certWriter: %v", err)
+	}
+
+	dnsName := ServiceToCommonName(ns, svc)
+
+	certs, _, err := certWriter.EnsureCert(dnsName)
+	if err != nil {
+		return certs, fmt.Errorf("failed to ensure certs: %v", err)
+	}
+
+	if err := WriteCertsToDir(certPath, certs); err != nil {
+		return certs, fmt.Errorf("failed to WriteCertsToDir: %v", err)
+	}
+	return certs, nil
+}
+
+// PatchCABundle patch the caBundle to MutatingWebhookConfiguration
+func (c *CertificateBuilder) PatchCABundle(webhookName string, ca []byte) (err error) {
+
+	var m *v1.MutatingWebhookConfiguration
+
+	klog.Info("start patch MutatingWebhookConfiguration caBundle", "name", webhookName)
+
+	ctx := context.Background()
+
+	if m, err = c.Client.GetAdmissionWebhookConfig(ctx, webhookName); err != nil {
+		klog.Error(err, "fail to get mutatingWebHook", "name", webhookName)
+		return err
+	}
+
+	current := m.DeepCopy()
+	for i := range m.Webhooks {
+		m.Webhooks[i].ClientConfig.CABundle = ca
+	}
+
+	if reflect.DeepEqual(m.Webhooks, current.Webhooks) {
+		klog.Info("no need to patch the MutatingWebhookConfiguration", "name", webhookName)
+		return nil
+	}
+
+	patchWebhook := map[string]interface{}{
+		"webhooks": m.Webhooks,
+	}
+	patchJson, err := json.Marshal(patchWebhook)
+	if err != nil {
+		return err
+	}
+	if err := c.Client.PatchAdmissionWebhookConfig(ctx, m.Name, patchJson); err != nil {
+		klog.Error(err, "fail to patch CABundle to mutatingWebHook", "name", webhookName)
+		return err
+	}
+
+	klog.Infof("finished patch MutatingWebhookConfiguration caBundle %s", webhookName)
+
+	return nil
+}

--- a/pkg/webhook/cert/fs.go
+++ b/pkg/webhook/cert/fs.go
@@ -1,0 +1,71 @@
+/*
+ Copyright 2022 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cert
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"k8s.io/klog"
+)
+
+func WriteCertsToDir(dir string, certs *Artifacts) error {
+	_, err := os.Stat(dir)
+	switch {
+	case os.IsNotExist(err):
+		klog.Infof("cert directory doesn't exist, creating directory %s", dir)
+		err = os.MkdirAll(dir, 0640)
+		if err != nil {
+			return fmt.Errorf("can't create dir: %v", dir)
+		}
+	case err != nil:
+		return err
+	}
+
+	// write or overwrite the cert for ca
+	filename := path.Join(dir, CAKeyName)
+	if err := ioutil.WriteFile(filename, certs.CAKey, 0600); err != nil {
+		return err
+	}
+	filename = path.Join(dir, CACertName)
+	if err := ioutil.WriteFile(filename, certs.CACert, 0600); err != nil {
+		return err
+	}
+
+	// write or overwrite the certs for serverName
+	filename = path.Join(dir, ServerCertName)
+	if err := ioutil.WriteFile(filename, certs.Cert, 0600); err != nil {
+		return err
+	}
+	filename = path.Join(dir, ServerKeyName)
+	if err := ioutil.WriteFile(filename, certs.Key, 0600); err != nil {
+		return err
+	}
+
+	// write or overwrite the certs for serverName2
+	filename = path.Join(dir, ServerCertName2)
+	if err := ioutil.WriteFile(filename, certs.Cert, 0600); err != nil {
+		return err
+	}
+	filename = path.Join(dir, ServerKeyName2)
+	if err := ioutil.WriteFile(filename, certs.Key, 0600); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/webhook/cert/secret.go
+++ b/pkg/webhook/cert/secret.go
@@ -1,0 +1,174 @@
+/*
+ Copyright 2022 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cert
+
+import (
+	"context"
+	"errors"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+)
+
+// secretCertWriter provisions the certificate by reading and writing to the k8s secrets.
+type secretCertWriter struct {
+	*SecretCertWriterOptions
+
+	// dnsName is the DNS name that the certificate is for.
+	dnsName string
+}
+
+// SecretCertWriterOptions is options for constructing a secretCertWriter.
+type SecretCertWriterOptions struct {
+	// client talks to a kubernetes cluster for creating the secret.
+	Client *k8sclient.K8sClient
+	// certGenerator generates the certificates.
+	CertGenerator CertGenerator
+	// secret points the secret that contains certificates that written by the CertWriter.
+	Secret *types.NamespacedName
+}
+
+var _ CertWriter = &secretCertWriter{}
+
+func (ops *SecretCertWriterOptions) setDefaults() {
+	if ops.CertGenerator == nil {
+		ops.CertGenerator = &SelfSignedCertGenerator{}
+	}
+}
+
+func (ops *SecretCertWriterOptions) validate() error {
+	if ops.Client == nil {
+		return errors.New("client must be set in SecretCertWriterOptions")
+	}
+	if ops.Secret == nil {
+		return errors.New("secret must be set in SecretCertWriterOptions")
+	}
+	return nil
+}
+
+// NewSecretCertWriter constructs a CertWriter that persists the certificate in a k8s secret.
+func NewSecretCertWriter(ops SecretCertWriterOptions) (CertWriter, error) {
+	ops.setDefaults()
+	err := ops.validate()
+	if err != nil {
+		return nil, err
+	}
+	return &secretCertWriter{
+		SecretCertWriterOptions: &ops,
+	}, nil
+}
+
+// EnsureCert provisions certificates for a webhookClientConfig by writing the certificates to a k8s secret.
+func (s *secretCertWriter) EnsureCert(dnsName string) (*Artifacts, bool, error) {
+	// Create or refresh the certs based on clientConfig
+	s.dnsName = dnsName
+	return handleCommon(s.dnsName, s)
+}
+
+var _ certReadWriter = &secretCertWriter{}
+
+func (s *secretCertWriter) buildSecret() (*corev1.Secret, *Artifacts, error) {
+	certs, err := s.CertGenerator.Generate(s.dnsName)
+	if err != nil {
+		return nil, nil, err
+	}
+	secret := certsToSecret(certs, *s.Secret)
+	return secret, certs, err
+}
+
+func (s *secretCertWriter) write() (*Artifacts, error) {
+	secret, certs, err := s.buildSecret()
+	if err != nil {
+		return nil, err
+	}
+	_, err = s.Client.CreateSecret(context.TODO(), secret)
+	if apierrors.IsAlreadyExists(err) {
+		return nil, err
+	}
+	return certs, err
+}
+
+func (s *secretCertWriter) overwrite(resourceVersion string) (
+	*Artifacts, error) {
+	secret, certs, err := s.buildSecret()
+	if err != nil {
+		return nil, err
+	}
+	secret.ResourceVersion = resourceVersion
+	err = s.Client.UpdateSecret(context.TODO(), secret)
+	if err != nil {
+		klog.Infof("Cert writer update secret failed: %v", err)
+		return certs, err
+	}
+	klog.Infof("Cert writer update secret %s resourceVersion from %s to %s",
+		secret.Name, resourceVersion, secret.ResourceVersion)
+	return certs, err
+}
+
+func (s *secretCertWriter) read() (*Artifacts, error) {
+	secret, err := s.Client.GetSecret(context.TODO(), s.Secret.Name, s.Secret.Namespace)
+	if apierrors.IsNotFound(err) {
+		return nil, err
+	} else if err != nil {
+		return nil, err
+	}
+	certs := secretToCerts(secret)
+	if certs != nil && certs.CACert != nil && certs.CAKey != nil {
+		// Store the CA for next usage.
+		s.CertGenerator.SetCA(certs.CAKey, certs.CACert)
+	}
+	return certs, nil
+}
+
+func secretToCerts(secret *corev1.Secret) *Artifacts {
+	if secret.Data == nil {
+		return &Artifacts{ResourceVersion: secret.ResourceVersion}
+	}
+	return &Artifacts{
+		CAKey:           secret.Data[CAKeyName],
+		CACert:          secret.Data[CACertName],
+		Cert:            secret.Data[ServerCertName],
+		Key:             secret.Data[ServerKeyName],
+		ResourceVersion: secret.ResourceVersion,
+	}
+}
+
+func certsToSecret(certs *Artifacts, sec types.NamespacedName) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: sec.Namespace,
+			Name:      sec.Name,
+		},
+		Data: map[string][]byte{
+			CAKeyName:       certs.CAKey,
+			CACertName:      certs.CACert,
+			ServerKeyName:   certs.Key,
+			ServerKeyName2:  certs.Key,
+			ServerCertName:  certs.Cert,
+			ServerCertName2: certs.Cert,
+		},
+	}
+}

--- a/pkg/webhook/cert/selsigned.go
+++ b/pkg/webhook/cert/selsigned.go
@@ -1,0 +1,196 @@
+/*
+ Copyright 2022 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cert
+
+import (
+	"crypto"
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"net"
+	"time"
+
+	"k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+)
+
+const (
+	rsaKeySize = 2048
+)
+
+// ServiceToCommonName generates the CommonName for the certificate when using a k8s service.
+func ServiceToCommonName(serviceNamespace, serviceName string) string {
+	return fmt.Sprintf("%s.%s.svc", serviceName, serviceNamespace)
+}
+
+// SelfSignedCertGenerator implements the certGenerator interface.
+// It provisions self-signed certificates.
+type SelfSignedCertGenerator struct {
+	caKey  []byte
+	caCert []byte
+}
+
+var _ CertGenerator = &SelfSignedCertGenerator{}
+
+// SetCA sets the PEM-encoded CA private key and CA cert for signing the generated serving cert.
+func (cp *SelfSignedCertGenerator) SetCA(caKey, caCert []byte) {
+	cp.caKey = caKey
+	cp.caCert = caCert
+}
+
+// Generate creates and returns a CA certificate, certificate and
+// key for the server. serverKey and serverCert are used by the server
+// to establish trust for clients, CA certificate is used by the
+// client to verify the server authentication chain.
+// The cert will be valid for 365 days.
+func (cp *SelfSignedCertGenerator) Generate(commonName string) (*Artifacts, error) {
+	var signingKey *rsa.PrivateKey
+	var signingCert *x509.Certificate
+	var valid bool
+	var err error
+
+	valid, signingKey, signingCert = cp.validCACert()
+	if !valid {
+		signingKey, err = NewPrivateKey()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create the CA private key: %v", err)
+		}
+		signingCert, err = cert.NewSelfSignedCACert(cert.Config{CommonName: "webhook-cert-ca"}, signingKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create the CA cert: %v", err)
+		}
+	}
+
+	hostIP := net.ParseIP(commonName)
+	var altIPs []net.IP
+	DNSNames := []string{"localhost"}
+	if hostIP.To4() != nil {
+		altIPs = append(altIPs, hostIP.To4())
+	} else {
+		DNSNames = append(DNSNames, commonName)
+	}
+
+	key, err := NewPrivateKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the private key: %v", err)
+	}
+	signedCert, err := NewSignedCert(
+		cert.Config{
+			CommonName: commonName,
+			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			AltNames:   cert.AltNames{IPs: altIPs, DNSNames: DNSNames},
+		},
+		key, signingCert, signingKey,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the cert: %v", err)
+	}
+	return &Artifacts{
+		Key:    EncodePrivateKeyPEM(key),
+		Cert:   EncodeCertPEM(signedCert),
+		CAKey:  EncodePrivateKeyPEM(signingKey),
+		CACert: EncodeCertPEM(signingCert),
+	}, nil
+}
+
+func (cp *SelfSignedCertGenerator) validCACert() (bool, *rsa.PrivateKey, *x509.Certificate) {
+	if !ValidCACert(cp.caKey, cp.caCert, cp.caCert, "",
+		time.Now().AddDate(1, 0, 0)) {
+		return false, nil, nil
+	}
+
+	var ok bool
+	key, err := keyutil.ParsePrivateKeyPEM(cp.caKey)
+	if err != nil {
+		return false, nil, nil
+	}
+	privateKey, ok := key.(*rsa.PrivateKey)
+	if !ok {
+		return false, nil, nil
+	}
+
+	certs, err := cert.ParseCertsPEM(cp.caCert)
+	if err != nil {
+		return false, nil, nil
+	}
+	if len(certs) != 1 {
+		return false, nil, nil
+	}
+	return true, privateKey, certs[0]
+}
+
+// NewPrivateKey creates an RSA private key
+func NewPrivateKey() (*rsa.PrivateKey, error) {
+	return rsa.GenerateKey(cryptorand.Reader, rsaKeySize)
+}
+
+// NewSignedCert creates a signed certificate using the given CA certificate and key
+func NewSignedCert(cfg cert.Config, key crypto.Signer, caCert *x509.Certificate, caKey crypto.Signer) (*x509.Certificate, error) {
+	serial, err := cryptorand.Int(cryptorand.Reader, new(big.Int).SetInt64(math.MaxInt64))
+	if err != nil {
+		return nil, err
+	}
+	if len(cfg.CommonName) == 0 {
+		return nil, errors.New("must specify a CommonName")
+	}
+	if len(cfg.Usages) == 0 {
+		return nil, errors.New("must specify at least one ExtKeyUsage")
+	}
+
+	certTmpl := x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:   cfg.CommonName,
+			Organization: cfg.Organization,
+		},
+		DNSNames:     cfg.AltNames.DNSNames,
+		IPAddresses:  cfg.AltNames.IPs,
+		SerialNumber: serial,
+		NotBefore:    caCert.NotBefore,
+		NotAfter:     time.Now().Add(time.Hour * 24 * 365 * 10).UTC(),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  cfg.Usages,
+	}
+	certDERBytes, err := x509.CreateCertificate(cryptorand.Reader, &certTmpl, caCert, key.Public(), caKey)
+	if err != nil {
+		return nil, err
+	}
+	return x509.ParseCertificate(certDERBytes)
+}
+
+// EncodePrivateKeyPEM returns PEM-encoded private key data
+func EncodePrivateKeyPEM(key *rsa.PrivateKey) []byte {
+	block := pem.Block{
+		Type:  keyutil.RSAPrivateKeyBlockType,
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+	return pem.EncodeToMemory(&block)
+}
+
+// EncodeCertPEM returns PEM-encoded certificate data
+func EncodeCertPEM(ct *x509.Certificate) []byte {
+	block := pem.Block{
+		Type:  cert.CertificateBlockType,
+		Bytes: ct.Raw,
+	}
+	return pem.EncodeToMemory(&block)
+}

--- a/pkg/webhook/watch/cert.go
+++ b/pkg/webhook/watch/cert.go
@@ -1,0 +1,115 @@
+/*
+ Copyright 2022 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package watch
+
+import (
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/klog"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/config"
+	ctrl "github.com/juicedata/juicefs-csi-driver/pkg/controller"
+	"github.com/juicedata/juicefs-csi-driver/pkg/webhook/cert"
+)
+
+func SetupWatcherForWebhook(mgr ctrlruntime.Manager, certBuilder *cert.CertificateBuilder, caCert []byte) (err error) {
+	klog.Info("SetupWatcherForWebhook start")
+	options := controller.Options{}
+	webhookName := config.WebhookName
+	options.Reconciler = &ctrl.WebhookReconciler{
+		CertBuilder: certBuilder,
+		WebhookName: webhookName,
+		CaCert:      caCert,
+	}
+	webhookController, err := controller.New("webhook-controller", mgr, options)
+	if err != nil {
+		return err
+	}
+
+	mutatingWebhookConfigurationEventHandler := &mutatingWebhookConfigurationEventHandler{}
+	err = webhookController.Watch(&source.Kind{
+		Type: &admissionv1.MutatingWebhookConfiguration{},
+	}, &handler.EnqueueRequestForObject{},
+		predicate.Funcs{
+			CreateFunc: mutatingWebhookConfigurationEventHandler.onCreateFunc(webhookName),
+			UpdateFunc: mutatingWebhookConfigurationEventHandler.onUpdateFunc(webhookName),
+			DeleteFunc: mutatingWebhookConfigurationEventHandler.onDeleteFunc(webhookName),
+		})
+	if err != nil {
+		klog.Error(err, "Failed to watch mutatingWebhookConfiguration")
+		return err
+	}
+
+	return
+}
+
+type mutatingWebhookConfigurationEventHandler struct{}
+
+func (handler *mutatingWebhookConfigurationEventHandler) onCreateFunc(webhookName string) func(e event.CreateEvent) bool {
+	return func(e event.CreateEvent) (onCreate bool) {
+		klog.Info("receive mutatingWebhookConfigurationEventHandler.onCreateFunc")
+		mutatingWebhookConfiguration, ok := e.Object.(*admissionv1.MutatingWebhookConfiguration)
+		if !ok {
+			klog.Infof("mutatingWebhookConfiguration.onCreateFunc Skip. object: %v", e.Object)
+			return false
+		}
+
+		if mutatingWebhookConfiguration.GetName() != webhookName {
+			klog.V(6).Infof("mutatingWebhookConfiguration.onUpdateFunc Skip. object: %v", e.Object)
+			return false
+		}
+
+		klog.V(5).Infof("mutatingWebhookConfigurationEventHandler.onCreateFunc name: %s", mutatingWebhookConfiguration.GetName())
+		return true
+	}
+}
+
+func (handler *mutatingWebhookConfigurationEventHandler) onUpdateFunc(webhookName string) func(e event.UpdateEvent) bool {
+	return func(e event.UpdateEvent) (needUpdate bool) {
+		klog.Info("receive mutatingWebhookConfigurationEventHandler.onUpdateFunc")
+		mutatingWebhookConfigurationNew, ok := e.ObjectNew.(*admissionv1.MutatingWebhookConfiguration)
+		if !ok {
+			klog.Infof("mutatingWebhookConfiguration.onUpdateFunc Skip. object: %v", e.ObjectNew)
+			return false
+		}
+
+		mutatingWebhookConfigurationOld, ok := e.ObjectOld.(*admissionv1.MutatingWebhookConfiguration)
+		if !ok {
+			klog.Infof("mutatingWebhookConfiguration.onUpdateFunc Skip. object: %v", e.ObjectNew)
+			return false
+		}
+
+		if mutatingWebhookConfigurationOld.GetName() != webhookName || mutatingWebhookConfigurationNew.GetName() != webhookName {
+			klog.V(6).Infof("mutatingWebhookConfiguration.onUpdateFunc Skip. object: %v", e.ObjectNew)
+			return false
+		}
+
+		klog.V(6).Infof("mutatingWebhookConfigurationEventHandler.onUpdateFunc name: %s", mutatingWebhookConfigurationNew.GetName())
+		return true
+	}
+}
+
+func (handler *mutatingWebhookConfigurationEventHandler) onDeleteFunc(webhookName string) func(e event.DeleteEvent) bool {
+	return func(e event.DeleteEvent) bool {
+		return false
+	}
+}


### PR DESCRIPTION
Separated from https://github.com/juicedata/juicefs-csi-driver/pull/454. Webhook server needs cert to communicate with Apiserver. CertBuilder can update cert automatically in secret.