### PR TITLE
fallback to apiserver if cannot connect to kubelet

### DIFF
--- a/.github/scripts/deploy-csi-in-k8s.sh
+++ b/.github/scripts/deploy-csi-in-k8s.sh
@@ -7,7 +7,7 @@ function main() {
   echo "withoutKubelet: " $withoutKubelet
   if [ $withoutKubelet == "withoutkubelet" ]; then
     deploy_csi_without_kubelet $deployMode
-  if [ $deployMode == "webhook" ]; then
+  elif [ $deployMode == "webhook" ]; then
     deploy_webhook
   elif [ $deployMode == "webhook-provisioner" ]; then
     deploy_webhook_provisioner
@@ -166,4 +166,4 @@ function deploy_webhook_provisioner() {
     sleep 5
   done
 }
-main $1
+main $1 $2

--- a/.github/scripts/deploy-csi-in-k8s.sh
+++ b/.github/scripts/deploy-csi-in-k8s.sh
@@ -2,7 +2,11 @@
 
 function main() {
   deployMode=$1
+  withoutKubelet=$2
   echo "deployMode: " $deployMode
+  echo "withoutKubelet: " $withoutKubelet
+  if [ $withoutKubelet == "withoutkubelet" ]; then
+    deploy_csi_without_kubelet $deployMode
   if [ $deployMode == "webhook" ]; then
     deploy_webhook
   elif [ $deployMode == "webhook-provisioner" ]; then
@@ -17,6 +21,43 @@ function deploy_csi() {
   sudo microk8s.kubectl label ns default juicefs.com/enable-injection=false
   deployMode=$1
   sudo kustomize build ${GITHUB_WORKSPACE}/deploy/kubernetes/csi-ci/$deployMode | sed -e "s@juicedata/juicefs-csi-driver.*\$@juicedata/juicefs-csi-driver:${dev_tag}@g" \
+    -e 's@/var/lib/kubelet@/var/snap/microk8s/common/var/lib/kubelet@g' | sudo microk8s.kubectl apply -f -
+  # Wait until the deploy finish
+  timeout=0
+  while true; do
+    if [ $timeout -gt 60 ]; then
+      echo "JuiceFS CSI is not ready within 5min."
+      node_pod=$(sudo microk8s.kubectl -n kube-system get pods -o name | grep juicefs-csi-node | cut -d/ -f2)
+      sudo microk8s.kubectl -n kube-system describe po $node_pod
+      ctrl_pod=$(sudo microk8s.kubectl -n kube-system get pods -o name | grep juicefs-csi-controller | cut -d/ -f2)
+      sudo microk8s.kubectl -n kube-system describe po $ctrl_pod
+      exit 1
+    fi
+    timeout=$(expr $timeout + 1)
+    echo "Wait JuiceFS CSI to be ready ..."
+    # The juicefs-csi-{node|controller} pods' containers should be all ready
+    all_count=$(sudo microk8s.kubectl -n kube-system get pods | grep juicefs-csi | wc -l)
+    count=$(sudo microk8s.kubectl -n kube-system get pods | grep juicefs-csi | grep Running | awk '{print $2}' | tr '/' '-' | bc | grep '^0$' | wc -l)
+    if [ $count = 3 ] && [ $all_count = 3 ]; then
+      node_pod=$(sudo microk8s.kubectl -n kube-system get pods | grep Running | grep juicefs-csi-node | awk '{print $1}' | cut -d/ -f2)
+      echo "JUICEFS_CSI_NODE_POD:" $node_pod
+      echo "JUICEFS_CSI_NODE_POD=$node_pod" >>$GITHUB_ENV
+      sudo microk8s.kubectl cp kube-system/$node_pod:/usr/local/bin/juicefs /usr/local/bin/juicefs -c juicefs-plugin &&
+        sudo chmod a+x /usr/local/bin/juicefs && juicefs -V
+      sudo microk8s.kubectl cp kube-system/$node_pod:/usr/bin/juicefs /usr/bin/juicefs -c juicefs-plugin &&
+        sudo chmod a+x /usr/bin/juicefs && /usr/bin/juicefs version
+      echo "JuiceFS CSI is ready."
+      break
+    fi
+    sleep 5
+  done
+}
+
+function deploy_csi_without_kubelet() {
+  sudo microk8s.kubectl delete -f ${GITHUB_WORKSPACE}/deploy/webhook.yaml
+  sudo microk8s.kubectl label ns default juicefs.com/enable-injection=false
+  deployMode=$1
+  sudo kustomize build ${GITHUB_WORKSPACE}/deploy/kubernetes/csi-ci/without-kubelet/$deployMode | sed -e "s@juicedata/juicefs-csi-driver.*\$@juicedata/juicefs-csi-driver:${dev_tag}@g" \
     -e 's@/var/lib/kubelet@/var/snap/microk8s/common/var/lib/kubelet@g' | sudo microk8s.kubectl apply -f -
   # Wait until the deploy finish
   timeout=0

--- a/.github/scripts/e2e-test.py
+++ b/.github/scripts/e2e-test.py
@@ -85,7 +85,8 @@ if __name__ == "__main__":
                 test_share_mount()
                 test_delete_one()
                 test_delete_all()
-                test_delete_pvc()
+                test_dynamic_delete_pod()
+                test_static_delete_pod()
 
             elif test_mode == "pod-provisioner":
                 test_dynamic_mount_image()
@@ -94,7 +95,8 @@ if __name__ == "__main__":
                 test_dynamic_pvc_delete_not_last_with_path_pattern()
                 test_delete_one()
                 test_delete_all()
-                test_delete_pvc()
+                test_dynamic_delete_pod()
+                test_static_delete_pod()
 
             elif test_mode == "webhook":
                 test_webhook_two_volume()

--- a/.github/scripts/e2e-test.py
+++ b/.github/scripts/e2e-test.py
@@ -83,12 +83,18 @@ if __name__ == "__main__":
 
             elif test_mode == "pod-mount-share":
                 test_share_mount()
+                test_delete_one()
+                test_delete_all()
+                test_delete_pvc()
 
             elif test_mode == "pod-provisioner":
                 test_dynamic_mount_image()
                 test_path_pattern_in_storage_class()
                 test_dynamic_pvc_delete_with_path_pattern()
                 test_dynamic_pvc_delete_not_last_with_path_pattern()
+                test_delete_one()
+                test_delete_all()
+                test_delete_pvc()
 
             elif test_mode == "webhook":
                 test_webhook_two_volume()

--- a/.github/scripts/test_case.py
+++ b/.github/scripts/test_case.py
@@ -361,13 +361,14 @@ def test_delete_one():
         raise Exception("Pods of deployment {} are not ready within 5 min.".format(deployment.name))
 
     volume_id = pvc.get_volume_id()
-    test_mode = os.getenv("TEST_MODE")
-    if test_mode == "pod-mount-share":
-        volume_id = STORAGECLASS_NAME
     LOG.info("Get volume_id {}".format(volume_id))
 
     # check mount pod refs
-    mount_pod_name = get_only_mount_pod_name(volume_id)
+    unique_id = volume_id
+    test_mode = os.getenv("TEST_MODE")
+    if test_mode == "pod-mount-share":
+        unique_id = STORAGECLASS_NAME
+    mount_pod_name = get_only_mount_pod_name(unique_id)
     LOG.info("Check mount pod {} refs.".format(mount_pod_name))
     result = check_mount_pod_refs(mount_pod_name, 3)
     if not result:
@@ -419,13 +420,14 @@ def test_delete_all():
         raise Exception("Pods of deployment {} are not ready within 5 min.".format(deployment.name))
 
     volume_id = pvc.get_volume_id()
-    test_mode = os.getenv("TEST_MODE")
-    if test_mode == "pod-mount-share":
-        volume_id = STORAGECLASS_NAME
     LOG.info("Get volume_id {}".format(volume_id))
 
     # check mount pod refs
-    mount_pod_name = get_only_mount_pod_name(volume_id)
+    unique_id = volume_id
+    test_mode = os.getenv("TEST_MODE")
+    if test_mode == "pod-mount-share":
+        unique_id = STORAGECLASS_NAME
+    mount_pod_name = get_only_mount_pod_name(unique_id)
     LOG.info("Check mount pod {} refs.".format(mount_pod_name))
     result = check_mount_pod_refs(mount_pod_name, 3)
     if not result:
@@ -586,9 +588,6 @@ def test_dynamic_delete_pod():
     # check mount point
     LOG.info("Check mount point..")
     volume_id = pvc.get_volume_id()
-    test_mode = os.getenv("TEST_MODE")
-    if test_mode == "pod-mount-share":
-        volume_id = STORAGECLASS_NAME
     LOG.info("Get volume_id {}".format(volume_id))
     check_path = volume_id + "/out.txt"
     result = check_mount_point(check_path)
@@ -596,7 +595,11 @@ def test_dynamic_delete_pod():
         raise Exception("mount Point of /jfs/{}/out.txt are not ready within 5 min.".format(volume_id))
 
     LOG.info("Mount pod delete..")
-    mount_pod = Pod(name=get_only_mount_pod_name(volume_id), deployment_name="", replicas=1, namespace=KUBE_SYSTEM)
+    unique_id = volume_id
+    test_mode = os.getenv("TEST_MODE")
+    if test_mode == "pod-mount-share":
+        unique_id = STORAGECLASS_NAME
+    mount_pod = Pod(name=get_only_mount_pod_name(unique_id), deployment_name="", replicas=1, namespace=KUBE_SYSTEM)
     mount_pod.delete()
     LOG.info("Wait for a sec..")
     time.sleep(5)

--- a/.github/scripts/test_case.py
+++ b/.github/scripts/test_case.py
@@ -361,6 +361,9 @@ def test_delete_one():
         raise Exception("Pods of deployment {} are not ready within 5 min.".format(deployment.name))
 
     volume_id = pvc.get_volume_id()
+    test_mode = os.getenv("TEST_MODE")
+    if test_mode == "pod-mount-share":
+        volume_id = STORAGECLASS_NAME
     LOG.info("Get volume_id {}".format(volume_id))
 
     # check mount pod refs
@@ -416,6 +419,9 @@ def test_delete_all():
         raise Exception("Pods of deployment {} are not ready within 5 min.".format(deployment.name))
 
     volume_id = pvc.get_volume_id()
+    test_mode = os.getenv("TEST_MODE")
+    if test_mode == "pod-mount-share":
+        volume_id = STORAGECLASS_NAME
     LOG.info("Get volume_id {}".format(volume_id))
 
     # check mount pod refs
@@ -580,6 +586,9 @@ def test_dynamic_delete_pod():
     # check mount point
     LOG.info("Check mount point..")
     volume_id = pvc.get_volume_id()
+    test_mode = os.getenv("TEST_MODE")
+    if test_mode == "pod-mount-share":
+        volume_id = STORAGECLASS_NAME
     LOG.info("Get volume_id {}".format(volume_id))
     check_path = volume_id + "/out.txt"
     result = check_mount_point(check_path)

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -117,7 +117,6 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/.github/scripts/
           python3 e2e-test.py
-          exit 1
       - name: Setup upterm session
         if: ${{ failure() }}
         timeout-minutes: 60
@@ -163,7 +162,6 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/.github/scripts/
           python3 e2e-test.py
-          exit 1
       - name: Setup upterm session
         if: ${{ failure() }}
         timeout-minutes: 60

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -117,6 +117,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/.github/scripts/
           python3 e2e-test.py
+          exit 1
       - name: Setup upterm session
         if: ${{ failure() }}
         timeout-minutes: 60
@@ -162,6 +163,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/.github/scripts/
           python3 e2e-test.py
+          exit 1
       - name: Setup upterm session
         if: ${{ failure() }}
         timeout-minutes: 60

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -113,7 +113,7 @@ jobs:
           JUICEFS_NAME: "ce-secret"
           JUICEFS_META_URL: "redis://redis.default.svc.cluster.local:6379/1"
           JUICEFS_MODE: ce
-          TEST_MODE: ${{matrix.wtestmode}}
+          TEST_MODE: ${{matrix.testmode}}
         run: |
           cd ${GITHUB_WORKSPACE}/.github/scripts/
           python3 e2e-test.py
@@ -158,7 +158,7 @@ jobs:
           JUICEFS_NAME: "csi-ci"
           JUICEFS_META_URL: ""
           JUICEFS_MODE: "ee"
-          TEST_MODE: ${{matrix.wtestmode}}
+          TEST_MODE: ${{matrix.testmode}}
         run: |
           cd ${GITHUB_WORKSPACE}/.github/scripts/
           python3 e2e-test.py

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -98,7 +98,7 @@ jobs:
           make push-dev
       - name: Deploy JuiceFS CSI
         run: |
-          testmode=${{matrix.wtestmode}}
+          testmode=${{matrix.testmode}}
           cd ${GITHUB_WORKSPACE}
           dev_tag=dev-$(git describe --always)
           echo "Dev tag is: " $dev_tag
@@ -142,7 +142,7 @@ jobs:
           make push-dev
       - name: Deploy JuiceFS CSI
         run: |
-          testmode=${{matrix.wtestmode}}
+          testmode=${{matrix.testmode}}
           cd ${GITHUB_WORKSPACE}
           dev_tag=dev-$(git describe --always)
           echo "Dev tag is: " $dev_tag

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -69,8 +69,103 @@ jobs:
           value=`printf '%s\n' "${testmode[@]}" | jq -R . | jq -cs .`
           echo "value: $value"
           echo "matrix=$value" >> $GITHUB_OUTPUT
+          
+          wtestmode=("pod" "pod-mount-share" "pod-provisioner")
+          value=`printf '%s\n' "${wtestmode[@]}" | jq -R . | jq -cs .`
+          echo "value without kubelet: $value"
+          echo "wmatrix=$value" >> $GITHUB_OUTPUT
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      wmatrix: ${{ steps.set-matrix.outputs.wmatrix }}
+
+  e2e-ce-without-kubelet-test:
+    runs-on: ubuntu-latest
+    needs: build-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        testmode: ${{ fromJson(needs.build-matrix.outputs.wmatrix) }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare microk8s environment
+        run: ${GITHUB_WORKSPACE}/.github/scripts/k8s-deps.sh
+      - name: Build image
+        env:
+          DEV_K8S: microk8s
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          make image-dev
+          make push-dev
+      - name: Deploy JuiceFS CSI
+        run: |
+          testmode=${{matrix.wtestmode}}
+          cd ${GITHUB_WORKSPACE}
+          dev_tag=dev-$(git describe --always)
+          echo "Dev tag is: " $dev_tag
+          export dev_tag=$dev_tag
+          .github/scripts/deploy-csi-in-k8s.sh ${testmode} withoutkubelet
+      - name: Run e2e test
+        env:
+          JUICEFS_STORAGE: s3
+          JUICEFS_BUCKET: "http://juicefs-bucket.minio.default.svc.cluster.local:9000"
+          JUICEFS_ACCESS_KEY: "minioadmin"
+          JUICEFS_SECRET_KEY: "minioadmin"
+          JUICEFS_NAME: "ce-secret"
+          JUICEFS_META_URL: "redis://redis.default.svc.cluster.local:6379/1"
+          JUICEFS_MODE: ce
+          TEST_MODE: ${{matrix.wtestmode}}
+        run: |
+          cd ${GITHUB_WORKSPACE}/.github/scripts/
+          python3 e2e-test.py
+      - name: Setup upterm session
+        if: ${{ failure() }}
+        timeout-minutes: 60
+        uses: lhotari/action-upterm@v1
+
+  e2e-ee-without-kubelet-test:
+    runs-on: ubuntu-latest
+    needs: build-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        testmode: ${{ fromJson(needs.build-matrix.outputs.wmatrix) }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare microk8s environment
+        run: ${GITHUB_WORKSPACE}/.github/scripts/k8s-deps.sh
+      - name: Build image
+        env:
+          DEV_K8S: microk8s
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          make image-dev
+          make push-dev
+      - name: Deploy JuiceFS CSI
+        run: |
+          testmode=${{matrix.wtestmode}}
+          cd ${GITHUB_WORKSPACE}
+          dev_tag=dev-$(git describe --always)
+          echo "Dev tag is: " $dev_tag
+          export dev_tag=$dev_tag
+          .github/scripts/deploy-csi-in-k8s.sh ${testmode} withoutkubelet
+      - name: Run e2e test
+        env:
+          JUICEFS_TOKEN: ${{ secrets.JUICEFS_CI_VOLUME_TOKEN }}
+          JUICEFS_STORAGE: s3
+          JUICEFS_BUCKET: "http://juicefs-bucket.minio.default.svc.cluster.local:9000"
+          JUICEFS_ACCESS_KEY: "minioadmin"
+          JUICEFS_SECRET_KEY: "minioadmin"
+          JUICEFS_NAME: "csi-ci"
+          JUICEFS_META_URL: ""
+          JUICEFS_MODE: "ee"
+          TEST_MODE: ${{matrix.wtestmode}}
+        run: |
+          cd ${GITHUB_WORKSPACE}/.github/scripts/
+          python3 e2e-test.py
+      - name: Setup upterm session
+        if: ${{ failure() }}
+        timeout-minutes: 60
+        uses: lhotari/action-upterm@v1
 
   e2e-ce-test:
     runs-on: ubuntu-latest

--- a/cmd/app/pod_manager.go
+++ b/cmd/app/pod_manager.go
@@ -1,0 +1,96 @@
+/*
+ Copyright 2023 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/config"
+	mountctrl "github.com/juicedata/juicefs-csi-driver/pkg/controller"
+	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+)
+
+func init() {
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+}
+
+type PodManager struct {
+	mgr    ctrl.Manager
+	client *k8sclient.K8sClient
+}
+
+func NewPodManager() (*PodManager, error) {
+	conf, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	mgr, err := ctrl.NewManager(conf, ctrl.Options{
+		Scheme:             scheme,
+		Port:               9442,
+		MetricsBindAddress: "0.0.0.0:8082",
+		LeaderElectionID:   "pod.juicefs.com",
+		NewCache: cache.BuilderWithOptions(cache.Options{
+			Scheme: scheme,
+			SelectorsByObject: cache.SelectorsByObject{
+				&corev1.Pod{}: {
+					Label: labels.SelectorFromSet(labels.Set{config.PodTypeKey: config.PodTypeValue}),
+					Field: fields.SelectorFromSet(fields.Set{"spec.nodeName": config.NodeName}),
+				},
+			},
+		}),
+	})
+	if err != nil {
+		klog.Errorf("New pod controller error: %v", err)
+		return nil, err
+	}
+
+	// gen k8s client
+	k8sClient, err := k8sclient.NewClient()
+	if err != nil {
+		klog.V(5).Infof("Could not create k8s client %v", err)
+		return nil, err
+	}
+
+	return &PodManager{
+		mgr:    mgr,
+		client: k8sClient,
+	}, err
+}
+
+func (m *PodManager) Start(ctx context.Context) error {
+	// init Reconciler（Controller）
+	if err := (mountctrl.NewPodController(m.client)).SetupWithManager(m.mgr); err != nil {
+		klog.Errorf("Register pod controller error: %v", err)
+		return err
+	}
+	klog.Info("Pod manager started.")
+	if err := m.mgr.Start(ctx); err != nil {
+		klog.Errorf("Pod manager start error: %v", err)
+		return err
+	}
+	return nil
+}

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -24,7 +24,9 @@ import (
 	"time"
 
 	"k8s.io/klog"
+	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/juicedata/juicefs-csi-driver/cmd/app"
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 	"github.com/juicedata/juicefs-csi-driver/pkg/controller"
 	"github.com/juicedata/juicefs-csi-driver/pkg/driver"
@@ -123,10 +125,29 @@ func nodeRun() {
 	}()
 
 	// enable pod manager in csi node
-	if !process && podManager && config.KubeletPort != "" && config.HostIp != "" {
-		if err := controller.StartReconciler(); err != nil {
-			klog.V(5).Infof("Could not Start Reconciler: %v", err)
-			os.Exit(1)
+	if !process && podManager {
+		needStartPodManager := false
+		if config.KubeletPort != "" && config.HostIp != "" {
+			if err := controller.StartReconciler(); err != nil {
+				klog.V(5).Info("Could not Start Reconciler of polling kubelet and fallback to watch ApiServer.")
+				needStartPodManager = true
+			}
+		} else {
+			needStartPodManager = true
+		}
+
+		if needStartPodManager {
+			go func() {
+				ctx := ctrl.SetupSignalHandler()
+				mgr, err := app.NewPodManager()
+				if err != nil {
+					klog.Fatalln(err)
+				}
+
+				if err := mgr.Start(ctx); err != nil {
+					klog.Fatalln(err)
+				}
+			}()
 		}
 		klog.V(5).Infof("Pod Reconciler Started")
 	}

--- a/deploy/kubernetes/base/resources.yaml
+++ b/deploy/kubernetes/base/resources.yaml
@@ -199,7 +199,7 @@ metadata:
   name: csi.juicefs.com
 spec:
   attachRequired: false
-  podInfoOnMount: false
+  podInfoOnMount: true
 ---
 
 kind: StatefulSet

--- a/deploy/kubernetes/csi-ci/without-kubelet/pod-mount-share/daemonset.yaml
+++ b/deploy/kubernetes/csi-ci/without-kubelet/pod-mount-share/daemonset.yaml
@@ -1,0 +1,41 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: juicefs-csi-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: juicefs-plugin
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --nodeid=$(NODE_NAME)
+            - --v=6
+            - --enable-manager=true
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:/csi/csi.sock
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: JUICEFS_MOUNT_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUBELET_PORT
+              $patch: delete
+            - name: HOST_IP
+              $patch: delete
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: JUICEFS_MOUNT_PATH
+              value: /var/lib/juicefs/volume
+            - name: JUICEFS_CONFIG_PATH
+              value: /var/lib/juicefs/config
+            - name: STORAGE_CLASS_SHARE_MOUNT
+              value: "true"

--- a/deploy/kubernetes/csi-ci/without-kubelet/pod-mount-share/kustomization.yaml
+++ b/deploy/kubernetes/csi-ci/without-kubelet/pod-mount-share/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# MUST be kube-system for pods with system-cluster-critical priorityClass
+namespace: kube-system
+resources:
+- ../../../release
+patches:
+- path: daemonset.yaml
+  target:
+    kind: DaemonSet
+- path: statefulset.yaml
+  target:
+    kind: StatefulSet

--- a/deploy/kubernetes/csi-ci/without-kubelet/pod-mount-share/statefulset.yaml
+++ b/deploy/kubernetes/csi-ci/without-kubelet/pod-mount-share/statefulset.yaml
@@ -1,0 +1,43 @@
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: juicefs-csi-controller
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: juicefs-plugin
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --nodeid=$(NODE_NAME)
+            - --leader-election
+            - --v=6
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: JUICEFS_MOUNT_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: KUBELET_PORT
+              value: "10250"
+            - name: JUICEFS_MOUNT_PATH
+              value: /var/lib/juicefs/volume
+            - name: JUICEFS_CONFIG_PATH
+              value: /var/lib/juicefs/config
+            - name: STORAGE_CLASS_SHARE_MOUNT
+              value: "true"

--- a/deploy/kubernetes/csi-ci/without-kubelet/pod-provisioner/daemonset.yaml
+++ b/deploy/kubernetes/csi-ci/without-kubelet/pod-provisioner/daemonset.yaml
@@ -1,0 +1,21 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: juicefs-csi-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: juicefs-plugin
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --nodeid=$(NODE_NAME)
+            - --v=6
+            - --enable-manager=true
+          env:
+            - name: KUBELET_PORT
+              $patch: delete
+            - name: HOST_IP
+              $patch: delete

--- a/deploy/kubernetes/csi-ci/without-kubelet/pod-provisioner/kustomization.yaml
+++ b/deploy/kubernetes/csi-ci/without-kubelet/pod-provisioner/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# MUST be kube-system for pods with system-cluster-critical priorityClass
+namespace: kube-system
+resources:
+- ../../../release
+patches:
+- path: daemonset.yaml
+  target:
+    kind: DaemonSet
+- path: statefulset.yaml
+  target:
+    kind: StatefulSet

--- a/deploy/kubernetes/csi-ci/without-kubelet/pod-provisioner/statefulset.yaml
+++ b/deploy/kubernetes/csi-ci/without-kubelet/pod-provisioner/statefulset.yaml
@@ -1,0 +1,19 @@
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: juicefs-csi-controller
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: juicefs-plugin
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --nodeid=$(NODE_NAME)
+            - --leader-election
+            - --v=6
+            - --provisioner=true
+        - name: csi-provisioner
+          $patch: delete

--- a/deploy/kubernetes/csi-ci/without-kubelet/pod/daemonset.yaml
+++ b/deploy/kubernetes/csi-ci/without-kubelet/pod/daemonset.yaml
@@ -1,0 +1,21 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: juicefs-csi-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: juicefs-plugin
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --nodeid=$(NODE_NAME)
+            - --v=6
+            - --enable-manager=true
+          env:
+            - name: KUBELET_PORT
+              $patch: delete
+            - name: HOST_IP
+              $patch: delete

--- a/deploy/kubernetes/csi-ci/without-kubelet/pod/kustomization.yaml
+++ b/deploy/kubernetes/csi-ci/without-kubelet/pod/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# MUST be kube-system for pods with system-cluster-critical priorityClass
+namespace: kube-system
+resources:
+- ../../../release
+patches:
+- path: daemonset.yaml
+  target:
+    kind: DaemonSet
+- path: statefulset.yaml
+  target:
+    kind: StatefulSet

--- a/deploy/kubernetes/csi-ci/without-kubelet/pod/statefulset.yaml
+++ b/deploy/kubernetes/csi-ci/without-kubelet/pod/statefulset.yaml
@@ -1,0 +1,16 @@
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: juicefs-csi-controller
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: juicefs-plugin
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --nodeid=$(NODE_NAME)
+            - --leader-election
+            - --v=6

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,6 +75,7 @@ const (
 	UniqueId             = "juicefs-uniqueid"
 	CleanCache           = "juicefs-clean-cache"
 	MountContainerName   = "jfs-mount"
+	JuiceFSMountPod      = "juicefs-mountpod"
 
 	// CSI Secret
 	ProvisionerSecretName      = "csi.storage.k8s.io/provisioner-secret-name"

--- a/pkg/controller/pod_controller.go
+++ b/pkg/controller/pod_controller.go
@@ -124,9 +124,14 @@ func (m *PodController) Reconcile(ctx context.Context, request reconcile.Request
 		if err != nil {
 			return reconcile.Result{}, err
 		}
+		now := time.Now()
+		requeueAfter := delayAt.Sub(now)
+		if delayAt.Before(now) {
+			requeueAfter = 0
+		}
 		return reconcile.Result{
 			Requeue:      true,
-			RequeueAfter: delayAt.Sub(time.Now()),
+			RequeueAfter: requeueAfter,
 		}, nil
 	}
 	return reconcile.Result{}, nil

--- a/pkg/controller/pod_controller.go
+++ b/pkg/controller/pod_controller.go
@@ -1,0 +1,158 @@
+/*
+ Copyright 2023 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+	k8sexec "k8s.io/utils/exec"
+	"k8s.io/utils/mount"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/config"
+	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+)
+
+type PodController struct {
+	*k8sclient.K8sClient
+}
+
+func NewPodController(client *k8sclient.K8sClient) *PodController {
+	return &PodController{client}
+}
+
+func (m *PodController) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	klog.V(6).Infof("Receive pod %s %s", request.Name, request.Namespace)
+	mountPod, err := m.GetPod(ctx, request.Name, request.Namespace)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		klog.Errorf("get pod %s error: %v", request.Name, err)
+		return reconcile.Result{}, err
+	}
+	if mountPod == nil {
+		klog.V(6).Infof("pod %s has been deleted.", request.Name)
+		return reconcile.Result{}, nil
+	}
+
+	// get mount info
+	mit := newMountInfoTable()
+	if err := mit.parse(); err != nil {
+		klog.Errorf("doReconcile ParseMountInfo: %v", err)
+		return reconcile.Result{}, err
+	}
+
+	// get app pod list
+	var pv *corev1.PersistentVolume
+	var pvcNamespace string
+	pvs, err := m.K8sClient.ListPersistentVolumes(ctx, nil, nil)
+	if err != nil {
+		klog.Errorf("doReconcile ListPV: %v", err)
+		return reconcile.Result{}, err
+	}
+	uniqueId := mountPod.Annotations[config.UniqueId]
+	for _, p := range pvs {
+		if p.Spec.CSI == nil || p.Spec.CSI.Driver != config.DriverName {
+			continue
+		}
+		if uniqueId != "" && (p.Spec.CSI.VolumeHandle == uniqueId || p.Spec.StorageClassName == uniqueId) {
+			pv = &p
+			break
+		}
+	}
+	if pv != nil {
+		if pv.Spec.ClaimRef != nil {
+			pvcNamespace = pv.Spec.ClaimRef.Namespace
+		}
+	}
+	if pvcNamespace == "" {
+		klog.Errorf("can not get pvc based on mount pod %s/%s: %v", mountPod.Namespace, mountPod.Name, err)
+		return reconcile.Result{}, err
+	}
+
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{config.UniqueId: uniqueId},
+	}
+	podList, err := m.K8sClient.ListPod(ctx, pvcNamespace, &labelSelector, nil)
+	if err != nil {
+		klog.Errorf("doReconcile ListPod: %v", err)
+		return reconcile.Result{}, err
+	}
+
+	mounter := mount.SafeFormatAndMount{
+		Interface: mount.New(""),
+		Exec:      k8sexec.New(),
+	}
+
+	podDriver := NewPodDriver(m.K8sClient, mounter)
+	podDriver.SetMountInfo(*mit)
+	podDriver.mit.setPodsStatus(&corev1.PodList{Items: podList})
+
+	err = podDriver.Run(ctx, mountPod)
+	if err != nil {
+		klog.Errorf("Driver check pod %s error: %v", mountPod.Name, err)
+	}
+	return reconcile.Result{}, err
+}
+
+func (m *PodController) SetupWithManager(mgr ctrl.Manager) error {
+	c, err := controller.New("mount", mgr, controller.Options{Reconciler: m})
+	if err != nil {
+		return err
+	}
+
+	return c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
+		CreateFunc: func(event event.CreateEvent) bool {
+			pod := event.Object.(*corev1.Pod)
+			klog.V(6).Infof("watch pod %s created", pod.GetName())
+			return true
+		},
+		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
+			podNew, ok := updateEvent.ObjectNew.(*corev1.Pod)
+			klog.V(6).Infof("watch pod %s updated", podNew.GetName())
+			if !ok {
+				klog.V(6).Infof("pod.onUpdateFunc Skip object: %v", updateEvent.ObjectNew)
+				return false
+			}
+
+			podOld, ok := updateEvent.ObjectOld.(*corev1.Pod)
+			if !ok {
+				klog.V(6).Infof("pod.onUpdateFunc Skip object: %v", updateEvent.ObjectOld)
+				return false
+			}
+
+			if podNew.GetResourceVersion() == podOld.GetResourceVersion() {
+				klog.V(6).Info("pod.onUpdateFunc Skip due to resourceVersion not changed")
+				return false
+			}
+			return true
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			pod := deleteEvent.Object.(*corev1.Pod)
+			klog.V(6).Infof("watch pod %s deleted", pod.GetName())
+			return true
+		},
+	})
+}

--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -41,7 +41,13 @@ func StartReconciler() error {
 	if err != nil {
 		return err
 	}
-	kc, err := newKubeletClient(config.HostIp, port)
+	kc, err := k8sclient.NewKubeletClient(config.HostIp, port)
+	if err != nil {
+		return err
+	}
+
+	// check if kubelet can be connected
+	_, err = kc.GetNodeRunningPods()
 	if err != nil {
 		return err
 	}
@@ -57,7 +63,7 @@ func StartReconciler() error {
 	return nil
 }
 
-func doReconcile(ks *k8sclient.K8sClient, kc *kubeletClient) {
+func doReconcile(ks *k8sclient.K8sClient, kc *k8sclient.KubeletClient) {
 	for {
 		ctx := context.TODO()
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), config.ReconcileTimeout)

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -314,7 +314,11 @@ func (j *juicefs) JfsMount(ctx context.Context, volumeID string, target string, 
 	if err != nil {
 		return nil, err
 	}
-	mountPath, err := j.MountFs(ctx, jfsSetting)
+	appInfo, err := config.ParseAppInfo(volCtx)
+	if err != nil {
+		return nil, err
+	}
+	mountPath, err := j.MountFs(ctx, appInfo, jfsSetting)
 	if err != nil {
 		return nil, err
 	}
@@ -785,7 +789,7 @@ func (j *juicefs) SetQuota(ctx context.Context, secrets map[string]string, jfsSe
 }
 
 // MountFs mounts JuiceFS with idempotency
-func (j *juicefs) MountFs(ctx context.Context, jfsSetting *config.JfsSetting) (string, error) {
+func (j *juicefs) MountFs(ctx context.Context, appInfo *config.AppInfo, jfsSetting *config.JfsSetting) (string, error) {
 	var mnt podmount.MntInterface
 	if jfsSetting.UsePod {
 		jfsSetting.MountPath = filepath.Join(config.PodMountBase, jfsSetting.UniqueId)
@@ -795,7 +799,7 @@ func (j *juicefs) MountFs(ctx context.Context, jfsSetting *config.JfsSetting) (s
 		mnt = j.processMount
 	}
 
-	err := mnt.JMount(ctx, jfsSetting)
+	err := mnt.JMount(ctx, appInfo, jfsSetting)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/juicefs/juicefs_test.go
+++ b/pkg/juicefs/juicefs_test.go
@@ -297,7 +297,7 @@ func Test_juicefs_JfsMount(t *testing.T) {
 				return "", nil
 			})
 			defer patch3.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, _ context.Context, jfsSetting *config.JfsSetting) (string, error) {
+			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, _ context.Context, appInfo *config.AppInfo, jfsSetting *config.JfsSetting) (string, error) {
 				return "", nil
 			})
 			defer patch4.Reset()
@@ -328,7 +328,7 @@ func Test_juicefs_JfsMount(t *testing.T) {
 				return []byte(""), nil
 			})
 			defer patch3.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, _ context.Context, jfsSetting *config.JfsSetting) (string, error) {
+			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, _ context.Context, appInfo *config.AppInfo, jfsSetting *config.JfsSetting) (string, error) {
 				return "", nil
 			})
 			defer patch4.Reset()
@@ -370,7 +370,7 @@ func Test_juicefs_JfsMount(t *testing.T) {
 			jf := &juicefs{}
 			patch2 := ApplyMethod(reflect.TypeOf(jf), "Upgrade", func(_ *juicefs) {})
 			defer patch2.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, _ context.Context, jfsSetting *config.JfsSetting) (string, error) {
+			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, _ context.Context, appInfo *config.AppInfo, jfsSetting *config.JfsSetting) (string, error) {
 				return "", nil
 			})
 			defer patch4.Reset()
@@ -392,7 +392,7 @@ func Test_juicefs_JfsMount(t *testing.T) {
 			jf := &juicefs{}
 			patch2 := ApplyMethod(reflect.TypeOf(jf), "Upgrade", func(_ *juicefs) {})
 			defer patch2.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, _ context.Context, jfsSetting *config.JfsSetting) (string, error) {
+			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, _ context.Context, appInfo *config.AppInfo, jfsSetting *config.JfsSetting) (string, error) {
 				return "", errors.New("test")
 			})
 			defer patch4.Reset()
@@ -426,7 +426,7 @@ func Test_juicefs_JfsMount(t *testing.T) {
 				return []byte(""), nil
 			})
 			defer patch3.Reset()
-			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, _ context.Context, jfsSetting *config.JfsSetting) (string, error) {
+			patch4 := ApplyMethod(reflect.TypeOf(jf), "MountFs", func(_ *juicefs, _ context.Context, appInfo *config.AppInfo, jfsSetting *config.JfsSetting) (string, error) {
 				return "", nil
 			})
 			defer patch4.Reset()
@@ -664,7 +664,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 					Exec:      k8sexec.New(),
 				}),
 			}
-			_, e := jfs.MountFs(context.TODO(), jfsSetting)
+			_, e := jfs.MountFs(context.TODO(), nil, jfsSetting)
 			So(e, ShouldBeNil)
 		})
 		Convey("not MountPoint err", func() {
@@ -694,7 +694,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			_, e := jfs.MountFs(ctx, jfsSetting)
+			_, e := jfs.MountFs(ctx, nil, jfsSetting)
 			So(e, ShouldNotBeNil)
 		})
 		Convey("add ref err", func() {
@@ -721,7 +721,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 			mockMount := mocks.NewMockInterface(mockCtl)
 			//mockMount.EXPECT().IsLikelyNotMountPoint(mountPath).Return(false, nil)
 			mockMnt := mntmock.NewMockMntInterface(mockCtl)
-			mockMnt.EXPECT().JMount(context.TODO(), jfsSetting).Return(errors.New("test"))
+			mockMnt.EXPECT().JMount(context.TODO(), nil, jfsSetting).Return(errors.New("test"))
 
 			jfs := juicefs{
 				SafeFormatAndMount: mount.SafeFormatAndMount{
@@ -731,7 +731,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 				K8sClient: &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
 				podMount:  mockMnt,
 			}
-			_, e := jfs.MountFs(context.TODO(), jfsSetting)
+			_, e := jfs.MountFs(context.TODO(), nil, jfsSetting)
 			So(e, ShouldNotBeNil)
 		})
 		Convey("jmount err", func() {
@@ -757,7 +757,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 			mockMount := mocks.NewMockInterface(mockCtl)
 			//mockMount.EXPECT().IsLikelyNotMountPoint(mountPath).Return(true, nil)
 			mockMnt := mntmock.NewMockMntInterface(mockCtl)
-			mockMnt.EXPECT().JMount(context.TODO(), jfsSetting).Return(errors.New("test"))
+			mockMnt.EXPECT().JMount(context.TODO(), nil, jfsSetting).Return(errors.New("test"))
 
 			jfs := juicefs{
 				SafeFormatAndMount: mount.SafeFormatAndMount{
@@ -767,7 +767,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 				K8sClient:    &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
 				processMount: mockMnt,
 			}
-			_, e := jfs.MountFs(context.TODO(), jfsSetting)
+			_, e := jfs.MountFs(context.TODO(), nil, jfsSetting)
 			So(e, ShouldNotBeNil)
 		})
 		Convey("jmount", func() {
@@ -793,7 +793,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 			mockMount := mocks.NewMockInterface(mockCtl)
 			//mockMount.EXPECT().IsLikelyNotMountPoint(mountPath).Return(true, nil)
 			mockMnt := mntmock.NewMockMntInterface(mockCtl)
-			mockMnt.EXPECT().JMount(context.TODO(), jfsSetting).Return(nil)
+			mockMnt.EXPECT().JMount(context.TODO(), nil, jfsSetting).Return(nil)
 
 			jfs := juicefs{
 				SafeFormatAndMount: mount.SafeFormatAndMount{
@@ -803,7 +803,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 				K8sClient:    &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
 				processMount: mockMnt,
 			}
-			_, e := jfs.MountFs(context.TODO(), jfsSetting)
+			_, e := jfs.MountFs(context.TODO(), nil, jfsSetting)
 			So(e, ShouldBeNil)
 		})
 		Convey("not exist jmount err", func() {
@@ -828,7 +828,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 
 			mockMount := mocks.NewMockInterface(mockCtl)
 			mockMnt := mntmock.NewMockMntInterface(mockCtl)
-			mockMnt.EXPECT().JMount(context.TODO(), jfsSetting).Return(errors.New("test"))
+			mockMnt.EXPECT().JMount(context.TODO(), nil, jfsSetting).Return(errors.New("test"))
 
 			jfs := juicefs{
 				SafeFormatAndMount: mount.SafeFormatAndMount{
@@ -838,7 +838,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 				K8sClient:    &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
 				processMount: mockMnt,
 			}
-			_, e := jfs.MountFs(context.TODO(), jfsSetting)
+			_, e := jfs.MountFs(context.TODO(), nil, jfsSetting)
 			So(e, ShouldNotBeNil)
 		})
 		Convey("not exist", func() {
@@ -863,7 +863,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 
 			mockMount := mocks.NewMockInterface(mockCtl)
 			mockMnt := mntmock.NewMockMntInterface(mockCtl)
-			mockMnt.EXPECT().JMount(context.TODO(), jfsSetting).Return(nil)
+			mockMnt.EXPECT().JMount(context.TODO(), nil, jfsSetting).Return(nil)
 
 			jfs := juicefs{
 				SafeFormatAndMount: mount.SafeFormatAndMount{
@@ -873,7 +873,7 @@ func Test_juicefs_MountFs(t *testing.T) {
 				K8sClient:    &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
 				processMount: mockMnt,
 			}
-			_, e := jfs.MountFs(context.TODO(), jfsSetting)
+			_, e := jfs.MountFs(context.TODO(), nil, jfsSetting)
 			So(e, ShouldBeNil)
 		})
 	})

--- a/pkg/juicefs/mount/interface.go
+++ b/pkg/juicefs/mount/interface.go
@@ -26,7 +26,7 @@ import (
 
 type MntInterface interface {
 	k8sMount.Interface
-	JMount(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) error
+	JMount(ctx context.Context, appInfo *jfsConfig.AppInfo, jfsSetting *jfsConfig.JfsSetting) error
 	JCreateVolume(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) error
 	JDeleteVolume(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) error
 	GetMountRef(ctx context.Context, target, podName string) (int, error) // podName is only used by podMount

--- a/pkg/juicefs/mount/mocks/mock_mnt.go
+++ b/pkg/juicefs/mount/mocks/mock_mnt.go
@@ -138,17 +138,17 @@ func (mr *MockMntInterfaceMockRecorder) JDeleteVolume(arg0, arg1 interface{}) *g
 }
 
 // JMount mocks base method.
-func (m *MockMntInterface) JMount(arg0 context.Context, arg1 *config.JfsSetting) error {
+func (m *MockMntInterface) JMount(arg0 context.Context, arg1 *config.AppInfo, arg2 *config.JfsSetting) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JMount", arg0, arg1)
+	ret := m.ctrl.Call(m, "JMount", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // JMount indicates an expected call of JMount.
-func (mr *MockMntInterfaceMockRecorder) JMount(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMntInterfaceMockRecorder) JMount(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JMount", reflect.TypeOf((*MockMntInterface)(nil).JMount), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JMount", reflect.TypeOf((*MockMntInterface)(nil).JMount), arg0, arg1, arg2)
 }
 
 // JUmount mocks base method.

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -56,15 +56,15 @@ func NewPodMount(client *k8sclient.K8sClient, mounter k8sMount.SafeFormatAndMoun
 	return &PodMount{mounter, client}
 }
 
-func (p *PodMount) JMount(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) error {
+func (p *PodMount) JMount(ctx context.Context, appInfo *jfsConfig.AppInfo, jfsSetting *jfsConfig.JfsSetting) error {
 	podName, err := p.genMountPodName(ctx, jfsSetting)
 	if err != nil {
 		return err
 	}
 
 	// set mount pod name in app pod
-	if jfsSetting.AppInfo.Name != "" && jfsSetting.AppInfo.Namespace != "" {
-		err = p.setMountLabel(ctx, jfsSetting.UniqueId, podName, jfsSetting.AppInfo.Name, jfsSetting.AppInfo.Namespace)
+	if appInfo != nil && appInfo.Name != "" && appInfo.Namespace != "" {
+		err = p.setMountLabel(ctx, jfsSetting.UniqueId, podName, appInfo.Name, appInfo.Namespace)
 		if err != nil {
 			return err
 		}
@@ -491,7 +491,7 @@ func (p *PodMount) setMountLabel(ctx context.Context, uniqueId, mountPodName str
 	if err != nil {
 		return err
 	}
-	klog.Infof("setMountLabel: set mount info %s in pod %s", jfsConfig.Namespace, uniqueId, podName)
+	klog.Infof("setMountLabel: set mount info %s in pod %s", uniqueId, podName)
 	if err := util.AddPodLabel(ctx, p.K8sClient, pod, map[string]string{jfsConfig.UniqueId: uniqueId}); err != nil {
 		return err
 	}

--- a/pkg/juicefs/mount/pod_mount_test.go
+++ b/pkg/juicefs/mount/pod_mount_test.go
@@ -616,7 +616,11 @@ func TestWaitUntilMount(t *testing.T) {
 				}
 				_, _ = p.K8sClient.CreatePod(context.TODO(), tt.pod)
 			}
-			podName, err := p.createOrAddRef(context.TODO(), tt.args.jfsSetting)
+			podName, err := p.genMountPodName(context.TODO(), tt.args.jfsSetting)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createOrAddRef() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			err = p.createOrAddRef(context.TODO(), podName, tt.args.jfsSetting)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createOrAddRef() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -656,7 +660,9 @@ func TestWaitUntilMountWithMock(t *testing.T) {
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			_, err := p.createOrAddRef(ctx, &jfsConfig.JfsSetting{Storage: "ttt"})
+			podName, err := p.genMountPodName(context.TODO(), &jfsConfig.JfsSetting{Storage: "ttt"})
+			So(err, ShouldBeNil)
+			err = p.createOrAddRef(ctx, podName, &jfsConfig.JfsSetting{Storage: "ttt"})
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -686,7 +692,7 @@ func TestJMount(t *testing.T) {
 			})
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
-			err := p.JMount(ctx, &jfsConfig.JfsSetting{Storage: "ttt"})
+			err := p.JMount(ctx, nil, &jfsConfig.JfsSetting{Storage: "ttt"})
 			So(err, ShouldNotBeNil)
 		})
 	})

--- a/pkg/juicefs/mount/process_mount.go
+++ b/pkg/juicefs/mount/process_mount.go
@@ -129,7 +129,7 @@ func (p *ProcessMount) JDeleteVolume(ctx context.Context, jfsSetting *jfsConfig.
 	return nil
 }
 
-func (p *ProcessMount) JMount(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) error {
+func (p *ProcessMount) JMount(ctx context.Context, _ *jfsConfig.AppInfo, jfsSetting *jfsConfig.JfsSetting) error {
 	// create subpath if readonly mount
 	if jfsSetting.SubPath != "" {
 		if util.ContainsString(jfsSetting.Options, "read-only") || util.ContainsString(jfsSetting.Options, "ro") {

--- a/pkg/juicefs/mount/process_mount_test.go
+++ b/pkg/juicefs/mount/process_mount_test.go
@@ -178,7 +178,7 @@ func TestProcessMount_JMount(t *testing.T) {
 				p := &ProcessMount{
 					SafeFormatAndMount: *mounter,
 				}
-				if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
+				if err := p.JMount(context.TODO(), nil, &jfsConfig.JfsSetting{
 					Source:    eeSource,
 					VolumeId:  volumeId,
 					MountPath: targetPath,
@@ -208,7 +208,7 @@ func TestProcessMount_JMount(t *testing.T) {
 				}
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
-				if err := p.JMount(ctx, &jfsConfig.JfsSetting{
+				if err := p.JMount(ctx, nil, &jfsConfig.JfsSetting{
 					Source:    eeSource,
 					VolumeId:  volumeId,
 					MountPath: targetPath,
@@ -261,7 +261,7 @@ func TestProcessMount_JMount(t *testing.T) {
 						p := &ProcessMount{
 							SafeFormatAndMount: *mounter,
 						}
-						if err := p.JMount(context.TODO(), &jfsConfig.JfsSetting{
+						if err := p.JMount(context.TODO(), nil, &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							Storage:   "ceph",
 							VolumeId:  volumeId,
@@ -304,7 +304,7 @@ func TestProcessMount_JMount(t *testing.T) {
 						}
 						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 						defer cancel()
-						if err := p.JMount(ctx, &jfsConfig.JfsSetting{
+						if err := p.JMount(ctx, nil, &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							Storage:   "ceph",
 							VolumeId:  volumeId,
@@ -347,7 +347,7 @@ func TestProcessMount_JMount(t *testing.T) {
 						}
 						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 						defer cancel()
-						if err := p.JMount(ctx, &jfsConfig.JfsSetting{
+						if err := p.JMount(ctx, nil, &jfsConfig.JfsSetting{
 							Source: ceSource, Storage: "ceph",
 							VolumeId:  volumeId,
 							MountPath: targetPath,
@@ -366,7 +366,7 @@ func TestProcessMount_JMount(t *testing.T) {
 						}
 						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 						defer cancel()
-						if err := p.JMount(ctx, &jfsConfig.JfsSetting{
+						if err := p.JMount(ctx, nil, &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							VolumeId:  volumeId,
 							MountPath: targetPath,
@@ -388,7 +388,7 @@ func TestProcessMount_JMount(t *testing.T) {
 						}
 						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 						defer cancel()
-						if err := p.JMount(ctx, &jfsConfig.JfsSetting{
+						if err := p.JMount(ctx, nil, &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							VolumeId:  volumeId,
 							MountPath: targetPath,
@@ -415,7 +415,7 @@ func TestProcessMount_JMount(t *testing.T) {
 						}
 						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 						defer cancel()
-						if err := p.JMount(ctx, &jfsConfig.JfsSetting{
+						if err := p.JMount(ctx, nil, &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							VolumeId:  volumeId,
 							MountPath: targetPath,
@@ -444,7 +444,7 @@ func TestProcessMount_JMount(t *testing.T) {
 
 						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 						defer cancel()
-						if err := p.JMount(ctx, &jfsConfig.JfsSetting{
+						if err := p.JMount(ctx, nil, &jfsConfig.JfsSetting{
 							Source:    ceSource,
 							VolumeId:  volumeId,
 							MountPath: targetPath,


### PR DESCRIPTION
fix https://github.com/juicedata/juicefs-csi-driver/issues/478

1. enable `podInfoOnMount` in csiDriver
2. set mount pod info in app pod
3. add pod manager to watch mount pod. list app pods by labels and run podDriver(mountpoint recover).