### PR TITLE
rename diagnose.sh into csi-doctor.sh, and simplify usage

### DIFF
--- a/docs/en/administration/going-production.md
+++ b/docs/en/administration/going-production.md
@@ -1,5 +1,5 @@
 ---
-title: Production Deployment Recommendations
+title: Production Recommendations
 sidebar_position: 1
 ---
 

--- a/docs/en/administration/troubleshooting.md
+++ b/docs/en/administration/troubleshooting.md
@@ -8,9 +8,9 @@ Read this chapter to learn how to troubleshoot JuiceFS CSI Driver, to continue, 
 
 ## Diagnostic script {#csi-doctor}
 
-Our diagnostic script [`csi-doctor.sh`](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh) is recommended for CSI Driver debugging, without this script, you'll have to manually execute a series of commands (introduced in other sections in this chapter) to obtain information.
+It is recommended to use the diagnostic script [`csi-doctor.sh`](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh) to collect logs and related information, without this script, you'll have to manually execute a series of commands (introduced in other sections in this chapter) to obtain information.
 
-To install this script, choose any node with `kubectl` permission, run:
+To install this script, choose any node in the cluster that can execute `kubectl`, run:
 
 ```shell
 wget https://raw.githubusercontent.com/juicedata/juicefs-csi-driver/master/scripts/csi-doctor.sh
@@ -23,6 +23,7 @@ Assuming application pod being `dynamic-ce-1`, in namespace `default`, to acquir
 # Get mount pod for specified application pod
 $ ./csi-doctor.sh get-mount dynamic-ce-1
 kube-system juicefs-ubuntu-node-2-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-whrrym
+
 # Get all application pods that's sharing the specified mount pod
 $ ./csi-doctor.sh get-app juicefs-ubuntu-node-3-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-octdjc
 default dynamic-ce-5
@@ -221,15 +222,15 @@ kubectl -n kube-system get po -l app=juicefs-csi-controller -o jsonpath='{.items
 
 Image tag will contain the CSI Driver version string.
 
-### Diagnosis script
+### Gather information through diagnostic script {#gather-information-through-diagnostic-script}
 
-For JuiceFS Cloud Services and Enterprise users, use the [`csi-doctor.sh`](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh) to collect relevant information, and send it to Juicedata team for support.
+You can use [diagnostic script](#csi-doctor) to collect logs and related information, and send them to the community or the Juicedata team for troubleshooting support.
 
 Assuming the application pod being `dynamic-ce-1`, in namespace `default`, run:
 
 ```shell
-./csi-doctor.sh collect dynamic-ce-1 -n default
+$ ./csi-doctor.sh collect dynamic-ce-1 -n default
 Results have been compressed to dynamic-ce-1.diagnose.tar.gz
 ```
 
-All relevant Kubernetes manifests, logs, events are packed into a tar file, send this file to Juicedata team for further support.
+All related Kubernetes resources, logs, and events are collected and packaged into a tar file, send this file to relevant people for further support.

--- a/docs/en/administration/troubleshooting.md
+++ b/docs/en/administration/troubleshooting.md
@@ -6,6 +6,29 @@ sidebar_position: 6
 
 Read this chapter to learn how to troubleshoot JuiceFS CSI Driver, to continue, you should already be familiar with [the JuiceFS CSI Architecture](../introduction.md#architecture), i.e. have a basic understanding of the roles of each CSI Driver component.
 
+## Diagnostic script {#csi-doctor}
+
+Our diagnostic script [`csi-doctor.sh`](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh) is recommended for CSI Driver debugging, without this script, you'll have to manually execute a series of commands (introduced in other sections in this chapter) to obtain information.
+
+To install this script, choose any node with `kubectl` permission, run:
+
+```shell
+wget https://raw.githubusercontent.com/juicedata/juicefs-csi-driver/master/scripts/csi-doctor.sh
+chmod a+x csi-doctor.sh
+```
+
+Assuming application pod being `dynamic-ce-1`, in namespace `default`, to acquire the mount pod name that accompanies the application pod:
+
+```shell
+# Get mount pod for specified application pod
+$ ./csi-doctor.sh get-mount dynamic-ce-1
+kube-system juicefs-ubuntu-node-2-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-whrrym
+# Get all application pods that's sharing the specified mount pod
+$ ./csi-doctor.sh get-app juicefs-ubuntu-node-3-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-octdjc
+default dynamic-ce-5
+default dynamic-ce-2
+```
+
 ## Basic principles for troubleshooting {#basic-principles}
 
 In JuiceFS CSI Driver, most frequently encountered problems are PV creation failures (managed by CSI Controller) and pod creation failures (managed by CSI Node / Mount Pod).
@@ -200,80 +223,13 @@ Image tag will contain the CSI Driver version string.
 
 ### Diagnosis script
 
-You can also use the [diagnosis script](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/diagnose.sh) to collect logs and related information.
+For JuiceFS Cloud Services and Enterprise users, use the [`csi-doctor.sh`](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh) to collect relevant information, and send it to Juicedata team for support.
 
-First, install the script to any node with `kubectl` access:
-
-```shell
-wget https://raw.githubusercontent.com/juicedata/juicefs-csi-driver/master/scripts/diagnose.sh
-chmod a+x diagnose.sh
-```
-
-Get the mount pod used by the application pod using the script. For example, assuming that the application pod name is `dynamic-ce-1`, and the namespace is `default`.
+Assuming the application pod being `dynamic-ce-1`, in namespace `default`, run:
 
 ```shell
-$ ./diagnose.sh
-Usage:
-    ./diagnose.sh COMMAND [OPTIONS]
-ENV:
-    JUICEFS_NAMESPACE: namespace of JuiceFS CSI Driver, default is kube-system.
-COMMAND:
-    help
-        Display this help message.
-    get-mount
-        Print mount pod used by specified app pod.
-    get-app
-        Print app pods using specified mount pod.
-    collect
-        Collect csi & mount pods logs of juicefs.
-OPTIONS:
-    -po, --pod name
-        Set the name of app pod.
-    -n, --namespace name
-        Set the namespace of app pod, default is default.
-    -m, --mount pod name
-        Set the name of mount pod.
-
-# Set the namespace where the juicefs csi driver component deployed in, the default is kube-system
-$ export JUICEFS_NAMESPACE=kube-system
-# Get the mount pod used by the specified pod
-$ ./diagnose.sh get-mount -po dynamic-ce-1
-Mount Pod which app dynamic-ce-1 using is:
-namespace:
-  kube-system
-name:
-  juicefs-ubuntu-node-2-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-whrrym
+./csi-doctor.sh collect dynamic-ce-1 -n default
+Results have been compressed to dynamic-ce-1.diagnose.tar.gz
 ```
 
-Collect diagnose information using the script. For example, assuming that the application pod name is `dynamic-ce-1`, and the namespace is `default`.
-
-```shell
-# Set the namespace where the juicefs csi driver component deployed in, the default is kube-system
-$ export JUICEFS_NAMESPACE=kube-system
-# collect diagnostics information
-$ ./diagnose.sh collect -po dynamic-ce-1 -n default
-Start collecting, pod=dynamic-ce-1, namespace=default
-...
-please get diagnose_juicefs_1671073110.tar.gz for diagnostics
-```
-
-All relevant information is collected and packaged in an archive under the execution path.
-
-If the mount pod name is known, the diagnostic script can also be used to get all application pods using that mount pod.
-For example, assuming that the mount pod name is `juicefs-ubuntu-node-3-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-octdjc`,
-and the namespace where the JuiceFS CSI Driver component deployed in is `kube-system`.
-
-```shell
-# Set the namespace where the juicefs csi driver component deployed in, the default is kube-system
-$ export JUICEFS_NAMESPACE=kube-system
-# Get all application pods using the specified mount pod
-$ ./diagnose.sh get-app -m juicefs-ubuntu-node-3-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-octdjc
-App pods using mount pod [juicefs-ubuntu-node-3-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-octdjc]:
-namespace:
-  default
-apps:
-  dynamic-ce-5
-  dynamic-ce-2
-  dynamic-ce-3
-  dynamic-ce-4
-```
+All relevant Kubernetes manifests, logs, events are packed into a tar file, send this file to Juicedata team for further support.

--- a/docs/zh_cn/administration/troubleshooting.md
+++ b/docs/zh_cn/administration/troubleshooting.md
@@ -8,7 +8,7 @@ sidebar_position: 6
 
 ## 诊断脚本 {#csi-doctor}
 
-你可以使用诊断脚本 [`csi-doctor`](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh) 来收集日志及相关信息。
+你可以使用诊断脚本 [`csi-doctor.sh`](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh) 来收集日志及相关信息。
 
 在集群中任意一台可以执行 `kubectl` 的节点上，安装诊断脚本：
 
@@ -224,7 +224,7 @@ kubectl -n kube-system get po -l app=juicefs-csi-controller -o jsonpath='{.items
 
 ### 诊断脚本
 
-对于 JuiceFS 商业版用户，可以使用[诊断脚本](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh)来收集日志及相关信息，发送给 Juicedata 团队进行排查支持。
+对于 JuiceFS 云服务和企业版用户，可以使用[诊断脚本](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh)来收集日志及相关信息，发送给 Juicedata 团队进行排查支持。
 
 假设应用 pod 名为 `dynamic-ce-1`，所在 namespace 为 `default`，用下方命令收集排查信息：
 

--- a/docs/zh_cn/administration/troubleshooting.md
+++ b/docs/zh_cn/administration/troubleshooting.md
@@ -6,6 +6,53 @@ sidebar_position: 6
 
 阅读本章以了解如何对 JuiceFS CSI 驱动进行问题排查。不论面临何种错误，排查过程都需要你熟悉 CSI 驱动的各个组件及其作用，因此继续阅读前，请确保你已了解 [JuiceFS CSI 驱动架构](../introduction.md#architecture)。
 
+## 诊断脚本 {#csi-doctor}
+
+你可以使用诊断脚本 [`csi-doctor`](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh) 来收集日志及相关信息。
+
+在集群中任意一台可以执行 `kubectl` 的节点上，安装诊断脚本：
+
+```shell
+wget https://raw.githubusercontent.com/juicedata/juicefs-csi-driver/master/scripts/csi-doctor.sh
+chmod a+x csi-doctor.sh
+```
+
+使用诊断脚本获取应用 pod 使用的 mount pod。假设应用 pod 名为 `dynamic-ce-1`，所在 namespace 为 `default`。
+
+```shell
+$ ./diagnose.sh
+Usage:
+    ./diagnose.sh COMMAND [OPTIONS]
+ENV:
+    JUICEFS_NAMESPACE: namespace of JuiceFS CSI Driver, default is kube-system.
+COMMAND:
+    help
+        Display this help message.
+    get-mount
+        Print mount pod used by specified app pod.
+    get-app
+        Print app pods using specified mount pod.
+    collect
+        Collect csi & mount pods logs of juicefs.
+OPTIONS:
+    -po, --pod name
+        Set the name of app pod.
+    -n, --namespace name
+        Set the namespace of app pod, default is default.
+    -m, --mount pod name
+        Set the name of mount pod.
+
+# 设置 juicefs csi driver 组件所在 namespace，默认为 kube-system
+$ export JUICEFS_NAMESPACE=kube-system
+# 获取指定 pod 所用的 mount pod
+$ ./diagnose.sh get-mount -po dynamic-ce-1
+Mount Pod which app dynamic-ce-1 using is:
+namespace:
+  kube-system
+name:
+  juicefs-ubuntu-node-2-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-whrrym
+```
+
 ## 基础问题排查原则 {#basic-principles}
 
 在 JuiceFS CSI 驱动中，常见错误有两种：一种是 PV 创建失败，属于 CSI Controller 的职责；另一种是应用 Pod 创建失败，属于 CSI Node 和 Mount Pod 的职责。

--- a/docs/zh_cn/administration/troubleshooting.md
+++ b/docs/zh_cn/administration/troubleshooting.md
@@ -25,7 +25,7 @@ $ ./csi-doctor.sh get-mount dynamic-ce-1
 kube-system juicefs-ubuntu-node-2-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-whrrym
 
 # 获取使用指定 mount pod 的所有应用 pod
-$ ./diagnose.sh get-app juicefs-ubuntu-node-3-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-octdjc
+$ ./csi-doctor.sh get-app juicefs-ubuntu-node-3-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-octdjc
 default dynamic-ce-5
 default dynamic-ce-2
 ```
@@ -229,7 +229,7 @@ kubectl -n kube-system get po -l app=juicefs-csi-controller -o jsonpath='{.items
 假设应用 pod 名为 `dynamic-ce-1`，所在 namespace 为 `default`，用下方命令收集排查信息：
 
 ```shell
-./diagnose.sh collect dynamic-ce-1 -n default
+./csi-doctor.sh collect dynamic-ce-1 -n default
 ```
 
 所有相关的日志、事件都被收集和打包在了一个压缩包里，将压缩包发送给 Juicedata 进行后续支持。

--- a/docs/zh_cn/administration/troubleshooting.md
+++ b/docs/zh_cn/administration/troubleshooting.md
@@ -8,7 +8,7 @@ sidebar_position: 6
 
 ## 诊断脚本 {#csi-doctor}
 
-你可以使用诊断脚本 [`csi-doctor.sh`](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh) 来收集日志及相关信息。
+我们推荐使用诊断脚本 [`csi-doctor.sh`](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh) 来收集日志及相关信息，本章所介绍的排查手段中，大部分采集信息的命令，都在脚本中进行了集成，使用起来更为便捷。
 
 在集群中任意一台可以执行 `kubectl` 的节点上，安装诊断脚本：
 
@@ -17,14 +17,14 @@ wget https://raw.githubusercontent.com/juicedata/juicefs-csi-driver/master/scrip
 chmod a+x csi-doctor.sh
 ```
 
-使用诊断脚本获取应用 pod 使用的 mount pod。假设应用 pod 名为 `dynamic-ce-1`，所在 namespace 为 `default`。
+脚本可用来方便地获取 Mount Pod 相关信息。假设应用 pod 名为 `dynamic-ce-1`，所在 namespace 为 `default`：
 
 ```shell
-# 获取指定 pod 所用的 mount pod
+# 获取指定应用 Pod 所用的 Mount Pod
 $ ./csi-doctor.sh get-mount dynamic-ce-1
 kube-system juicefs-ubuntu-node-2-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-whrrym
 
-# 获取使用指定 mount pod 的所有应用 pod
+# 获取使用指定 Mount Pod 的所有应用 Pod
 $ ./csi-doctor.sh get-app juicefs-ubuntu-node-3-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-octdjc
 default dynamic-ce-5
 default dynamic-ce-2
@@ -224,12 +224,13 @@ kubectl -n kube-system get po -l app=juicefs-csi-controller -o jsonpath='{.items
 
 ### 诊断脚本
 
-对于 JuiceFS 云服务和企业版用户，可以使用[诊断脚本](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh)来收集日志及相关信息，发送给 Juicedata 团队进行排查支持。
+对于 JuiceFS 云服务和企业版用户，可以使用 [`csi-doctor.sh`](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh) 来收集日志及相关信息，发送给 Juicedata 团队进行排查支持。
 
 假设应用 pod 名为 `dynamic-ce-1`，所在 namespace 为 `default`，用下方命令收集排查信息：
 
 ```shell
-./csi-doctor.sh collect dynamic-ce-1 -n default
+$ ./csi-doctor.sh collect dynamic-ce-1 -n default
+Results have been compressed to dynamic-ce-1.diagnose.tar.gz
 ```
 
-所有相关的日志、事件都被收集和打包在了一个压缩包里，将压缩包发送给 Juicedata 进行后续支持。
+所有相关的 Kubernetes 资源、日志、事件都被收集和打包在了一个压缩包里，将此压缩包发送给 Juicedata 团队进行后续支持。

--- a/docs/zh_cn/administration/troubleshooting.md
+++ b/docs/zh_cn/administration/troubleshooting.md
@@ -20,37 +20,14 @@ chmod a+x csi-doctor.sh
 使用诊断脚本获取应用 pod 使用的 mount pod。假设应用 pod 名为 `dynamic-ce-1`，所在 namespace 为 `default`。
 
 ```shell
-$ ./diagnose.sh
-Usage:
-    ./diagnose.sh COMMAND [OPTIONS]
-ENV:
-    JUICEFS_NAMESPACE: namespace of JuiceFS CSI Driver, default is kube-system.
-COMMAND:
-    help
-        Display this help message.
-    get-mount
-        Print mount pod used by specified app pod.
-    get-app
-        Print app pods using specified mount pod.
-    collect
-        Collect csi & mount pods logs of juicefs.
-OPTIONS:
-    -po, --pod name
-        Set the name of app pod.
-    -n, --namespace name
-        Set the namespace of app pod, default is default.
-    -m, --mount pod name
-        Set the name of mount pod.
-
-# 设置 juicefs csi driver 组件所在 namespace，默认为 kube-system
-$ export JUICEFS_NAMESPACE=kube-system
 # 获取指定 pod 所用的 mount pod
-$ ./diagnose.sh get-mount -po dynamic-ce-1
-Mount Pod which app dynamic-ce-1 using is:
-namespace:
-  kube-system
-name:
-  juicefs-ubuntu-node-2-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-whrrym
+$ ./csi-doctor.sh get-mount dynamic-ce-1
+kube-system juicefs-ubuntu-node-2-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-whrrym
+
+# 获取使用指定 mount pod 的所有应用 pod
+$ ./diagnose.sh get-app juicefs-ubuntu-node-3-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-octdjc
+default dynamic-ce-5
+default dynamic-ce-2
 ```
 
 ## 基础问题排查原则 {#basic-principles}
@@ -247,78 +224,12 @@ kubectl -n kube-system get po -l app=juicefs-csi-controller -o jsonpath='{.items
 
 ### 诊断脚本
 
-你可以使用[诊断脚本](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/diagnose.sh)来收集日志及相关信息。
+对于 JuiceFS 商业版用户，可以使用[诊断脚本](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh)来收集日志及相关信息，发送给 Juicedata 团队进行排查支持。
 
-在集群中任意一台可以执行 `kubectl` 的节点上，安装诊断脚本：
-
-```shell
-wget https://raw.githubusercontent.com/juicedata/juicefs-csi-driver/master/scripts/diagnose.sh
-chmod a+x diagnose.sh
-```
-
-使用诊断脚本获取应用 pod 使用的 mount pod。假设应用 pod 名为 `dynamic-ce-1`，所在 namespace 为 `default`。
+假设应用 pod 名为 `dynamic-ce-1`，所在 namespace 为 `default`，用下方命令收集排查信息：
 
 ```shell
-$ ./diagnose.sh
-Usage:
-    ./diagnose.sh COMMAND [OPTIONS]
-ENV:
-    JUICEFS_NAMESPACE: namespace of JuiceFS CSI Driver, default is kube-system.
-COMMAND:
-    help
-        Display this help message.
-    get-mount
-        Print mount pod used by specified app pod.
-    get-app
-        Print app pods using specified mount pod.
-    collect
-        Collect csi & mount pods logs of juicefs.
-OPTIONS:
-    -po, --pod name
-        Set the name of app pod.
-    -n, --namespace name
-        Set the namespace of app pod, default is default.
-    -m, --mount pod name
-        Set the name of mount pod.
-
-# 设置 juicefs csi driver 组件所在 namespace，默认为 kube-system
-$ export JUICEFS_NAMESPACE=kube-system
-# 获取指定 pod 所用的 mount pod
-$ ./diagnose.sh get-mount -po dynamic-ce-1
-Mount Pod which app dynamic-ce-1 using is:
-namespace:
-  kube-system
-name:
-  juicefs-ubuntu-node-2-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-whrrym
+./diagnose.sh collect dynamic-ce-1 -n default
 ```
 
-也可以使用诊断脚本来收集信息。假设应用 pod 名为 `dynamic-ce-1`，所在 namespace 为 `default`。
-
-```shell
-# 设置 juicefs csi driver 组件所在 namespace，默认为 kube-system
-$ export JUICEFS_NAMESPACE=kube-system
-# 收集诊断信息
-$ ./diagnose.sh collect -po dynamic-ce-1 -n default
-Start collecting, pod=dynamic-ce-1, namespace=default
-...
-please get diagnose_juicefs_1671073110.tar.gz for diagnostics
-```
-
-所有相关的信息都被收集和打包在了一个压缩包里。
-
-如果已知 Mount pod name，也可以使用诊断脚本获取所有使用该 mount pod 的所有应用 pod。假设已知 Mount pod 名为 `juicefs-ubuntu-node-3-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-octdjc`，JuiceFS CSI 驱动的组件所在 namespace 为 `kube-system`。
-
-```shell
-# 设置 juicefs csi driver 组件所在 namespace，默认为 kube-system
-$ export JUICEFS_NAMESPACE=kube-system
-# 获取使用指定 mount pod 的所有应用 pod
-$ ./diagnose.sh get-app -m juicefs-ubuntu-node-3-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-octdjc
-App pods using mount pod [juicefs-ubuntu-node-3-pvc-b94bd312-f5f7-4f46-afdb-2d1bc20371b5-octdjc]:
-namespace:
-  default
-apps:
-  dynamic-ce-5
-  dynamic-ce-2
-  dynamic-ce-3
-  dynamic-ce-4
-```
+所有相关的日志、事件都被收集和打包在了一个压缩包里，将压缩包发送给 Juicedata 进行后续支持。

--- a/docs/zh_cn/administration/troubleshooting.md
+++ b/docs/zh_cn/administration/troubleshooting.md
@@ -8,7 +8,7 @@ sidebar_position: 6
 
 ## 诊断脚本 {#csi-doctor}
 
-我们推荐使用诊断脚本 [`csi-doctor.sh`](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh) 来收集日志及相关信息，本章所介绍的排查手段中，大部分采集信息的命令，都在脚本中进行了集成，使用起来更为便捷。
+推荐使用诊断脚本 [`csi-doctor.sh`](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh) 来收集日志及相关信息，本章所介绍的排查手段中，大部分采集信息的命令，都在脚本中进行了集成，使用起来更为便捷。
 
 在集群中任意一台可以执行 `kubectl` 的节点上，安装诊断脚本：
 
@@ -222,9 +222,9 @@ kubectl -n kube-system get po -l app=juicefs-csi-controller -o jsonpath='{.items
 
 以上命令会有类似 `juicedata/juicefs-csi-driver:v0.17.1` 这样的输出，最后的 `v0.17.1` 即为 JuiceFS CSI 驱动的版本。
 
-### 诊断脚本
+### 通过诊断脚本收集信息 {#gather-information-through-diagnostic-script}
 
-对于 JuiceFS 云服务和企业版用户，可以使用 [`csi-doctor.sh`](https://github.com/juicedata/juicefs-csi-driver/blob/master/scripts/csi-doctor.sh) 来收集日志及相关信息，发送给 Juicedata 团队进行排查支持。
+可以使用[诊断脚本](#csi-doctor)来收集日志及相关信息，发送给开源社区或者 Juicedata 团队进行排查支持。
 
 假设应用 pod 名为 `dynamic-ce-1`，所在 namespace 为 `default`，用下方命令收集排查信息：
 
@@ -233,4 +233,4 @@ $ ./csi-doctor.sh collect dynamic-ce-1 -n default
 Results have been compressed to dynamic-ce-1.diagnose.tar.gz
 ```
 
-所有相关的 Kubernetes 资源、日志、事件都被收集和打包在了一个压缩包里，将此压缩包发送给 Juicedata 团队进行后续支持。
+所有相关的 Kubernetes 资源、日志、事件都被收集和打包在了一个压缩包里，然后将此压缩包发送给相关人员。

--- a/scripts/csi-doctor.sh
+++ b/scripts/csi-doctor.sh
@@ -94,7 +94,7 @@ get_app_pod() {
       break
     fi
   done
-  namespace=$(kubectl get pvc -A --field-selector=metadata.name=$pvc_name | grep -v NAME | awk '{print $1}')
+  namespace=$(kubectl get pvc -A --field-selector=metadata.name=$pvc_name -ojsonpath={..namespace})
 
   annos=$(kubectl -n $juicefs_namespace get po $mountpod -o go-template='{{range $k,$v := .metadata.annotations}}{{$v}}{{"\n"}}{{end}}')
   i=0
@@ -109,7 +109,7 @@ get_app_pod() {
   set -e
 
   declare -A app_maps
-  alls=$(kubectl get po -n $namespace | grep -v NAME | awk '{print $1}')
+  alls=$(kubectl get po -n $namespace --no-headers | awk '{print $1}')
   for po in ${alls[@]}; do
     pod_id=$(kubectl -n $namespace get po $po -o jsonpath='{.metadata.uid}')
     app_maps[$pod_id]=$po

--- a/scripts/csi-doctor.sh
+++ b/scripts/csi-doctor.sh
@@ -167,12 +167,13 @@ collect_juicefs_csi_msg() {
 
 archive() {
   set -e
-  tar -zcf "${current_dir}/diagnose_juicefs_${timestamp}.tar.gz" -C /tmp $(basename $diagnose_dir)
-  echo "Results have been saved to $(basename $diagnose_dir).tar.gz"
+  archive_file_path="${current_dir}/diagnose_juicefs_${timestamp}.tar.gz"
+  tar -zcf "${archive_file_path}" -C /tmp $(basename $diagnose_dir)
+  echo "Results have been saved to ${archive_file_path}"
 }
 
 pd_collect() {
-  echo "Start collecting logs for ${namespace} ${app}"
+  echo "Start collecting logs for ${namespace}/${app}"
   collect_mount_pod_msg
   collect_juicefs_csi_msg
   juicefs_resources
@@ -190,7 +191,6 @@ collect() {
   juicefs_namespace=${juicefs_namespace:-"kube-system"}
   current_dir=$(pwd)
   timestamp=$(date +%s)
-  # debug information was collected in folder /root/beiye-ci.beiyealiyun.diagnose (compressed as /root/beiye-ci.beiyealiyun.diagnose.tar.gz)
   diagnose_result="${app}.diagnose.tar.gz"
   diagnose_dir="/tmp/${app}.diagnose"
   mkdir -p "$diagnose_dir"


### PR DESCRIPTION
## improvements

* shorter command invocation, e.g. `csi-doctor.sh get-mount APP_POD_NAME`
* print help msg when subcommand arguments aren't provided
* raise error when arguments are invalid (by `set -e` in appropriate positions)
* improve `collect` command, see screenshots in synopsis
* rewrite grep / awk commands using -ojsonpath

## synopsis

* collect

<img width="803" alt="image" src="https://user-images.githubusercontent.com/4319104/210322813-2d0032ab-f370-44b7-974e-85f59a911748.png">

* get-app, get-mount

<img width="636" alt="image" src="https://user-images.githubusercontent.com/4319104/210322896-49c43ae5-e4bc-4823-b2af-2b3336fbc8c9.png">
