### PR TITLE
Support template secret

### DIFF
--- a/pkg/driver/provisioner.go
+++ b/pkg/driver/provisioner.go
@@ -92,13 +92,13 @@ func (j *provisionerService) Provision(ctx context.Context, options provisioncon
 	pvName := options.PVName
 	scParams := make(map[string]string)
 	for k, v := range options.StorageClass.Parameters {
-		if strings.HasPrefix(k,"csi.storage.k8s.io/") {
+		if strings.HasPrefix(k, "csi.storage.k8s.io/") {
 			scParams[k] = pvMeta.ResolveSecret(v, pvName)
 		} else {
 			scParams[k] = v
 		}
 	}
- 
+
 	secret, err := j.K8sClient.GetSecret(ctx, scParams[config.ProvisionerSecretName], scParams[config.ProvisionerSecretNamespace])
 	if err != nil {
 		klog.Errorf("[PVCReconciler]: Get Secret error: %v", err)
@@ -112,7 +112,7 @@ func (j *provisionerService) Provision(ctx context.Context, options provisioncon
 	volCtx := make(map[string]string)
 	volCtx["subPath"] = subPath
 	volCtx["capacity"] = strconv.FormatInt(options.PVC.Spec.Resources.Requests.Storage().Value(), 10)
-        for k, v := range scParams {
+	for k, v := range scParams {
 		volCtx[k] = v
 	}
 	pv := &corev1.PersistentVolume{

--- a/pkg/driver/provisioner.go
+++ b/pkg/driver/provisioner.go
@@ -20,14 +20,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 	provisioncontroller "sigs.k8s.io/sig-storage-lib-external-provisioner/v6/controller"
-        "strconv"
-        "strings"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs"
@@ -89,17 +89,17 @@ func (j *provisionerService) Provision(ctx context.Context, options provisioncon
 		subPath = pvMeta.StringParser(options.StorageClass.Parameters["pathPattern"])
 	}
 
-        pvName := options.PVName
-        scParams := make(map[string]string)
-        for k, v := range options.StorageClass.Parameters {
-                if strings.HasPrefix(k,"csi.storage.k8s.io/") {
-                        scParams[k] = pvMeta.ResolveSecret(v, pvName)
-                } else {
-                        scParams[k] = v
-                }
-        }
+	pvName := options.PVName
+	scParams := make(map[string]string)
+	for k, v := range options.StorageClass.Parameters {
+		if strings.HasPrefix(k,"csi.storage.k8s.io/") {
+			scParams[k] = pvMeta.ResolveSecret(v, pvName)
+		} else {
+			scParams[k] = v
+		}
+	}
  
-        secret, err := j.K8sClient.GetSecret(ctx, scParams[config.ProvisionerSecretName], scParams[config.ProvisionerSecretNamespace])
+	secret, err := j.K8sClient.GetSecret(ctx, scParams[config.ProvisionerSecretName], scParams[config.ProvisionerSecretNamespace])
 	if err != nil {
 		klog.Errorf("[PVCReconciler]: Get Secret error: %v", err)
 		return nil, provisioncontroller.ProvisioningFinished, errors.New("unable to provision new pv: " + err.Error())

--- a/pkg/util/pvc.go
+++ b/pkg/util/pvc.go
@@ -104,7 +104,7 @@ func (meta *PVCMetadata) ResolveSecret(str string, pvName string) string {
 			return pvName
 		}
 		for ak, av := range meta.annotations {
-			if k == "pvc.annotations['"+ ak +"']" {
+			if k == "pvc.annotations['"+ak+"']" {
 				return av
 			}
 		}

--- a/pkg/util/pvc_test.go
+++ b/pkg/util/pvc_test.go
@@ -268,3 +268,93 @@ func TestCheckForSubPath(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveSecret(t *testing.T) {
+	type fields struct {
+		data        map[string]string
+		labels      map[string]string
+		annotations map[string]string
+	}
+	type args struct {
+		str string
+		pvname string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			name: "test-pvc-name",
+			fields: fields{
+				data: map[string]string{
+					"name":      "test",
+					"namespace": "default",
+				},
+			},
+			args: args{
+				str: "${pvc.name}",
+				pvname: "pv-a",
+			},
+			want: "test",
+		},
+		{
+			name: "test-pvc-namespace",
+			fields: fields{
+				data: map[string]string{
+					"name":      "test",
+					"namespace": "default",
+				},
+			},
+			args: args{
+				str: "${pvc.namespace}",
+				pvname: "pv-a",
+			},
+			want: "default",
+		},
+		{
+			name: "test-pvc-annotation",
+			fields: fields{
+				data: map[string]string{
+					"name":      "test",
+					"namespace": "default",
+				},
+				annotations: map[string]string{
+					"a.a": "b",
+				},
+			},
+			args: args{
+				str: "${pvc.annotations['a.a']}",
+				pvname: "pv-a",
+			},
+			want: "b",
+		},
+		{
+			name: "test-pv-name",
+			fields: fields{
+				data: map[string]string{
+					"name":      "test",
+					"namespace": "default",
+				},
+			},
+			args: args{
+				str: "${pv.name}",
+				pvname: "pv-a",
+			},
+			want: "pv-a",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := &PVCMetadata{
+				data:        tt.fields.data,
+				labels:      tt.fields.labels,
+				annotations: tt.fields.annotations,
+			}
+			if got := meta.ResolveSecret(tt.args.str, tt.args.pvname); got != tt.want {
+				t.Errorf("ResolveSecret() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/util/pvc_test.go
+++ b/pkg/util/pvc_test.go
@@ -276,7 +276,7 @@ func TestResolveSecret(t *testing.T) {
 		annotations map[string]string
 	}
 	type args struct {
-		str string
+		str    string
 		pvname string
 	}
 	tests := []struct {
@@ -294,7 +294,7 @@ func TestResolveSecret(t *testing.T) {
 				},
 			},
 			args: args{
-				str: "${pvc.name}",
+				str:    "${pvc.name}",
 				pvname: "pv-a",
 			},
 			want: "test",
@@ -308,7 +308,7 @@ func TestResolveSecret(t *testing.T) {
 				},
 			},
 			args: args{
-				str: "${pvc.namespace}",
+				str:    "${pvc.namespace}",
 				pvname: "pv-a",
 			},
 			want: "default",
@@ -325,7 +325,7 @@ func TestResolveSecret(t *testing.T) {
 				},
 			},
 			args: args{
-				str: "${pvc.annotations['a.a']}",
+				str:    "${pvc.annotations['a.a']}",
 				pvname: "pv-a",
 			},
 			want: "b",
@@ -339,7 +339,7 @@ func TestResolveSecret(t *testing.T) {
 				},
 			},
 			args: args{
-				str: "${pv.name}",
+				str:    "${pv.name}",
 				pvname: "pv-a",
 			},
 			want: "pv-a",


### PR DESCRIPTION
https://github.com/juicedata/juicefs-csi-driver/issues/698.

``${pvc.name}``, ``${pvc.namespace}``, ``${pvc.annotations['<annotation>']}`` will be resolved by user's pvc. 
It works in my cluster. 
can you review it when you are available?