### PR TITLE
Support secret finalizer

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -94,6 +94,10 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 	if req.Parameters["pathPattern"] != "" {
 		klog.Warningf("CreateVolume: volume %s uses pathPattern, please enable provisioner in CSI Controller, not works in default mode.", volumeId)
 	}
+	// check if use secretFinalizer
+	if req.Parameters["secretFinalizer"] == "true" {
+		klog.Warningf("CreateVolume: volume %s uses secretFinalizer, please enable provisioner in CSI Controller, not works in default mode.", volumeId)
+	}
 
 	volCtx["subPath"] = subPath
 	volCtx["capacity"] = strconv.FormatInt(requiredCap, 10)

--- a/pkg/driver/provisioner.go
+++ b/pkg/driver/provisioner.go
@@ -149,7 +149,13 @@ func (j *provisionerService) Provision(ctx context.Context, options provisioncon
 			Namespace: scParams[config.ControllerExpandSecretNamespace],
 		}
 	}
-	util.AddSecretFinalizer(ctx, j.K8sClient, secret, config.Finalizer)
+	if options.StorageClass.Parameters["secretFinalizer"] == "true" {
+		klog.V(6).Infof("Provisioner: Add Finalizer on %s/%s", secret.Namespace, secret.Name)
+		err = util.AddSecretFinalizer(ctx, j.K8sClient, secret, config.Finalizer)
+		if err != nil {
+			klog.Warningf("Fails to add a finalizer to the secret, error: %v", err)
+		}
+	}
 	return pv, provisioncontroller.ProvisioningFinished, nil
 }
 
@@ -191,15 +197,16 @@ func (j *provisionerService) Delete(ctx context.Context, volume *corev1.Persiste
 		return errors.New("unable to provision delete volume: " + err.Error())
 	}
 
-	shouldRemoveFinalizer, err := util.CheckForSecretFinalizer(ctx, j.K8sClient, volume)
-	if err != nil {
-		klog.Errorf("Provisioner: CheckForSecretFinalizer error: %v", err)
-		return err
+	if volume.Spec.CSI.VolumeAttributes["secretFinalizer"] == "true" {
+		shouldRemoveFinalizer, err := util.CheckForSecretFinalizer(ctx, j.K8sClient, volume)
+		if err != nil {
+			klog.Errorf("Provisioner: CheckForSecretFinalizer error: %v", err)
+			return err
+		}
+		if shouldRemoveFinalizer {
+			klog.V(6).Infof("Provisioner: Remove Finalizer on %s/%s", secretNamespace, secretName)
+			util.RemoveSecretFinalizer(ctx, j.K8sClient, secret, config.Finalizer)
+		}
 	}
-	if shouldRemoveFinalizer {
-		klog.V(5).Infof("Provisioner: Remove Finalizer on %s/%s", secretNamespace, secretName)
-		util.RemoveSecretFinalizer(ctx, j.K8sClient, secret, config.Finalizer)
-	}
-
 	return nil
 }

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -235,6 +235,16 @@ func (k *K8sClient) DeleteSecret(ctx context.Context, secretName string, namespa
 	return k.CoreV1().Secrets(namespace).Delete(ctx, secretName, metav1.DeleteOptions{})
 }
 
+func (k *K8sClient) PatchSecret(ctx context.Context, secret *corev1.Secret, data []byte, pt types.PatchType) error {
+	if secret == nil {
+		klog.V(5).Info("Patch secret: secret is nil")
+		return nil
+	}
+	klog.V(6).Infof("Patch secret %v", secret.Name)
+	_, err := k.CoreV1().Secrets(secret.Namespace).Patch(ctx, secret.Name, pt, data, metav1.PatchOptions{})
+	return err
+}
+
 func (k *K8sClient) GetJob(ctx context.Context, jobName, namespace string) (*batchv1.Job, error) {
 	klog.V(6).Infof("Get job %s", jobName)
 	job, err := k.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})

--- a/pkg/util/pvc.go
+++ b/pkg/util/pvc.go
@@ -139,7 +139,7 @@ func CheckForSecretFinalizer(ctx context.Context, client *k8s.K8sClient, volume 
 		pvSecretName := pv.Spec.PersistentVolumeSource.CSI.VolumeAttributes[config.ProvisionerSecretName]
 		// Cannot remove the secret if it is used by another pv
 		if secretNamespace == pvSecretNamespace && secretName == pvSecretName {
-			klog.V(6).Infof("PV %s uses the same secret %s/%s", pv.Name, pvSecretNamespace, pvSecretName)
+			klog.V(5).Infof("PV %s uses the same secret %s/%s", pv.Name, pvSecretNamespace, pvSecretName)
 			return false, nil
 		}
 	}

--- a/pkg/util/pvc.go
+++ b/pkg/util/pvc.go
@@ -18,13 +18,17 @@ package util
 
 import (
 	"context"
+	"encoding/json"
+	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"regexp"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 
+	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 	k8s "github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
 )
 
@@ -112,4 +116,67 @@ func (meta *PVCMetadata) ResolveSecret(str string, pvName string) string {
 		return ""
 	})
 	return resolved
+}
+
+func CheckForSecretFinalizer(ctx context.Context, client *k8s.K8sClient, volume *v1.PersistentVolume) (shouldRemoveFinalizer bool, err error) {
+	sc := volume.Spec.StorageClassName
+	secretNamespace := volume.Spec.PersistentVolumeSource.CSI.VolumeAttributes[config.ProvisionerSecretNamespace]
+	secretName := volume.Spec.PersistentVolumeSource.CSI.VolumeAttributes[config.ProvisionerSecretName]
+	if sc == "" || secretNamespace == "" || secretName == "" {
+		klog.V(5).Infof("Cannot check for the secret, storageclass: %s, secretNamespace: %s, secretName: %s", sc, secretNamespace, secretName)
+		return false, nil
+	}
+	// get all pvs
+	pvs, err := client.ListPersistentVolumes(ctx, nil, nil)
+	if err != nil {
+		return false, err
+	}
+	for _, pv := range pvs {
+		if pv.Name == volume.Name || pv.DeletionTimestamp != nil || pv.Spec.StorageClassName != sc {
+			continue
+		}
+		pvSecretNamespace := pv.Spec.PersistentVolumeSource.CSI.VolumeAttributes[config.ProvisionerSecretNamespace]
+		pvSecretName := pv.Spec.PersistentVolumeSource.CSI.VolumeAttributes[config.ProvisionerSecretName]
+		// Cannot remove the secret if it is used by another pv
+		if secretNamespace == pvSecretNamespace && secretName == pvSecretName {
+			klog.V(6).Infof("PV %s uses the same secret %s/%s", pv.Name, pvSecretNamespace, pvSecretName)
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func patchSecretFinalizer(ctx context.Context, client *k8s.K8sClient, secret *v1.Secret) error {
+	f := secret.GetFinalizers()
+	payload := []k8s.PatchListValue{{
+		Op:    "replace",
+		Path:  "/metadata/finalizers",
+		Value: f,
+	}}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		klog.Errorf("Parse json error: %v", err)
+		return err
+	}
+	if err := client.PatchSecret(ctx, secret, payloadBytes, types.JSONPatchType); err != nil {
+		klog.Errorf("Patch secret err:%v", err)
+		return err
+	}
+	return nil
+}
+
+func AddSecretFinalizer(ctx context.Context, client *k8s.K8sClient, secret *v1.Secret, finalizer string) error {
+	if controllerutil.ContainsFinalizer(secret, finalizer) {
+		return nil
+	}
+	controllerutil.AddFinalizer(secret, finalizer)
+	return patchSecretFinalizer(ctx, client, secret)
+}
+
+func RemoveSecretFinalizer(ctx context.Context, client *k8s.K8sClient, secret *v1.Secret, finalizer string) error {
+	if !controllerutil.ContainsFinalizer(secret, finalizer) {
+		return nil
+	}
+	controllerutil.RemoveFinalizer(secret, finalizer)
+	return patchSecretFinalizer(ctx, client, secret)
 }


### PR DESCRIPTION
https://github.com/juicedata/juicefs-csi-driver/issues/707

Here is a draft patch. It works in my cluster.

the secret can't delete if there is a pv referring to it
```
$ kubectl delete secret juicefs-secret -n kyungwan-nam
secret "juicefs-secret" deleted

^C
$ kubectl describe secret juicefs-secret  -n kyungwan-nam
Name:         juicefs-secret
Namespace:    kwnam
Labels:       <none>
Annotations:  <none>

Type:  Opaque

Data
====
access-key:      5 bytes
bucket:          59 bytes
format-options:  29 bytes
metaurl:         46 bytes
name:            11 bytes
secret-key:      10 bytes
storage:         5 bytes

$ kubectl delete pvc juicefs-pvc -n kyungwan-nam
persistentvolumeclaim "juicefs-pvc" deleted
$ kubectl describe secret juicefs-secret  -n kyungwan-nam
Error from server (NotFound): secrets "juicefs-secret" not found
```

Can you review or comment?
Thank!