### PR TITLE
hacked in naïve approach to adding ports to mount pods that assumes p…

### DIFF
--- a/pkg/juicefs/mount/builder/pod.go
+++ b/pkg/juicefs/mount/builder/pod.go
@@ -56,6 +56,9 @@ func (r *Builder) NewMountPod(podName string) *corev1.Pod {
 				"umount %s && rmdir %s", r.jfsSetting.MountPath, r.jfsSetting.MountPath)}},
 		},
 	}
+	pod.Spec.Containers[0].Ports = []corev1.ContainerPort{
+		{Name: "prometheus", ContainerPort: 9567},
+	}
 	gracePeriod := int64(10)
 	pod.Spec.TerminationGracePeriodSeconds = &gracePeriod
 


### PR DESCRIPTION
…ort will always be enabled and is hardcoded to 9567 (matches default configuration).

This PR is a quick/dirty implementation starter for the feature request: https://github.com/juicedata/juicefs-csi-driver/issues/529

...and is basically just intended to reduce the barrier to implementation rather than be a solid, verified implementation. 