### PR TITLE
Introduce `JUICEFS_IMMUTABLE`, mount `/etc/updatedb.conf` only in mutable environments

### DIFF
--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -62,6 +63,14 @@ func parseControllerConfig() {
 		config.FormatInPod = true
 		config.MountManager = false
 		config.ByProcess = false
+	}
+	if jfsImmutable := os.Getenv("JUICEFS_IMMUTABLE"); jfsImmutable != "" {
+		// check if running in an immutable environment
+		if immutable, err := strconv.ParseBool(jfsImmutable); err == nil {
+			config.Immutable = immutable
+		} else {
+			klog.Errorf("cannot parse JUICEFS_IMMUTABLE: %v", err)
+		}
 	}
 
 	config.NodeName = os.Getenv("NODE_NAME")

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"k8s.io/klog"
@@ -42,12 +43,22 @@ func parseNodeConfig() {
 		return
 	}
 	config.FormatInPod = formatInPod
+
+	if jfsImmutable := os.Getenv("JUICEFS_IMMUTABLE"); jfsImmutable != "" {
+		if immutable, err := strconv.ParseBool(jfsImmutable); err == nil {
+			config.Immutable = immutable
+		} else {
+			klog.Errorf("cannot parse JUICEFS_IMMUTABLE: %v", err)
+		}
+	}
+
 	config.NodeName = os.Getenv("NODE_NAME")
 	config.Namespace = os.Getenv("JUICEFS_MOUNT_NAMESPACE")
 	config.PodName = os.Getenv("POD_NAME")
 	config.MountPointPath = os.Getenv("JUICEFS_MOUNT_PATH")
 	config.JFSConfigPath = os.Getenv("JUICEFS_CONFIG_PATH")
 	config.MountLabels = os.Getenv("JUICEFS_MOUNT_LABELS")
+
 	config.HostIp = os.Getenv("HOST_IP")
 	config.KubeletPort = os.Getenv("KUBELET_PORT")
 	jfsMountPriorityName := os.Getenv("JUICEFS_MOUNT_PRIORITY_NAME")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,7 @@ var (
 	Provisioner  = false // provisioner in controller
 	MountManager = false // manage mount pod in controller (only in k8s)
 	Webhook      = false // inject juicefs client as sidecar in pod (only in k8s)
+	Immutable    = false // csi driver is running in an immutable environment
 
 	NodeName           = ""
 	Namespace          = ""

--- a/pkg/juicefs/mount/builder/common.go
+++ b/pkg/juicefs/mount/builder/common.go
@@ -93,7 +93,7 @@ func (r *Builder) getVolumes() []corev1.Volume {
 				Type: &dir,
 			},
 		}}, {
-		Name: "updatedb",
+		Name: UpdateDBDirName,
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
 				Path: "/etc/updatedb.conf",
@@ -158,7 +158,7 @@ func (r *Builder) getVolumeMounts() []corev1.VolumeMount {
 		MountPath:        config.PodMountBase,
 		MountPropagation: &mp,
 	}, {
-		Name:             "updatedb",
+		Name:             UpdateDBDirName,
 		MountPath:        "/etc/updatedb.conf",
 		MountPropagation: &mp,
 	}}

--- a/pkg/juicefs/mount/builder/pod_test.go
+++ b/pkg/juicefs/mount/builder/pod_test.go
@@ -78,7 +78,7 @@ var (
 					Name: UpdateDBDirName,
 					VolumeSource: corev1.VolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/etc/updatedb.conf",
+							Path: UpdateDBCfgFile,
 							Type: &file,
 						},
 					},
@@ -107,7 +107,7 @@ var (
 					}, {
 
 						Name:             UpdateDBDirName,
-						MountPath:        "/etc/updatedb.conf",
+						MountPath:        UpdateDBCfgFile,
 						MountPropagation: &mp,
 					},
 				},

--- a/pkg/juicefs/mount/builder/pod_test.go
+++ b/pkg/juicefs/mount/builder/pod_test.go
@@ -75,7 +75,7 @@ var (
 						},
 					},
 				}, {
-					Name: "updatedb",
+					Name: UpdateDBDirName,
 					VolumeSource: corev1.VolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{
 							Path: "/etc/updatedb.conf",
@@ -106,7 +106,7 @@ var (
 						MountPropagation: &mp,
 					}, {
 
-						Name:             "updatedb",
+						Name:             UpdateDBDirName,
 						MountPath:        "/etc/updatedb.conf",
 						MountPropagation: &mp,
 					},


### PR DESCRIPTION
Some Kubernetes distributions, such as [Talos Linux](https://www.talos.dev/), do not ship `updatedb` at all. In these environments, the JuiceFS CSI mount pod fails to start due to `/etc/updatedb.conf` not being present on the host for bind mounting, nor can `FileOrCreate` create it due to `/etc` being read-only. This patch introduces `JUICEFS_IMMUTABLE` as a new environment variable for both controller and node instances to handle these kinds of cases that need special attention in immutable environments. I've also updated `updatedb`-related hard-coded strings to use the constant definitions in `common.go`.