### PR TITLE
automatically select the juicefs client in need

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,29 +36,28 @@ ARG JUICEFS_MOUNT_IMAGE
 
 WORKDIR /app
 
-ENV JUICEFS_CLI=/usr/bin/juicefs
 ENV JFS_AUTO_UPGRADE=${JFS_AUTO_UPGRADE:-enabled}
 ENV JFS_MOUNT_PATH=/usr/local/juicefs/mount/jfsmount
 ENV JFSCHAN=${JFSCHAN}
 ENV JUICEFS_MOUNT_IMAGE=${JUICEFS_MOUNT_IMAGE}
 
-ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-${TARGETARCH} /tini
-RUN chmod +x /tini
-
+ADD docker/juicefs.sh /usr/local/bin/juicefs
 RUN apt-get update && apt-get install -y librados2 curl fuse procps iputils-ping strace iproute2 net-tools tcpdump lsof && \
     rm -rf /var/cache/apt/* && \
-    curl -sSL https://juicefs.com/static/juicefs -o ${JUICEFS_CLI} && chmod +x ${JUICEFS_CLI} && \
+    curl -sSL https://juicefs.com/static/juicefs -o /usr/local/bin/juicefs-ee && \
+    curl -sSL https://github.com/krallin/tini/releases/download/v0.19.0/tini-${TARGETARCH} /tini && \
+    chmod +x /tini /usr/local/bin/juicefs* && \
     mkdir -p /root/.juicefs && \
     ln -s /usr/local/bin/python /usr/bin/python && \
     mkdir /root/.acl && cp /etc/passwd /root/.acl/passwd && cp /etc/group /root/.acl/group && \
-    ln -sf /root/.acl/passwd /etc/passwd && ln -sf /root/.acl/group  /etc/group
+    ln -sf /root/.acl/passwd /etc/passwd && ln -sf /root/.acl/group /etc/group
 
 COPY --from=builder /workspace/juicefs-csi-driver/bin/juicefs-csi-driver /usr/local/bin/
-COPY --from=builder /workspace/juicefs/juicefs /usr/local/bin/
+COPY --from=builder /workspace/juicefs/juicefs /usr/local/bin/juicefs-ce
 
-RUN ln -s /usr/local/bin/juicefs /bin/mount.juicefs
+RUN ln -s /usr/local/bin/juicefs-ce /bin/mount.juicefs
 COPY THIRD-PARTY /
 
-RUN /usr/bin/juicefs version && /usr/local/bin/juicefs --version
+RUN /usr/bin/local/juicefs-ee version && /usr/local/bin/juicefs-ce --version
 
 ENTRYPOINT ["/tini", "--", "juicefs-csi-driver"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,6 +58,6 @@ COPY --from=builder /workspace/juicefs/juicefs /usr/local/bin/juicefs-ce
 RUN ln -s /usr/local/bin/juicefs-ce /bin/mount.juicefs
 COPY THIRD-PARTY /
 
-RUN /usr/bin/local/juicefs-ee version && /usr/local/bin/juicefs-ce --version
+RUN /usr/local/bin/juicefs-ee version && /usr/local/bin/juicefs-ce --version
 
 ENTRYPOINT ["/tini", "--", "juicefs-csi-driver"]

--- a/docker/ceph.Dockerfile
+++ b/docker/ceph.Dockerfile
@@ -48,21 +48,20 @@ FROM ${BASE_IMAGE}
 
 WORKDIR /app
 
-ENV JUICEFS_CLI=/usr/bin/juicefs
 ENV JFS_AUTO_UPGRADE=${JFS_AUTO_UPGRADE:-enabled}
 ENV JFS_MOUNT_PATH=/usr/local/juicefs/mount/jfsmount
 
 RUN yum install -y librados2 curl fuse && \
     rm -rf /var/cache/yum/* && \
-    curl -sSL https://juicefs.com/static/juicefs -o ${JUICEFS_CLI} && chmod +x ${JUICEFS_CLI} && \
+    curl -sSL https://juicefs.com/static/juicefs -o /usr/local/bin/juicefs-ee && chmod +x /usr/local/bin/juicefs-ee && \
     mkdir -p /root/.juicefs
 
 COPY --from=builder /workspace/juicefs-csi-driver/bin/juicefs-csi-driver /usr/local/bin/
-COPY --from=builder /workspace/juicefs/juicefs /usr/local/bin/
+COPY --from=builder /workspace/juicefs/juicefs /usr/local/bin/juicefs-ce
 
-RUN ln -s /usr/local/bin/juicefs /bin/mount.juicefs
+RUN ln -s /usr/local/bin/juicefs-ce /bin/mount.juicefs
 COPY ../THIRD-PARTY /
 
-RUN /usr/bin/juicefs version && /usr/local/bin/juicefs --version
+RUN /usr/bin/local/juicefs-ee version && /usr/local/bin/juicefs-ce --version
 
 ENTRYPOINT ["juicefs-csi-driver"]

--- a/docker/ceph.Dockerfile
+++ b/docker/ceph.Dockerfile
@@ -51,9 +51,10 @@ WORKDIR /app
 ENV JFS_AUTO_UPGRADE=${JFS_AUTO_UPGRADE:-enabled}
 ENV JFS_MOUNT_PATH=/usr/local/juicefs/mount/jfsmount
 
+ADD docker/juicefs.sh /usr/local/bin/juicefs
 RUN yum install -y librados2 curl fuse && \
     rm -rf /var/cache/yum/* && \
-    curl -sSL https://juicefs.com/static/juicefs -o /usr/local/bin/juicefs-ee && chmod +x /usr/local/bin/juicefs-ee && \
+    curl -sSL https://juicefs.com/static/juicefs -o /usr/local/bin/juicefs-ee && chmod +x /usr/local/bin/juicefs* && \
     mkdir -p /root/.juicefs
 
 COPY --from=builder /workspace/juicefs-csi-driver/bin/juicefs-csi-driver /usr/local/bin/
@@ -62,6 +63,6 @@ COPY --from=builder /workspace/juicefs/juicefs /usr/local/bin/juicefs-ce
 RUN ln -s /usr/local/bin/juicefs-ce /bin/mount.juicefs
 COPY ../THIRD-PARTY /
 
-RUN /usr/bin/local/juicefs-ee version && /usr/local/bin/juicefs-ce --version
+RUN /usr/local/bin/juicefs-ee version && /usr/local/bin/juicefs-ce --version
 
 ENTRYPOINT ["juicefs-csi-driver"]

--- a/docker/csi.Dockerfile
+++ b/docker/csi.Dockerfile
@@ -36,8 +36,8 @@ ARG JUICEFS_MOUNT_IMAGE
 ENV JUICEFS_MOUNT_IMAGE=${JUICEFS_MOUNT_IMAGE}
 
 COPY --from=builder /workspace/bin/juicefs-csi-driver /usr/local/bin/juicefs-csi-driver
-COPY --from=builder /workspace/juicefs/juicefs /usr/local/bin/juicefs
-RUN ln -s /usr/local/bin/juicefs /bin/mount.juicefs
+COPY --from=builder /workspace/juicefs/juicefs /usr/local/bin/juicefs-ce
+RUN ln -s /usr/local/bin/juicefs-ce /bin/mount.juicefs
 RUN apk add --no-cache tini
 
 ENTRYPOINT ["/sbin/tini", "--", "juicefs-csi-driver"]

--- a/docker/dev.juicefs.Dockerfile
+++ b/docker/dev.juicefs.Dockerfile
@@ -24,5 +24,5 @@ RUN apt-get update && apt-get install -y musl-tools upx-ucl librados-dev && \
 
 FROM juicedata/mount:nightly
 
-COPY --from=builder /workspace/juicefs /usr/local/bin/
-RUN /usr/local/bin/juicefs --version
+COPY --from=builder /workspace/juicefs /usr/local/bin/juicefs-ce
+RUN /usr/local/bin/juicefs-ce --version

--- a/docker/fuse.Dockerfile
+++ b/docker/fuse.Dockerfile
@@ -22,9 +22,10 @@ ENV JFS_AUTO_UPGRADE=${JFS_AUTO_UPGRADE:-enabled}
 ENV JFS_MOUNT_PATH=/usr/local/juicefs/mount/jfsmount
 ENV JFSCHAN=${JFSCHAN}
 
+ADD docker/juicefs.sh /usr/local/bin/juicefs
 RUN apt-get update && apt-get install -y librados2 curl fuse && \
     rm -rf /var/cache/apt/* && \
-    curl -sSL https://juicefs.com/static/juicefs -o /usr/local/bin/juicefs-ee && chmod +x /usr/local/bin/juicefs-ee && \
+    curl -sSL https://juicefs.com/static/juicefs -o /usr/local/bin/juicefs-ee && chmod +x /usr/local/bin/juicefs* && \
     mkdir -p /root/.juicefs && \
     ln -s /usr/local/bin/python /usr/bin/python && \
     mkdir /root/.acl && cp /etc/passwd /root/.acl/passwd && cp /etc/group /root/.acl/group && \
@@ -35,7 +36,7 @@ COPY --from=builder /workspace/juicefs/juicefs /usr/local/bin/juicefs-ce
 RUN ln -s /usr/local/bin/juicefs-ce /bin/mount.juicefs
 COPY THIRD-PARTY /
 
-RUN /usr/bin/local/juicefs-ee version && /usr/local/bin/juicefs-ce --version
+RUN /usr/local/bin/juicefs-ee version && /usr/local/bin/juicefs-ce --version
 
 ENV K8S_VERSION v1.14.8
 RUN curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/${TARGETARCH}/kubectl && chmod +x /usr/local/bin/kubectl

--- a/docker/fuse.Dockerfile
+++ b/docker/fuse.Dockerfile
@@ -18,25 +18,24 @@ ARG JFSCHAN
 
 WORKDIR /app
 
-ENV JUICEFS_CLI=/usr/bin/juicefs
 ENV JFS_AUTO_UPGRADE=${JFS_AUTO_UPGRADE:-enabled}
 ENV JFS_MOUNT_PATH=/usr/local/juicefs/mount/jfsmount
 ENV JFSCHAN=${JFSCHAN}
 
 RUN apt-get update && apt-get install -y librados2 curl fuse && \
     rm -rf /var/cache/apt/* && \
-    curl -sSL https://juicefs.com/static/juicefs -o ${JUICEFS_CLI} && chmod +x ${JUICEFS_CLI} && \
+    curl -sSL https://juicefs.com/static/juicefs -o /usr/local/bin/juicefs-ee && chmod +x /usr/local/bin/juicefs-ee && \
     mkdir -p /root/.juicefs && \
     ln -s /usr/local/bin/python /usr/bin/python && \
     mkdir /root/.acl && cp /etc/passwd /root/.acl/passwd && cp /etc/group /root/.acl/group && \
-    ln -sf /root/.acl/passwd /etc/passwd && ln -sf /root/.acl/group  /etc/group
+    ln -sf /root/.acl/passwd /etc/passwd && ln -sf /root/.acl/group /etc/group
 
-COPY --from=builder /workspace/juicefs/juicefs /usr/local/bin/
+COPY --from=builder /workspace/juicefs/juicefs /usr/local/bin/juicefs-ce
 
-RUN ln -s /usr/local/bin/juicefs /bin/mount.juicefs
+RUN ln -s /usr/local/bin/juicefs-ce /bin/mount.juicefs
 COPY THIRD-PARTY /
 
-RUN /usr/bin/juicefs version && /usr/local/bin/juicefs --version
+RUN /usr/bin/local/juicefs-ee version && /usr/local/bin/juicefs-ce --version
 
 ENV K8S_VERSION v1.14.8
 RUN curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/${TARGETARCH}/kubectl && chmod +x /usr/local/bin/kubectl

--- a/docker/juicefs.Dockerfile
+++ b/docker/juicefs.Dockerfile
@@ -37,9 +37,10 @@ ENV JFS_AUTO_UPGRADE=${JFS_AUTO_UPGRADE:-enabled}
 ENV JFS_MOUNT_PATH=/usr/local/juicefs/mount/jfsmount
 ENV JFSCHAN=${JFSCHAN}
 
+ADD docker/juicefs.sh /usr/local/bin/juicefs
 RUN apt-get update && apt-get install -y librados2 curl fuse procps iputils-ping strace iproute2 net-tools tcpdump lsof && \
     rm -rf /var/cache/apt/* && \
-    curl -sSL https://juicefs.com/static/juicefs -o /usr/local/bin/juicefs-ee && chmod +x /usr/local/bin/juicefs-ee && \
+    curl -sSL https://juicefs.com/static/juicefs -o /usr/local/bin/juicefs-ee && chmod +x /usr/local/bin/juicefs* && \
     mkdir -p /root/.juicefs && \
     ln -s /usr/local/bin/python /usr/bin/python && \
     mkdir /root/.acl && cp /etc/passwd /root/.acl/passwd && cp /etc/group /root/.acl/group && \
@@ -48,4 +49,4 @@ RUN apt-get update && apt-get install -y librados2 curl fuse procps iputils-ping
 RUN ln -s /usr/local/bin/juicefs-ce /bin/mount.juicefs
 COPY THIRD-PARTY /
 
-RUN /usr/bin/local/juicefs-ee version && /usr/local/bin/juicefs-ce --version
+RUN /usr/local/bin/juicefs-ee version && /usr/local/bin/juicefs-ce --version

--- a/docker/juicefs.Dockerfile
+++ b/docker/juicefs.Dockerfile
@@ -33,20 +33,19 @@ ARG JFSCHAN
 WORKDIR /app
 COPY --from=builder /workspace/juicefs/juicefs /usr/local/bin/
 
-ENV JUICEFS_CLI=/usr/bin/juicefs
 ENV JFS_AUTO_UPGRADE=${JFS_AUTO_UPGRADE:-enabled}
 ENV JFS_MOUNT_PATH=/usr/local/juicefs/mount/jfsmount
 ENV JFSCHAN=${JFSCHAN}
 
 RUN apt-get update && apt-get install -y librados2 curl fuse procps iputils-ping strace iproute2 net-tools tcpdump lsof && \
     rm -rf /var/cache/apt/* && \
-    curl -sSL https://juicefs.com/static/juicefs -o ${JUICEFS_CLI} && chmod +x ${JUICEFS_CLI} && \
+    curl -sSL https://juicefs.com/static/juicefs -o /usr/local/bin/juicefs-ee && chmod +x /usr/local/bin/juicefs-ee && \
     mkdir -p /root/.juicefs && \
     ln -s /usr/local/bin/python /usr/bin/python && \
     mkdir /root/.acl && cp /etc/passwd /root/.acl/passwd && cp /etc/group /root/.acl/group && \
-    ln -sf /root/.acl/passwd /etc/passwd && ln -sf /root/.acl/group  /etc/group
+    ln -sf /root/.acl/passwd /etc/passwd && ln -sf /root/.acl/group /etc/group
 
-RUN ln -s /usr/local/bin/juicefs /bin/mount.juicefs
+RUN ln -s /usr/local/bin/juicefs-ce /bin/mount.juicefs
 COPY THIRD-PARTY /
 
-RUN /usr/bin/juicefs version && /usr/local/bin/juicefs --version
+RUN /usr/bin/local/juicefs-ee version && /usr/local/bin/juicefs-ce --version

--- a/docker/juicefs.sh
+++ b/docker/juicefs.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 cmdline=$(cat /proc/1/cmdline | tr -d '\0')
-any_mount_running=$(echo $cmdline | grep -ao '/mount.juicefs')
+any_mount_running=$(echo "$cmdline" | grep -ao '/mount.juicefs')
 if [[ -z "$any_mount_running" ]]
 then
   echo 'Cannot infer juicefs client from PID 1, use the following instead:'
@@ -10,7 +10,7 @@ then
   exit 0
 fi
 ee_mount_path='/sbin/mount.juicefs'
-ee_is_running=$(echo $cmdline | grep -ao "$ee_mount_path")
+ee_is_running=$(echo "$cmdline" | grep -ao "$ee_mount_path")
 if [[ ! -z "$ee_is_running" ]]
 then
   exec /usr/local/bin/juicefs-ee $@

--- a/docker/juicefs.sh
+++ b/docker/juicefs.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 
+cmdline=$(cat /proc/1/cmdline | tr -d '\0')
+any_mount_running=$(echo $cmdline | grep -ao '/mount.juicefs')
+if [[ -z "$any_mount_running" ]]
+then
+  echo 'Cannot infer juicefs client from PID 1, use the following instead:'
+  echo '/usr/local/bin/juicefs-ce'
+  echo '/usr/local/bin/juicefs-ee'
+  exit 0
+fi
 ee_mount_path='/sbin/mount.juicefs'
-ee_is_running=$(grep -ao "$ee_mount_path" /proc/1/cmdline)
+ee_is_running=$(echo $cmdline | grep -ao "$ee_mount_path")
 if [[ ! -z "$ee_is_running" ]]
 then
   exec /usr/local/bin/juicefs-ee $@

--- a/docker/juicefs.sh
+++ b/docker/juicefs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+ee_mount_path='/sbin/mount.juicefs'
+ee_is_running=$(grep -ao "$ee_mount_path" /proc/1/cmdline)
+if [[ ! -z "$ee_is_running" ]]
+then
+  exec /usr/local/bin/juicefs-ee $@
+else
+  exec /usr/local/bin/juicefs-ce $@
+fi

--- a/juicefs-cli/Dockerfile
+++ b/juicefs-cli/Dockerfile
@@ -1,8 +1,0 @@
-FROM python
-
-ENV JUICEFS_CLI=/bin/juicefs
-RUN curl --silent --location https://juicefs.com/static/juicefs -o ${JUICEFS_CLI}
-RUN chmod +x ${JUICEFS_CLI}
-RUN juicefs version
-
-ENTRYPOINT ["juicefs"]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,8 +51,8 @@ var (
 	PodMountBase    = "/jfs"
 	MountBase       = "/var/lib/jfs"
 	FsType          = "juicefs"
-	CliPath         = "/usr/bin/juicefs"
-	CeCliPath       = "/usr/local/bin/juicefs"
+	CliPath         = "/usr/local/bin/juicefs-ee"
+	CeCliPath       = "/usr/local/bin/juicefs-ce"
 	CeMountPath     = "/bin/mount.juicefs"
 	JfsMountPath    = "/sbin/mount.juicefs"
 )

--- a/pkg/juicefs/mount/builder/pod.go
+++ b/pkg/juicefs/mount/builder/pod.go
@@ -167,7 +167,8 @@ func (r *Builder) getCommand() string {
 			}
 		}
 		mountArgs = append(mountArgs, "-o", strings.Join(options, ","))
-		cmd = strings.Join(mountArgs, " ")
+		rmcmd := fmt.Sprintf("rm %s; ", config.JfsMountPath)
+		cmd = rmcmd + strings.Join(mountArgs, " ")
 	} else {
 		klog.V(5).Infof("Mount: mount %v at %v", util.StripPasswd(r.jfsSetting.Source), r.jfsSetting.MountPath)
 		mountArgs := []string{config.JfsMountPath, r.jfsSetting.Source, r.jfsSetting.MountPath}
@@ -177,7 +178,8 @@ func (r *Builder) getCommand() string {
 		}
 		mountOptions = append(mountOptions, options...)
 		mountArgs = append(mountArgs, "-o", strings.Join(mountOptions, ","))
-		cmd = strings.Join(mountArgs, " ")
+		rmcmd := fmt.Sprintf("rm %s; ", config.CeMountPath)
+		cmd = rmcmd + strings.Join(mountArgs, " ")
 	}
 	return util.QuoteForShell(cmd)
 }

--- a/pkg/juicefs/mount/builder/pod.go
+++ b/pkg/juicefs/mount/builder/pod.go
@@ -167,8 +167,7 @@ func (r *Builder) getCommand() string {
 			}
 		}
 		mountArgs = append(mountArgs, "-o", strings.Join(options, ","))
-		rmcmd := fmt.Sprintf("rm %s; ", config.JfsMountPath)
-		cmd = rmcmd + strings.Join(mountArgs, " ")
+		cmd = strings.Join(mountArgs, " ")
 	} else {
 		klog.V(5).Infof("Mount: mount %v at %v", util.StripPasswd(r.jfsSetting.Source), r.jfsSetting.MountPath)
 		mountArgs := []string{config.JfsMountPath, r.jfsSetting.Source, r.jfsSetting.MountPath}
@@ -178,8 +177,7 @@ func (r *Builder) getCommand() string {
 		}
 		mountOptions = append(mountOptions, options...)
 		mountArgs = append(mountArgs, "-o", strings.Join(mountOptions, ","))
-		rmcmd := fmt.Sprintf("rm %s; ", config.CeMountPath)
-		cmd = rmcmd + strings.Join(mountArgs, " ")
+		cmd = strings.Join(mountArgs, " ")
 	}
 	return util.QuoteForShell(cmd)
 }


### PR DESCRIPTION
**PR halted**, need further discussion, CE & EE may develop their own respective docker image, obviate the need for this pr.

---

two methods can be considered:

* modify `PATH` so that `juicefs` always resolves to the one in use
* remove the unused juicefs client, users won't have access to the other one at all
* (currently implemented in this pr) use a wrapper shell script

closes https://github.com/juicedata/juicefs-csi-driver/issues/566