### PR TITLE
Add Documentation for enabling encryption while using the Helm Chart …

### DIFF
--- a/docs/en/security/encryption.md
+++ b/docs/en/security/encryption.md
@@ -14,6 +14,14 @@ kubectl -n kube-system patch ds juicefs-csi-node --patch '{"spec": {"template": 
 kubectl -n kube-system get pod -l app.kubernetes.io/name=juicefs-csi-driver
 ```
 
+Using Helm to install the CSI driver:
+```
+# values.yaml
+node:
+  additionalArguments:
+  - "--format-in-pod=true"
+```
+
 ## Set private key configuration in Secret
 
 ### Community edition


### PR DESCRIPTION
…for the CSI Driver

Documentation belongs to https://github.com/juicedata/charts/pull/45