### PR TITLE
bring multi-pv support to get-mount, add get-oplog command

### DIFF
--- a/docs/en/administration/troubleshooting.md
+++ b/docs/en/administration/troubleshooting.md
@@ -17,6 +17,8 @@ wget https://raw.githubusercontent.com/juicedata/juicefs-csi-driver/master/scrip
 chmod a+x csi-doctor.sh
 ```
 
+If kubectl is renamed in your environment (folks use this method to manage multiple Kubernetes clusters), or put elsewhere other than `PATH`, you can easily match this by editing the script, and change the `$kbctl` variable.
+
 A commonly used feature is obtaining mount pod information. Assuming application pod being `my-app-pod` in namespace `default`, to obtain the mount pod that accompanies the application pod:
 
 ```shell
@@ -191,6 +193,8 @@ Under JuiceFS file system root, there are some pseudo files that provide special
 
 * `cat /jfs/.accesslog` prints access logs in real time, use this to analyze file system access patterns. See [Access log (Community Edition)](https://juicefs.com/docs/community/fault_diagnosis_and_analysis/#access-log) and [Access log (Cloud Service)](https://juicefs.com/docs/cloud/administration/fault_diagnosis_and_analysis/#oplog)
 * `cat /jfs/.stats` prints real-time statistics for this JuiceFS mount point. When performance isn't ideal, use this to find out the culprit. See [Real-time statistics (Community Edition)](https://juicefs.com/docs/community/performance_evaluation_guide/#juicefs-stats) and [Real-time statistics (Cloud Service)](https://juicefs.com/docs/cloud/administration/fault_diagnosis_and_analysis/#real-time-statistics)
+
+Obtaining file system access log for application pods can be wearisome, you'll need to first locate the mount pod for the application pod, and then enter the mount pod to run the corresponding commands, use [`csi-doctor.sh get-oplog APP_POD_NAME`](#csi-doctor) command to avoid the toil below.
 
 Inside mount pod, JuiceFS root is mounted at a directory that looks like `/var/lib/juicefs/volume/pvc-xxx-xxx-xxx-xxx-xxx-xxx`, and then bind to container via the Kubernetes bind mechanism. So for a given application pod, you can find its JuiceFS mount point on host using below commands, and access its pseudo files:
 

--- a/docs/zh_cn/administration/troubleshooting.md
+++ b/docs/zh_cn/administration/troubleshooting.md
@@ -17,6 +17,8 @@ wget https://raw.githubusercontent.com/juicedata/juicefs-csi-driver/master/scrip
 chmod a+x csi-doctor.sh
 ```
 
+如果在你的运行环境中，kubectl 被重命名（比方说需要管理多个 Kubernetes 集群时，常常用不同 alias 来调用不同集群的 kubectl），或者并未放在 `PATH` 下，你也可以方便地修改脚步，将 `$kbctl` 变量替换为实际需要运行的 kubectl。
+
 诊断脚本中最为常用的功能，就是方便地获取 Mount Pod 相关信息。假设应用 Pod 为 `default` 命名空间下的 `my-app-pod`：
 
 ```shell
@@ -191,6 +193,8 @@ JuiceFS 文件系统的根目录下有一些提供特殊功能的隐藏文件，
 
 * `cat /jfs/.accesslog` 实时打印文件系统的访问日志，用于分析应用程序对文件系统的访问模式，详见[「访问日志（社区版）」](https://juicefs.com/docs/zh/community/fault_diagnosis_and_analysis#access-log)和[「访问日志（云服务）」](https://juicefs.com/docs/zh/cloud/administration/fault_diagnosis_and_analysis#oplog)。
 * `cat /jfs/.stats` 打印文件系统的实时统计数据，当 JuiceFS 性能不佳时，可以通过实时统计数据判断问题所在。详见[「实时统计数据（社区版）」](https://juicefs.com/docs/zh/community/performance_evaluation_guide/#juicefs-stats)和[「实时统计数据（云服务）」](https://juicefs.com/docs/zh/cloud/administration/fault_diagnosis_and_analysis#stats)。
+
+在 CSI 驱动下获取应用的访问日志，步骤稍显繁琐，你需要先找到应用容器对应的 Mount Pod，再进入容器执行打印日志的命令。推荐直接使用 [`csi-doctor.sh get-oplog APP_POD_NAME`](#csi-doctor) 快速获得相应的命令，避免使用下方繁琐的手动步骤。
 
 Mount Pod 会将 JuiceFS 根目录挂载到形如 `/var/lib/juicefs/volume/pvc-xxx-xxx-xxx-xxx-xxx-xxx` 的目录下，再通过 Kubernetes 的 bind 机制映射到容器内，因此，对于给定应用 Pod，你可以参考下方命令，找到其 PV 的宿主机挂载点，然后查看隐藏文件：
 


### PR DESCRIPTION
get-oplog synopsis:

```shell
$ /root/csi-doctor.sh get-oplog juicefs-app
kubectl -n kube-system exec -it -c jfs-mount juicefs-chaos-k8s-003-pvc-b39ff1c3-5683-4a6d-bddf-579f7ff6f022-xtlxsp -- cat /jfs/pvc-b39ff1c3-5683-4a6d-bddf-579f7ff6f022-xtlxsp/.accesslog
kubectl -n kube-system exec -it -c jfs-mount juicefs-chaos-k8s-003-juicefs-pv-rysqzd -- cat /jfs/juicefs-pv-rysqzd/.accesslog
```