### PR TITLE
move livenessProbe to where it belongs

### DIFF
--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -272,14 +272,6 @@ spec:
         - name: JUICEFS_CONFIG_PATH
           value: /var/lib/juicefs/config
         image: juicedata/juicefs-csi-driver:v0.17.4
-        livenessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /healthz
-            port: healthz
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 3
         name: juicefs-plugin
         ports:
         - containerPort: 9909
@@ -327,6 +319,14 @@ spec:
         - name: HEALTH_PORT
           value: "9909"
         image: quay.io/k8scsi/livenessprobe:v1.1.0
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi

--- a/deploy/k8s_before_v1_18.yaml
+++ b/deploy/k8s_before_v1_18.yaml
@@ -272,14 +272,6 @@ spec:
         - name: JUICEFS_CONFIG_PATH
           value: /var/lib/juicefs/config
         image: juicedata/juicefs-csi-driver:v0.17.4
-        livenessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /healthz
-            port: healthz
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 3
         name: juicefs-plugin
         ports:
         - containerPort: 9909
@@ -327,6 +319,14 @@ spec:
         - name: HEALTH_PORT
           value: "9909"
         image: quay.io/k8scsi/livenessprobe:v1.1.0
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi

--- a/deploy/kubernetes/base/resources.yaml
+++ b/deploy/kubernetes/base/resources.yaml
@@ -257,14 +257,6 @@ spec:
               add:
               - SYS_ADMIN
             privileged: true
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: healthz
-            initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 10
-            failureThreshold: 5
         - name: csi-provisioner
           image: quay.io/k8scsi/csi-provisioner:v1.6.0
           args:
@@ -289,6 +281,14 @@ spec:
               value: /csi/csi.sock
             - name: HEALTH_PORT
               value: "9909"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 5
           volumeMounts:
             - name: socket-dir
               mountPath: /csi


### PR DESCRIPTION
suggestion: could we delete liveness probe container altogether? since it doesn't really represent the liveness & healthness of the csi controller plugin container.

related: https://github.com/juicedata/juicefs-csi-driver/issues/531