### PR TITLE
fix: Secret Finalizer doesn't release if retain reclaimPolicy

### DIFF
--- a/pkg/driver/provisioner.go
+++ b/pkg/driver/provisioner.go
@@ -149,7 +149,8 @@ func (j *provisionerService) Provision(ctx context.Context, options provisioncon
 			Namespace: scParams[config.ControllerExpandSecretNamespace],
 		}
 	}
-	if options.StorageClass.Parameters["secretFinalizer"] == "true" {
+
+	if pv.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimDelete && options.StorageClass.Parameters["secretFinalizer"] == "true" {
 		klog.V(6).Infof("Provisioner: Add Finalizer on %s/%s", secret.Namespace, secret.Name)
 		err = util.AddSecretFinalizer(ctx, j.K8sClient, secret, config.Finalizer)
 		if err != nil {


### PR DESCRIPTION
fix https://github.com/juicedata/juicefs-csi-driver/issues/734
don't have to set the secret finalizer if not ``Delete`` ReclaimPolicy.

