### PR TITLE
translate introduction.md

### DIFF
--- a/docs/en/examples/mount-image.md
+++ b/docs/en/examples/mount-image.md
@@ -5,8 +5,7 @@ sidebar_label: Customize the Container Image of Mount Pod
 # How to customize the container image of Mount Pod
 
 :::note
-This feature requires JuiceFS CSI Driver version 0.17.1 and above.
-If the CSI Driver is started by process mounting, that is, the startup parameters of CSI Node and CSI Controller use `--by-process=true`, all relevant settings described in this document will be ignored.
+This feature requires JuiceFS CSI Driver 0.17.1 and above, and is not supported under [mount by process](../introduction.md#by-process) mode.
 :::
 
 By default, the container image of the JuiceFS Mount Pod is `juicedata/mount:v<JUICEFS-CE-LATEST-VERSION>-<JUICEFS-EE-LATEST-VERSION>`, where `<JUICEFS-CE-LATEST-VERSION>` means The latest version number of JuiceFS Community Edition client (e.g. `1.0.0`), `<JUICEFS-EE-LATEST-VERSION>` represents the latest version number of JuiceFS Cloud Service client (e.g. `4.8.0`). You can view all image tags on [Docker Hub](https://hub.docker.com/r/juicedata/mount/tags).

--- a/docs/en/getting_started.md
+++ b/docs/en/getting_started.md
@@ -147,23 +147,6 @@ Before getting started, you need:
 * Make sure JuiceFS is accessible from Kuberenetes cluster. It is recommended to create the file system inside the same region as Kubernetes cluster.
 * Install JuiceFS CSI driver following the [Installation](#installation) steps.
 
-### Table of contents
-
-* [Static Provisioning](examples/static-provisioning.md)
-* [Dynamic Provisioning](examples/dynamic-provisioning.md)
-* [Config File System Settings](examples/format-options.md)
-* [Config Mount Options](examples/mount-options.md)
-* [Mount Subdirectory](examples/subpath.md)
-* [Data Encryption](examples/encrypt.md)
-* [Manage Permissions in JuiceFS](examples/permission.md)
-* [Use ReadWriteMany and ReadOnlyMany](examples/rwx-and-rox.md)
-* [Config Mount Pod Resources](examples/mount-resources.md)
-* [Set Configuration Files and Environment Variables in Mount Pod](examples/config-and-env.md)
-* [Delay Deletion of Mount Pod](examples/delay-delete.md)
-* [Configure Mount Pod to Clean Cache When Exiting](examples/cache-clean.md)
-* [Reclaim Policy of PV](examples/reclaim-policy.md)
-* [Automatic Mount Point Recovery](administration/recover_failed_mountpoint.md)
-
 ## Troubleshooting & FAQs
 
 If you encounter any issue, please refer to [Troubleshooting](troubleshooting.md) or [FAQ](FAQs.md) document.

--- a/docs/en/getting_started.md
+++ b/docs/en/getting_started.md
@@ -141,11 +141,7 @@ Since Kubernetes will deprecate some old APIs when a new version is released, yo
 
 ## Usage
 
-Before getting started, you need:
-
-* Get yourself familiar with how to setup Kubernetes and how to use JuiceFS file system.
-* Make sure JuiceFS is accessible from Kuberenetes cluster. It is recommended to create the file system inside the same region as Kubernetes cluster.
-* Install JuiceFS CSI driver following the [Installation](#installation) steps.
+Please refer to the "User Guide" category on the left sidebar.
 
 ## Troubleshooting & FAQs
 

--- a/docs/en/guide/resource-optimization.md
+++ b/docs/en/guide/resource-optimization.md
@@ -8,10 +8,6 @@ Every application pod that uses JuiceFS PV requires a running mount pod (reused 
 
 Read the official documentation [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to learn about pod resource requests and limits. For a default JuiceFS mount pod, resource requests is 1 CPU and 1GiB memory, resource limits is 2 CPU and 5GiB memory.
 
-:::note
-If the CSI driver is started by process mounting, that is, the startup parameters of CSI Node and CSI Controller use `--by-process=true`, you need to increase the resource requests of CSI Node `DaemonSet` to at least 1 CPU and 1GiB of memory , the resource limit is increased to at least 2 CPU and 5GiB of memory.
-:::
-
 ### Static provisioning
 
 You can set resource requests and limits in `PersistentVolume`:

--- a/docs/en/introduction.md
+++ b/docs/en/introduction.md
@@ -24,7 +24,7 @@ As shown in above diagram, JuiceFS CSI Driver run JuiceFS Client in a dedicated 
 * When multiple pods reference a same PV, mount pod will be reused. There'll be reference counting on mount pod to decide its deletion.
 * Components are decoupled from application pods, allowing CSI Driver to be easily upgraded, see [Upgrade JuiceFS CSI Driver](upgrade/upgrade-csi-driver.md).
 
-Take [dynamic provisioning](./examples/dynamic-provisioning.md) for example, this is the process of creating and using a PV:
+Take [dynamic provisioning](./examples/dynamic-provisioning.md) as an example, this is the process of creating and using a PV:
 
 * User creates a PVC (PersistentVolumeClaim) using the JuiceFS StorageClass;
 * PV is created and provisioned by CSI Controller, by default, a sub-directory named with PV ID will be created under JuiceFS root;

--- a/docs/en/introduction.md
+++ b/docs/en/introduction.md
@@ -15,16 +15,16 @@ juicefs-csi-controller-0   2/2     Running       0          141d
 juicefs-csi-node-8rd96     3/3     Running       0          141d
 ```
 
-JuiceFS CSI Driver architecture diagram:
+The architecture of the JuiceFS CSI Driver is shown in the figure:
 
 ![](./images/csi-driver-architecture.jpg)
 
-As shown in above diagram, JuiceFS CSI Driver run JuiceFS Client in a dedicated mount pod, Node Service will manage mount pod lifecycle. This architecture proves several advantages:
+As shown in above diagram, JuiceFS CSI Driver run JuiceFS Client in a dedicated mount pod, CSI Node Service will manage mount pod lifecycle. This architecture proves several advantages:
 
 * When multiple pods reference a same PV, mount pod will be reused. There'll be reference counting on mount pod to decide its deletion.
 * Components are decoupled from application pods, allowing CSI Driver to be easily upgraded, see [Upgrade JuiceFS CSI Driver](upgrade/upgrade-csi-driver.md).
 
-Take [dynamic provisioning](./examples/dynamic-provisioning.md) as an example, this is the process of creating and using a PV:
+Take ["Dynamic Provisioning"](./examples/dynamic-provisioning.md) as an example, this is the process of creating and using a PV:
 
 * User creates a PVC (PersistentVolumeClaim) using the JuiceFS StorageClass;
 * PV is created and provisioned by CSI Controller, by default, a sub-directory named with PV ID will be created under JuiceFS root;
@@ -33,7 +33,7 @@ Take [dynamic provisioning](./examples/dynamic-provisioning.md) as an example, t
 * CSI Node Service creates mount pod on the associating node;
 * A JuiceFS Client runs inside the mount pod, and mounts JuiceFS volume to host, path being `/var/lib/juicefs/volume/[pv-name]`;
 * CSI Node Service waits until mount pod is up and running, and binds PV with the associated container, the PV sub-directory is mounted in pod, path defined by `volumeMounts`;
-* Application pod is created by Kubelet;
+* Application pod is created by Kubelet.
 
 As explained above, when using JuiceFS CSI Driver, application pod is always accompanied by a mount pod:
 
@@ -44,12 +44,12 @@ kube-system   juicefs-host-pvc-xxx   1/1     Running        0            1d
 
 ## Mount by process {#by-process}
 
-Apart from using a dedicated mount pod (mount by pod), JuiceFS CSI Driver also supports running JuiceFS Client directly inside CSI Node, as processes (mount by process). In this mode, one or several JuiceFS Client will run inside the CSI Node pod, managing all JuiceFS mountpoint for application pods referencing JuiceFS PV in the associating node.
+Apart from using a dedicated mount pod (mount by pod), JuiceFS CSI Driver also supports running JuiceFS Client directly inside CSI Node Service, as processes (mount by process). In this mode, one or several JuiceFS Clients will run inside the CSI Node Service pod, managing all JuiceFS mount points for application pods referencing JuiceFS PV in the associating node.
 
-To enable mount by process, add `--by-process=true` to CSI Node and CSI Controller startup command.
+To enable mount by process, add `--by-process=true` to CSI Node Service and CSI Controller startup command.
 
-When all JuiceFS Client run inside CSI Node pod, it's not hard to imagine that CSI Node DaemonSet will be needing more resource. For CSI Node DaemonSet, it's recommended to increase resource requests to 1 CPU, 1GiB Memory, limits to 2 CPU, 5GiB Memory, or adjust according to the actual resource usage.
+When all JuiceFS Client run inside CSI Node Service pod, it's not hard to imagine that CSI Node Service will be needing more resource. It's recommended to increase resource requests to 1 CPU and 1GiB Memory, limits to 2 CPU and 5GiB Memory, or adjust according to the actual resource usage.
 
 In Kubernetes, mount by pod is no doubt the more recommended way to use JuiceFS CSI Driver. But outside the Kubernetes world, there'll be scenarios requiring the mount by process mode, for example, [Use JuiceFS CSI Driver in Nomad](./cookbook/csi-in-nomad.md).
 
-For versions before v0.10.0,  JuiceFS CSI Driver only supports mount by process. For v0.10.0 and above, mount by pod is the default behavior. To upgrade from v0.9 to v0.10, refer to [Upgrade JuiceFS CSI Driver from v0.9.0 to v0.10.0 and above](./upgrade/upgrade-csi-driver-from-0.9-to-0.10.md).
+For versions before v0.10.0, JuiceFS CSI Driver only supports mount by process. For v0.10.0 and above, mount by pod is the default behavior. To upgrade from v0.9 to v0.10, refer to [Upgrade JuiceFS CSI Driver from v0.9.0 to v0.10.0 and above](./upgrade/upgrade-csi-driver-from-0.9-to-0.10.md).

--- a/docs/zh_cn/examples/mount-image.md
+++ b/docs/zh_cn/examples/mount-image.md
@@ -5,8 +5,7 @@ sidebar_label: 自定义 Mount Pod 的容器镜像
 # 如何自定义 Mount Pod 的容器镜像
 
 :::note 注意
-此特性需使用 0.17.1 及以上版本的 JuiceFS CSI 驱动
-若采用进程挂载的方式启动 CSI 驱动，即 CSI Node 和 CSI Controller 的启动参数使用 `--by-process=true`，则本文档的相关配置会被忽略。
+此特性需使用 0.17.1 及以上版本的 JuiceFS CSI 驱动，且在[进程挂载](../introduction.md#by-process)模式下不支持。
 :::
 
 默认情况下，JuiceFS Mount Pod 的容器镜像为 `juicedata/mount:v<JUICEFS-CE-LATEST-VERSION>-<JUICEFS-EE-LATEST-VERSION>`，其中 `<JUICEFS-CE-LATEST-VERSION>` 表示 JuiceFS 社区版客户端的最新版本号（如 `1.0.0`），`<JUICEFS-EE-LATEST-VERSION>` 表示 JuiceFS 云服务客户端的最新版本号（如 `4.8.0`）。你可以在 [Docker Hub](https://hub.docker.com/r/juicedata/mount/tags) 上查看所有镜像标签。

--- a/docs/zh_cn/getting_started.md
+++ b/docs/zh_cn/getting_started.md
@@ -147,24 +147,6 @@ Helm 是 Kubernetes 的包管理器，Chart 是 Helm 管理的包。你可以把
 * 确保 JuiceFS 能够被 Kuberenetes 集群访问。建议在与 Kubernetes 集群相同的区域创建文件系统。
 * 参照[说明](#安装)安装 JuiceFS CSI 驱动。
 
-### 目录
-
-* [静态配置](examples/static-provisioning.md)
-* [动态配置](examples/dynamic-provisioning.md)
-* [配置文件系统设置](examples/format-options.md)
-* [设置挂载选项](examples/mount-options.md)
-* [设置缓存路径](examples/cache-dir.md)
-* [挂载子目录](examples/subpath.md)
-* [数据加密](examples/encrypt.md)
-* [管理权限](examples/permission.md)
-* [使用 ReadWriteMany 和 ReadOnlyMany](examples/rwx-and-rox.md)
-* [配置 Mount Pod 的资源限制](examples/mount-resources.md)
-* [在 Mount Pod 中设置配置文件和环境变量](examples/config-and-env.md)
-* [延迟删除 Mount Pod](examples/delay-delete.md)
-* [配置 Mount Pod 退出时清理缓存](examples/cache-clean.md)
-* [PV 的回收策略](examples/reclaim-policy.md)
-* [挂载点自动恢复](administration/recover_failed_mountpoint.md)
-
 ## 故障排查
 
 请参考 [故障排查](troubleshooting.md) 或 [FAQ](FAQs.md) 文档。

--- a/docs/zh_cn/getting_started.md
+++ b/docs/zh_cn/getting_started.md
@@ -141,11 +141,7 @@ Helm 是 Kubernetes 的包管理器，Chart 是 Helm 管理的包。你可以把
 
 ## 使用
 
-开始使用之前，你需要：
-
-* 了解如何设置 Kubernetes 和 JuiceFS
-* 确保 JuiceFS 能够被 Kuberenetes 集群访问。建议在与 Kubernetes 集群相同的区域创建文件系统。
-* 参照[说明](#安装)安装 JuiceFS CSI 驱动。
+请参考左侧侧边栏的「使用指南」分类
 
 ## 故障排查
 

--- a/docs/zh_cn/guide/resource-optimization.md
+++ b/docs/zh_cn/guide/resource-optimization.md
@@ -8,10 +8,6 @@ Kubernetes 的一大好处就是促进资源充分利用，在 JuiceFS CSI 驱�
 
 关于为 Pod 和容器管理资源，配置资源请求（`request`）和约束（`limit`），请详读 [Kubernetes 官方文档](https://kubernetes.io/zh-cn/docs/concepts/configuration/manage-resources-containers)，此处便不再赘述。JuiceFS Mount Pod 的资源请求默认为 1 CPU 和 1GiB 内存，资源约束默认为 2 CPU 和 5GiB 内存。
 
-:::note 注意
-若采用进程挂载的方式启动 CSI 驱动，即 CSI Node 和 CSI Controller 的启动参数使用 `--by-process=true`，需要将 CSI Node `DaemonSet` 的资源请求调大到至少 1 CPU 和 1GiB 内存，资源约束调大到至少 2 CPU 和 5GiB 内存。
-:::
-
 ### 静态配置
 
 您可以在 `PersistentVolume` 中配置资源请求和约束：

--- a/docs/zh_cn/introduction.md
+++ b/docs/zh_cn/introduction.md
@@ -4,9 +4,9 @@ sidebar_label: 介绍
 
 # JuiceFS CSI 驱动
 
-[JuiceFS CSI 驱动](https://github.com/juicedata/juicefs-csi-driver)遵循 [CSI](https://github.com/container-storage-interface/spec/blob/master/spec.md) 规范，实现了容器编排系统与 JuiceFS 文件系统之间的接口，让 JuiceFS 文件系统以卷（Volume）的形式提供给 Pod 使用。
+[JuiceFS CSI 驱动](https://github.com/juicedata/juicefs-csi-driver)遵循 [CSI](https://github.com/container-storage-interface/spec/blob/master/spec.md) 规范，实现了容器编排系统与 JuiceFS 文件系统之间的接口。在 Kubernetes 下，JuiceFS 可以用持久卷（PersistentVolume）的形式提供给 Pod 使用。
 
-JuiceFS CSI 驱动会在你的集群中部署以下组件：JuiceFS CSI Controller（StatefulSet）以及 JuiceFS CSI Node Service（DaemonSet），你可以方便地用 `kubectl` 查看：
+JuiceFS CSI 驱动包含以下组件：JuiceFS CSI Controller（StatefulSet）以及 JuiceFS CSI Node Service（DaemonSet），你可以方便地用 `kubectl` 查看：
 
 ```shell
 $ kubectl -n kube-system get pod -l app.kubernetes.io/name=juicefs-csi-driver
@@ -19,20 +19,20 @@ JuiceFS CSI 驱动的架构如图所示：
 
 ![](./images/csi-driver-architecture.jpg)
 
-顺着架构图简单介绍一番 CSI 驱动的工作原理：JuiceFS CSI 驱动采用单独的 Mount Pod 来运行 JuiceFS 客户端，并由 Node Service 来管理 Mount Pod 的生命周期。这样的架构提供如下好处：
+如架构图所示，JuiceFS CSI 驱动采用单独的 Mount Pod 来运行 JuiceFS 客户端，并由 Node Service 来管理 Mount Pod 的生命周期。这样的架构提供如下好处：
 
-* 允许多个应用 Pod 共用 PV，当多个 Pod 共用 PV 时，不会新建 Mount Pod，而是对已有的 Mount Pod 做引用计数，计数归零时删除 Mount Pod。
+* 多个 Pod 共用 PV 时，不会新建 Mount Pod，而是对已有的 Mount Pod 做引用计数，计数归零时删除 Mount Pod。
 * CSI 驱动组件与客户端解耦，方便 CSI 驱动自身的升级。详见[「升级」](upgrade/upgrade-csi-driver.md)。
 
 以[「动态配置」](./examples/dynamic-provisioning.md)为例，创建 PV 和使用的流程大致如下：
 
-* 用户创建 PVC (PersistentVolumeClaim)，声明其使用的 StorageClass；
+* 用户创建 PVC (PersistentVolumeClaim)，使用 JuiceFS 作为 StorageClass；
 * CSI Controller 负责在 JuiceFS 文件系统中做初始化，默认以 PV ID 为名字创建子目录，同时创建对应的 PV（PersistentVolume）；
-* Kubernetes (PVController 组件) 将上述用户创建的 PVC 与 CSI Controller 创建的 PV 进行绑定，此时 PVC 与 PV 的状态皆为 bound；
-* 用户创建应用 Pod，Pod 中声明使用的 PVC；
-* CSI Node Service 负责在应用 Pod 所在节点创建 Mount Pod，并等待其启动成功；
+* Kubernetes (PV Controller 组件) 将上述用户创建的 PVC 与 CSI Controller 创建的 PV 进行绑定，此时 PVC 与 PV 的状态变为 “Bound”；
+* 用户创建应用 Pod，Pod 中声明使用先前创建的 PVC；
+* CSI Node Service 负责在应用 Pod 所在节点创建 Mount Pod；
 * Mount Pod 启动，执行 JuiceFS 客户端挂载，运行 JuiceFS 客户端，挂载路径暴露在宿主机上，路径为 `/var/lib/juicefs/volume/[pv-name]`；
-* CSI Node Service 等待 Mount Pod 启动成功后，将 PV 对应的 JuiceFS 子目录 bind 到容器内，路径为其申明的 VolumeMount 路径；
+* CSI Node Service 等待 Mount Pod 启动成功后，将 PV 对应的 JuiceFS 子目录 bind 到容器内，路径为其声明的 VolumeMount 路径；
 * Kubelet 创建应用 Pod。
 
 因此在使用 JuiceFS CSI 驱动时，应用 Pod 总是与 Mount Pod 一起存在：
@@ -45,3 +45,15 @@ kube-system   juicefs-host-pvc-xxx   1/1     Running        0            1d
 阅读以下文章深入了解 CSI 驱动的架构设计：
 
 * [JuiceFS CSI Driver 架构设计详解](https://juicefs.com/zh-cn/blog/engineering/juicefs-csi-driver-arch-design)
+
+## 进程挂载模式 {#by-process}
+
+相较于采用独立 mount pod 的容器挂载方式，JuiceFS CSI Driver 还提供无需 mount pod 的进程挂载模式，在这种模式下，CSI Node 容器中将会负责运行一个或多个 JuiceFS 客户端，该节点上所有需要挂载的 JuiceFS PV，均在 CSI Node 容器中以进程模式执行挂载。
+
+在 CSI Node 和 CSI Controller 的启动参数中添加 `--by-process=true`，就能启用进程挂载模式。
+
+可想而知，由于所有 JuiceFS 客户端均在 CSI Node 容器中运行，这个 DaemonSet 将需要更大的资源声明，推荐将 CSI Node `DaemonSet` 的资源请求调大到至少 1 CPU 和 1GiB 内存，资源约束调大到至少 2 CPU 和 5GiB 内存，或者根据实际场景资源占用进行调整。
+
+在 Kubernetes 中，容器挂载模式无疑是更加推荐的 CSI 驱动用法，但脱离 Kubernetes 的某些场景，则可能需要选用进程挂载模式，比如[「在 Nomad 中使用 JuiceFS CSI 驱动」](./cookbook/csi-in-nomad.md)。
+
+在 v0.10.0 之前，JuiceFS CSI 驱动仅支持进程挂载模式。而 v0.10.0 及之后版本则默认为容器挂载模式。如果你需要在 v0.9 到 v0.10 进行升级，请参考[「从 v0.9.0 升级到 v0.10.0 及以上」](./upgrade/upgrade-csi-driver-from-0.9-to-0.10.md)。

--- a/docs/zh_cn/introduction.md
+++ b/docs/zh_cn/introduction.md
@@ -19,7 +19,7 @@ JuiceFS CSI 驱动的架构如图所示：
 
 ![](./images/csi-driver-architecture.jpg)
 
-如架构图所示，JuiceFS CSI 驱动采用单独的 Mount Pod 来运行 JuiceFS 客户端，并由 Node Service 来管理 Mount Pod 的生命周期。这样的架构提供如下好处：
+如架构图所示，JuiceFS CSI 驱动采用单独的 Mount Pod 来运行 JuiceFS 客户端，并由 CSI Node Service 来管理 Mount Pod 的生命周期。这样的架构提供如下好处：
 
 * 多个 Pod 共用 PV 时，不会新建 Mount Pod，而是对已有的 Mount Pod 做引用计数，计数归零时删除 Mount Pod。
 * CSI 驱动组件与客户端解耦，方便 CSI 驱动自身的升级。详见[「升级」](upgrade/upgrade-csi-driver.md)。
@@ -28,7 +28,7 @@ JuiceFS CSI 驱动的架构如图所示：
 
 * 用户创建 PVC (PersistentVolumeClaim)，使用 JuiceFS 作为 StorageClass；
 * CSI Controller 负责在 JuiceFS 文件系统中做初始化，默认以 PV ID 为名字创建子目录，同时创建对应的 PV（PersistentVolume）；
-* Kubernetes (PV Controller 组件) 将上述用户创建的 PVC 与 CSI Controller 创建的 PV 进行绑定，此时 PVC 与 PV 的状态变为 “Bound”；
+* Kubernetes (PV Controller 组件) 将上述用户创建的 PVC 与 CSI Controller 创建的 PV 进行绑定，此时 PVC 与 PV 的状态变为「Bound」；
 * 用户创建应用 Pod，Pod 中声明使用先前创建的 PVC；
 * CSI Node Service 负责在应用 Pod 所在节点创建 Mount Pod；
 * Mount Pod 启动，执行 JuiceFS 客户端挂载，运行 JuiceFS 客户端，挂载路径暴露在宿主机上，路径为 `/var/lib/juicefs/volume/[pv-name]`；
@@ -48,11 +48,11 @@ kube-system   juicefs-host-pvc-xxx   1/1     Running        0            1d
 
 ## 进程挂载模式 {#by-process}
 
-相较于采用独立 mount pod 的容器挂载方式，JuiceFS CSI Driver 还提供无需 mount pod 的进程挂载模式，在这种模式下，CSI Node 容器中将会负责运行一个或多个 JuiceFS 客户端，该节点上所有需要挂载的 JuiceFS PV，均在 CSI Node 容器中以进程模式执行挂载。
+相较于采用独立 mount pod 的容器挂载方式，JuiceFS CSI 驱动还提供无需 mount pod 的进程挂载模式，在这种模式下，CSI Node Service 容器中将会负责运行一个或多个 JuiceFS 客户端，该节点上所有需要挂载的 JuiceFS PV，均在 CSI Node Service 容器中以进程模式执行挂载。
 
-在 CSI Node 和 CSI Controller 的启动参数中添加 `--by-process=true`，就能启用进程挂载模式。
+在 CSI Node Service 和 CSI Controller 的启动参数中添加 `--by-process=true`，就能启用进程挂载模式。
 
-可想而知，由于所有 JuiceFS 客户端均在 CSI Node 容器中运行，这个 DaemonSet 将需要更大的资源声明，推荐将 CSI Node `DaemonSet` 的资源请求调大到至少 1 CPU 和 1GiB 内存，资源约束调大到至少 2 CPU 和 5GiB 内存，或者根据实际场景资源占用进行调整。
+可想而知，由于所有 JuiceFS 客户端均在 CSI Node Service 容器中运行，CSI Node Service 将需要更大的资源声明，推荐将其资源请求调大到至少 1 CPU 和 1GiB 内存，资源约束调大到至少 2 CPU 和 5GiB 内存，或者根据实际场景资源占用进行调整。
 
 在 Kubernetes 中，容器挂载模式无疑是更加推荐的 CSI 驱动用法，但脱离 Kubernetes 的某些场景，则可能需要选用进程挂载模式，比如[「在 Nomad 中使用 JuiceFS CSI 驱动」](./cookbook/csi-in-nomad.md)。
 


### PR DESCRIPTION
* 从快速上手删去了 toc: 侧边栏已经提供了目录, 况且后续也会将 examples 里的内容做进一步聚合
* 翻译架构介绍
* 增加了 by-process 的说明, 及其历史背景