### PR TITLE
adaptation for upgrade of ceph sdk

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - fix/image_build
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - fix/image_build
   schedule:
     - cron: "0 0 * * *"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,7 @@ ENV JUICEFS_EE_MOUNT_IMAGE=${JUICEFS_EE_MOUNT_IMAGE}
 ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-${TARGETARCH} /tini
 RUN chmod +x /tini
 
-RUN apt update && apt install -y software-properties-common && apt update && \
+RUN apt update && apt install -y software-properties-common wget gnupg gnupg2 && apt update && \
     wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
     apt-add-repository 'deb https://download.ceph.com/debian-pacific/ buster main' && \
     apt update

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,11 @@ ARG JUICEFS_REPO_BRANCH=main
 ARG JUICEFS_REPO_REF=${JUICEFS_REPO_BRANCH}
 ARG JUICEFS_CSI_REPO_REF=master
 
+RUN apt update && apt install -y software-properties-common && apt update && \
+    wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
+    apt-add-repository 'deb https://download.ceph.com/debian-pacific/ buster main' && \
+    apt update
+
 WORKDIR /workspace
 ENV GOPROXY=${GOPROXY:-https://proxy.golang.org}
 RUN apt-get update && apt-get install -y musl-tools upx-ucl librados-dev libcephfs-dev librbd-dev && \
@@ -45,7 +50,12 @@ ENV JUICEFS_EE_MOUNT_IMAGE=${JUICEFS_EE_MOUNT_IMAGE}
 ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-${TARGETARCH} /tini
 RUN chmod +x /tini
 
-RUN apt-get update && apt-get install -y librados2 curl fuse procps iputils-ping strace iproute2 net-tools tcpdump lsof && \
+RUN apt update && apt install -y software-properties-common && apt update && \
+    wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
+    apt-add-repository 'deb https://download.ceph.com/debian-pacific/ buster main' && \
+    apt update
+
+RUN apt-get update && apt-get install -y librados2 librados-dev libcephfs-dev librbd-dev curl fuse procps iputils-ping strace iproute2 net-tools tcpdump lsof && \
     rm -rf /var/cache/apt/* && \
     curl -sSL https://juicefs.com/static/juicefs -o ${JUICEFS_CLI} && chmod +x ${JUICEFS_CLI} && \
     mkdir -p /root/.juicefs && \

--- a/docker/ce.juicefs.Dockerfile
+++ b/docker/ce.juicefs.Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /workspace
 ENV GOPROXY=${GOPROXY:-https://proxy.golang.org}
 RUN apt-get update && apt-get install -y musl-tools upx-ucl librados-dev libcephfs-dev librbd-dev && \
     cd /workspace && git clone --branch=$JUICEFS_REPO_BRANCH $JUICEFS_REPO_URL && \
-    cd juicefs && git checkout $JUICEFS_REPO_REF && go get github.com/ceph/go-ceph@v0.4.0 && \
+    cd juicefs && git checkout $JUICEFS_REPO_REF && go get github.com/ceph/go-ceph@v0.4.0 && go mod tidy && \
     make juicefs.ceph && mv juicefs.ceph juicefs && mv juicefs /usr/local/bin/juicefs
 
 RUN ln -s /usr/local/bin/juicefs /bin/mount.juicefs && /usr/local/bin/juicefs --version

--- a/docker/ce.juicefs.Dockerfile
+++ b/docker/ce.juicefs.Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /workspace
 ENV GOPROXY=${GOPROXY:-https://proxy.golang.org}
 RUN apt-get update && apt-get install -y musl-tools upx-ucl librados-dev libcephfs-dev librbd-dev && \
     cd /workspace && git clone --branch=$JUICEFS_REPO_BRANCH $JUICEFS_REPO_URL && \
-    cd juicefs && git checkout $JUICEFS_REPO_REF && go get github.com/ceph/go-ceph@v0.4.0 && go mod tidy && \
+    cd juicefs && git checkout $JUICEFS_REPO_REF && go get github.com/ceph/go-ceph@v0.4.0 && \
     make juicefs.ceph && mv juicefs.ceph juicefs && mv juicefs /usr/local/bin/juicefs
 
 RUN ln -s /usr/local/bin/juicefs /bin/mount.juicefs && /usr/local/bin/juicefs --version

--- a/docker/ce.juicefs.Dockerfile
+++ b/docker/ce.juicefs.Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /workspace
 ENV GOPROXY=${GOPROXY:-https://proxy.golang.org}
 RUN apt-get update && apt-get install -y musl-tools upx-ucl librados-dev libcephfs-dev librbd-dev && \
     cd /workspace && git clone --branch=$JUICEFS_REPO_BRANCH $JUICEFS_REPO_URL && \
-    cd juicefs && git checkout $JUICEFS_REPO_REF && make juicefs.ceph && mv juicefs.ceph juicefs && \
-    mv juicefs /usr/local/bin/juicefs
+    cd juicefs && git checkout $JUICEFS_REPO_REF && go get github.com/ceph/go-ceph@v0.4.0 && go mod tidy && \
+    make juicefs.ceph && mv juicefs.ceph juicefs && mv juicefs /usr/local/bin/juicefs
 
 RUN ln -s /usr/local/bin/juicefs /bin/mount.juicefs && /usr/local/bin/juicefs --version

--- a/docker/ceph-0.18.juicefs.Dockerfile
+++ b/docker/ceph-0.18.juicefs.Dockerfile
@@ -1,0 +1,34 @@
+#Copyright 2023 Juicedata Inc
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
+FROM golang:1.18-buster
+
+ARG GOPROXY
+ARG JUICEFS_REPO_URL=https://github.com/juicedata/juicefs
+ARG JUICEFS_REPO_BRANCH=main
+ARG JUICEFS_REPO_REF=${JUICEFS_REPO_BRANCH}
+
+RUN apt update && apt install -y software-properties-common && apt update && \
+    wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
+    apt-add-repository 'deb https://download.ceph.com/debian-pacific/ buster main' && \
+    apt update
+
+WORKDIR /workspace
+ENV GOPROXY=${GOPROXY:-https://proxy.golang.org}
+RUN apt-get update && apt-get install -y musl-tools upx-ucl librados-dev libcephfs-dev librbd-dev && \
+    cd /workspace && git clone --branch=$JUICEFS_REPO_BRANCH $JUICEFS_REPO_URL && \
+    cd juicefs && git checkout $JUICEFS_REPO_REF && make juicefs.ceph && mv juicefs.ceph juicefs && \
+    mv juicefs /usr/local/bin/juicefs
+
+RUN ln -s /usr/local/bin/juicefs /bin/mount.juicefs && /usr/local/bin/juicefs --version

--- a/docker/fuse.Dockerfile
+++ b/docker/fuse.Dockerfile
@@ -4,6 +4,11 @@ ARG GOPROXY
 ARG JUICEFS_REPO_BRANCH=main
 ARG JUICEFS_REPO_REF=${JUICEFS_REPO_BRANCH}
 
+RUN apt update && apt install -y software-properties-common wget gnupg gnupg2 && apt update && \
+    wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
+    apt-add-repository 'deb https://download.ceph.com/debian-pacific/ buster main' && \
+    apt update
+
 WORKDIR /workspace
 ENV GOPROXY=${GOPROXY:-https://proxy.golang.org}
 RUN apt-get update && apt-get install -y musl-tools upx-ucl librados-dev libcephfs-dev librbd-dev && \
@@ -23,7 +28,11 @@ ENV JFS_AUTO_UPGRADE=${JFS_AUTO_UPGRADE:-enabled}
 ENV JFS_MOUNT_PATH=/usr/local/juicefs/mount/jfsmount
 ENV JFSCHAN=${JFSCHAN}
 
-RUN apt-get update && apt-get install -y librados2 curl fuse && \
+RUN apt update && apt install -y software-properties-common wget gnupg gnupg2 && apt update && \
+    wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
+    apt-add-repository 'deb https://download.ceph.com/debian-pacific/ buster main' && \
+    apt update
+RUN apt-get update && apt-get install -y librados2 curl fuse librados-dev libcephfs-dev librbd-dev && \
     rm -rf /var/cache/apt/* && \
     curl -sSL https://juicefs.com/static/juicefs -o ${JUICEFS_CLI} && chmod +x ${JUICEFS_CLI} && \
     mkdir -p /root/.juicefs && \


### PR DESCRIPTION
Juicefs upgrade ceph sdk from 0.4 to 0.18, PR: https://github.com/juicedata/juicefs/pull/3595

1. mount pod needs to be forward compatible, edit ceph sdk to 0.4 in `ce.juicefs.Dockerfile` (mount pod image)
2. adapt 0.18 ceph sdk in `Dockerfile` (csi image)
3. offer another image of mount pod that has 0.18 ceph sdk, seeing `ceph-0.18.juicefs.Dockerfile`, build image after juicefs v1.1.0 released.