### PR TITLE
support vci serverless

### DIFF
--- a/.github/scripts/e2e-test.py
+++ b/.github/scripts/e2e-test.py
@@ -25,7 +25,6 @@ from test_case import (
     test_static_delete_policy,
     test_deployment_using_storage_rw,
     test_quota_using_storage_rw,
-    test_deployment_using_storage_ro,
     test_deployment_use_pv_rw,
     test_deployment_use_pv_ro,
     test_delete_all,
@@ -67,7 +66,6 @@ if __name__ == "__main__":
                 test_dynamic_cache_clean_upon_umount()
                 test_static_delete_policy()
                 test_deployment_using_storage_rw()
-                test_deployment_using_storage_ro()
                 test_deployment_use_pv_rw()
                 test_deployment_use_pv_ro()
                 test_delete_one()
@@ -109,7 +107,6 @@ if __name__ == "__main__":
                 test_job_complete_using_storage()
                 test_static_delete_policy()
                 test_deployment_using_storage_rw()
-                test_deployment_using_storage_ro()
                 test_dynamic_mount_image_with_webhook()
                 test_static_mount_image_with_webhook()
                 test_deployment_dynamic_patch_pv_with_webhook()
@@ -121,7 +118,6 @@ if __name__ == "__main__":
                 test_webhook_two_volume()
                 test_static_delete_policy()
                 test_deployment_using_storage_rw()
-                test_deployment_using_storage_ro()
                 test_deployment_use_pv_rw()
                 test_deployment_use_pv_ro()
                 test_deployment_dynamic_patch_pv_with_webhook()
@@ -138,7 +134,6 @@ if __name__ == "__main__":
                 test_static_cache_clean_upon_umount()
                 test_dynamic_cache_clean_upon_umount()
                 test_deployment_using_storage_rw()
-                test_deployment_using_storage_ro()
                 test_deployment_use_pv_rw()
                 test_deployment_use_pv_ro()
                 test_delete_pvc()

--- a/.github/scripts/test_case.py
+++ b/.github/scripts/test_case.py
@@ -164,6 +164,7 @@ def test_quota_using_storage_rw():
     return
 
 
+# this case is not valid.
 def test_deployment_using_storage_ro():
     LOG.info("[test case] Deployment using storageClass with rom begin..")
     # deploy pvc

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -572,3 +572,38 @@ metadata:
 spec:
   attachRequired: false
   podInfoOnMount: true
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
+  name: juicefs-admission-serverless-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    caBundle: CA_BUNDLE
+    service:
+      name: juicefs-admission-webhook
+      namespace: kube-system
+      path: /juicefs/serverless/inject-v1-pod
+  failurePolicy: Fail
+  name: sidecar.inject.serverless.juicefs.com
+  namespaceSelector:
+    matchLabels:
+      juicefs.com/enable-serverless-injection: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+  timeoutSeconds: 20

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -69,6 +69,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - nodes/proxy
   verbs:
   - '*'
@@ -572,38 +579,3 @@ metadata:
 spec:
   attachRequired: false
   podInfoOnMount: true
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/instance: juicefs-csi-driver
-    app.kubernetes.io/name: juicefs-csi-driver
-    app.kubernetes.io/version: master
-  name: juicefs-admission-serverless-webhook
-webhooks:
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    caBundle: CA_BUNDLE
-    service:
-      name: juicefs-admission-webhook
-      namespace: kube-system
-      path: /juicefs/serverless/inject-v1-pod
-  failurePolicy: Fail
-  name: sidecar.inject.serverless.juicefs.com
-  namespaceSelector:
-    matchLabels:
-      juicefs.com/enable-serverless-injection: "true"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - pods
-  sideEffects: None
-  timeoutSeconds: 20

--- a/deploy/k8s_before_v1_18.yaml
+++ b/deploy/k8s_before_v1_18.yaml
@@ -572,3 +572,38 @@ metadata:
 spec:
   attachRequired: false
   podInfoOnMount: true
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
+  name: juicefs-admission-serverless-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    caBundle: CA_BUNDLE
+    service:
+      name: juicefs-admission-webhook
+      namespace: kube-system
+      path: /juicefs/serverless/inject-v1-pod
+  failurePolicy: Fail
+  name: sidecar.inject.serverless.juicefs.com
+  namespaceSelector:
+    matchLabels:
+      juicefs.com/enable-serverless-injection: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+  timeoutSeconds: 20

--- a/deploy/k8s_before_v1_18.yaml
+++ b/deploy/k8s_before_v1_18.yaml
@@ -69,6 +69,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - nodes/proxy
   verbs:
   - '*'
@@ -572,38 +579,3 @@ metadata:
 spec:
   attachRequired: false
   podInfoOnMount: true
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  labels:
-    app.kubernetes.io/instance: juicefs-csi-driver
-    app.kubernetes.io/name: juicefs-csi-driver
-    app.kubernetes.io/version: master
-  name: juicefs-admission-serverless-webhook
-webhooks:
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    caBundle: CA_BUNDLE
-    service:
-      name: juicefs-admission-webhook
-      namespace: kube-system
-      path: /juicefs/serverless/inject-v1-pod
-  failurePolicy: Fail
-  name: sidecar.inject.serverless.juicefs.com
-  namespaceSelector:
-    matchLabels:
-      juicefs.com/enable-serverless-injection: "true"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - pods
-  sideEffects: None
-  timeoutSeconds: 20

--- a/deploy/kubernetes/base/resources.yaml
+++ b/deploy/kubernetes/base/resources.yaml
@@ -510,6 +510,31 @@ webhooks:
       matchLabels:
         juicefs.com/enable-injection: "true"
 ---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: juicefs-admission-serverless-webhook
+webhooks:
+  - name: sidecar.inject.serverless.juicefs.com
+    rules:
+      - apiGroups:   [""]
+        apiVersions: ["v1"]
+        operations:  ["CREATE"]
+        resources:   ["pods"]
+    clientConfig:
+      service:
+        namespace: kube-system
+        name: juicefs-admission-webhook
+        path: "/juicefs/serverless/inject-v1-pod"
+      caBundle: CA_BUNDLE
+    timeoutSeconds: 20
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: ["v1","v1beta1"]
+    namespaceSelector:
+      matchLabels:
+        juicefs.com/enable-serverless-injection: "true"
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/kubernetes/release/kustomization.yaml
+++ b/deploy/kubernetes/release/kustomization.yaml
@@ -42,3 +42,14 @@ patches:
     version: v1
     kind: MutatingWebhookConfiguration
     name: juicefs-admission-webhook
+- patch: |-
+    $patch: delete
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: MutatingWebhookConfiguration
+    metadata:
+      name: juicefs-admission-serverless-webhook
+  target:
+    group: admissionregistration.k8s.io
+    version: v1
+    kind: MutatingWebhookConfiguration
+    name: juicefs-admission-serverless-webhook

--- a/deploy/webhook-with-certmanager.yaml
+++ b/deploy/webhook-with-certmanager.yaml
@@ -382,6 +382,41 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
+  labels:
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
+  name: juicefs-admission-serverless-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    caBundle: CA_BUNDLE
+    service:
+      name: juicefs-admission-webhook
+      namespace: kube-system
+      path: /juicefs/serverless/inject-v1-pod
+  failurePolicy: Fail
+  name: sidecar.inject.serverless.juicefs.com
+  namespaceSelector:
+    matchLabels:
+      juicefs.com/enable-serverless-injection: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+  timeoutSeconds: 20
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
   annotations:
     cert-manager.io/inject-ca-from: kube-system/juicefs-cert
   labels:

--- a/deploy/webhook.yaml
+++ b/deploy/webhook.yaml
@@ -391,6 +391,41 @@ metadata:
     app.kubernetes.io/instance: juicefs-csi-driver
     app.kubernetes.io/name: juicefs-csi-driver
     app.kubernetes.io/version: master
+  name: juicefs-admission-serverless-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    caBundle: CA_BUNDLE
+    service:
+      name: juicefs-admission-webhook
+      namespace: kube-system
+      path: /juicefs/serverless/inject-v1-pod
+  failurePolicy: Fail
+  name: sidecar.inject.serverless.juicefs.com
+  namespaceSelector:
+    matchLabels:
+      juicefs.com/enable-serverless-injection: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+  timeoutSeconds: 20
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
   name: juicefs-admission-webhook
 webhooks:
 - admissionReviewVersions:

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -84,6 +84,12 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 	for k, v := range req.Parameters {
 		volCtx[k] = v
 	}
+	// return error if set readonly in dynamic provisioner
+	for _, vc := range req.VolumeCapabilities {
+		if vc.AccessMode.GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY {
+			return nil, status.Errorf(codes.InvalidArgument, "Dynamic mounting uses the sub-path named pv name as data isolation, so read-only mode cannot be used.")
+		}
+	}
 	// create volume
 	//err := d.juicefs.JfsCreateVol(ctx, volumeId, subPath, secrets, volCtx)
 	//if err != nil {

--- a/pkg/juicefs/mount/builder/common.go
+++ b/pkg/juicefs/mount/builder/common.go
@@ -94,10 +94,6 @@ func (r *BaseBuilder) genCommonJuicePod(cnGen func() corev1.Container) *corev1.P
 			},
 		},
 	}}
-	pod.Spec.Containers[0].Env = []corev1.EnvVar{{
-		Name:  "JFS_FOREGROUND",
-		Value: "1",
-	}}
 	pod.Spec.Containers[0].Resources = r.jfsSetting.Resources
 	pod.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
 		PreStop: &corev1.Handler{

--- a/pkg/juicefs/mount/builder/common.go
+++ b/pkg/juicefs/mount/builder/common.go
@@ -18,13 +18,18 @@ package builder
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
+	"github.com/juicedata/juicefs-csi-driver/pkg/util"
 )
 
 const (
@@ -34,20 +39,293 @@ const (
 	UpdateDBCfgFile = "/etc/updatedb.conf"
 )
 
-type Builder struct {
+type BaseBuilder struct {
 	jfsSetting *config.JfsSetting
 	capacity   int64
 }
 
-func NewBuilder(setting *config.JfsSetting, capacity int64) *Builder {
-	return &Builder{setting, capacity}
+// genPodTemplate generates a pod template from csi pod
+func (r *BaseBuilder) genPodTemplate(baseCnGen func() corev1.Container) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: r.jfsSetting.Attr.Namespace,
+			Labels: map[string]string{
+				config.PodTypeKey:          config.PodTypeValue,
+				config.PodUniqueIdLabelKey: r.jfsSetting.UniqueId,
+			},
+			Annotations: make(map[string]string),
+		},
+		Spec: corev1.PodSpec{
+			Containers:         []corev1.Container{baseCnGen()},
+			NodeName:           config.NodeName,
+			HostNetwork:        r.jfsSetting.Attr.HostNetwork,
+			HostAliases:        r.jfsSetting.Attr.HostAliases,
+			HostPID:            r.jfsSetting.Attr.HostPID,
+			HostIPC:            r.jfsSetting.Attr.HostIPC,
+			DNSConfig:          r.jfsSetting.Attr.DNSConfig,
+			DNSPolicy:          r.jfsSetting.Attr.DNSPolicy,
+			ServiceAccountName: r.jfsSetting.ServiceAccountName,
+			ImagePullSecrets:   r.jfsSetting.Attr.ImagePullSecrets,
+			PreemptionPolicy:   r.jfsSetting.Attr.PreemptionPolicy,
+			Tolerations:        r.jfsSetting.Attr.Tolerations,
+		},
+	}
 }
 
-func (r *Builder) generateJuicePod() *corev1.Pod {
-	pod := r.generatePodTemplate()
+// genCommonJuicePod generates a pod with common settings
+func (r *BaseBuilder) genCommonJuicePod(cnGen func() corev1.Container) *corev1.Pod {
+	pod := r.genPodTemplate(cnGen)
+	// labels & annotations
+	pod.ObjectMeta.Labels, pod.ObjectMeta.Annotations = r._genMetadata()
+	pod.Spec.ServiceAccountName = r.jfsSetting.ServiceAccountName
+	pod.Spec.PriorityClassName = config.JFSMountPriorityName
+	pod.Spec.RestartPolicy = corev1.RestartPolicyAlways
+	gracePeriod := int64(10)
+	pod.Spec.TerminationGracePeriodSeconds = &gracePeriod
+	controllerutil.AddFinalizer(pod, config.Finalizer)
 
-	volumes := r.getVolumes()
-	volumeMounts := r.getVolumeMounts()
+	volumes, volumeMounts := r._genJuiceVolumes()
+	pod.Spec.Volumes = volumes
+	pod.Spec.Containers[0].VolumeMounts = volumeMounts
+	pod.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{{
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: r.jfsSetting.SecretName,
+			},
+		},
+	}}
+	pod.Spec.Containers[0].Env = []corev1.EnvVar{{
+		Name:  "JFS_FOREGROUND",
+		Value: "1",
+	}}
+	pod.Spec.Containers[0].Resources = r.jfsSetting.Resources
+	pod.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
+		PreStop: &corev1.Handler{
+			Exec: &corev1.ExecAction{Command: []string{"sh", "-c", fmt.Sprintf(
+				"umount %s && rmdir %s", r.jfsSetting.MountPath, r.jfsSetting.MountPath)}},
+		},
+	}
+
+	if r.jfsSetting.Attr.HostNetwork {
+		// When using hostNetwork, the MountPod will use a random port for metrics.
+		// Before inducing any auxiliary method to detect that random port, the
+		// best way is to avoid announcing any port about that.
+		pod.Spec.Containers[0].Ports = []corev1.ContainerPort{}
+	} else {
+		pod.Spec.Containers[0].Ports = []corev1.ContainerPort{
+			{Name: "metrics", ContainerPort: r.genMetricsPort()},
+		}
+	}
+	return pod
+}
+
+// genMountCommand generates mount command
+func (r *BaseBuilder) genMountCommand() string {
+	cmd := ""
+	options := r.jfsSetting.Options
+	if r.jfsSetting.IsCe {
+		klog.V(5).Infof("ceMount: mount %v at %v", util.StripPasswd(r.jfsSetting.Source), r.jfsSetting.MountPath)
+		mountArgs := []string{config.CeMountPath, "${metaurl}", r.jfsSetting.MountPath}
+		if !util.ContainsPrefix(options, "metrics=") {
+			if r.jfsSetting.Attr.HostNetwork {
+				// Pick up a random (useable) port for hostNetwork MountPods.
+				options = append(options, "metrics=0.0.0.0:0")
+			} else {
+				options = append(options, "metrics=0.0.0.0:9567")
+			}
+		}
+		mountArgs = append(mountArgs, "-o", strings.Join(options, ","))
+		cmd = strings.Join(mountArgs, " ")
+	} else {
+		klog.V(5).Infof("Mount: mount %v at %v", util.StripPasswd(r.jfsSetting.Source), r.jfsSetting.MountPath)
+		mountArgs := []string{config.JfsMountPath, r.jfsSetting.Source, r.jfsSetting.MountPath}
+		mountOptions := []string{"foreground", "no-update"}
+		if r.jfsSetting.EncryptRsaKey != "" {
+			mountOptions = append(mountOptions, "rsa-key=/root/.rsa/rsa-key.pem")
+		}
+		mountOptions = append(mountOptions, options...)
+		mountArgs = append(mountArgs, "-o", strings.Join(mountOptions, ","))
+		cmd = strings.Join(mountArgs, " ")
+	}
+	return util.QuoteForShell(cmd)
+}
+
+// genInitCommand generates init command
+func (r *BaseBuilder) genInitCommand() string {
+	formatCmd := r.jfsSetting.FormatCmd
+	if r.jfsSetting.EncryptRsaKey != "" {
+		if r.jfsSetting.IsCe {
+			formatCmd = formatCmd + " --encrypt-rsa-key=/root/.rsa/rsa-key.pem"
+		}
+	}
+	initCmds := []string{formatCmd}
+
+	// create subpath if readonly mount or in webhook mode
+	if r.jfsSetting.SubPath != "" {
+		if util.ContainsString(r.jfsSetting.Options, "read-only") || util.ContainsString(r.jfsSetting.Options, "ro") || config.Webhook {
+			// generate mount command
+			initCmds = append(initCmds,
+				r.getJobCommand(),
+				fmt.Sprintf("if [ ! -d /mnt/jfs/%s ]; then mkdir -m 777 /mnt/jfs/%s; fi;", r.jfsSetting.SubPath, r.jfsSetting.SubPath),
+				"umount /mnt/jfs",
+			)
+			// set quota in webhook mode
+			if config.Webhook && r.capacity > 0 {
+				quotaPath := r.jfsSetting.SubPath
+				var subdir string
+				for _, o := range r.jfsSetting.Options {
+					pair := strings.Split(o, "=")
+					if len(pair) != 2 {
+						continue
+					}
+					if pair[0] == "subdir" {
+						subdir = path.Join("/", pair[1])
+					}
+				}
+				var setQuotaCmd string
+				targetPath := path.Join(subdir, quotaPath)
+				capacity := strconv.FormatInt(r.capacity, 10)
+				if r.jfsSetting.IsCe {
+					// juicefs quota; if [ $? -eq 0 ]; then juicefs quota set ${metaurl} --path ${path} --capacity ${capacity}; fi
+					cmdArgs := []string{
+						config.CeCliPath, "quota; if [ $? -eq 0 ]; then",
+						config.CeCliPath,
+						"quota", "set", "${metaurl}",
+						"--path", targetPath,
+						"--capacity", capacity,
+						"; fi",
+					}
+					setQuotaCmd = strings.Join(cmdArgs, " ")
+				} else {
+					cmdArgs := []string{
+						config.CliPath, "quota; if [ $? -eq 0 ]; then",
+						config.CliPath,
+						"quota", "set", r.jfsSetting.Name,
+						"--path", targetPath,
+						"--capacity", capacity,
+						"; fi",
+					}
+					setQuotaCmd = strings.Join(cmdArgs, " ")
+				}
+				initCmds = append(initCmds, setQuotaCmd)
+			}
+		}
+	}
+	return strings.Join(initCmds, "\n")
+}
+
+// genJobCommand generates job command
+func (r *BaseBuilder) getJobCommand() string {
+	var cmd string
+	options := util.StripReadonlyOption(r.jfsSetting.Options)
+	if r.jfsSetting.IsCe {
+		args := []string{config.CeMountPath, "${metaurl}", "/mnt/jfs"}
+		if len(options) != 0 {
+			args = append(args, "-o", strings.Join(options, ","))
+		}
+		cmd = strings.Join(args, " ")
+	} else {
+		args := []string{config.JfsMountPath, r.jfsSetting.Source, "/mnt/jfs"}
+		if r.jfsSetting.EncryptRsaKey != "" {
+			options = append(options, "rsa-key=/root/.rsa/rsa-key.pem")
+		}
+		options = append(options, "background")
+		args = append(args, "-o", strings.Join(options, ","))
+		cmd = strings.Join(args, " ")
+	}
+	return util.QuoteForShell(cmd)
+}
+
+// genMetricsPort generates metrics port
+func (r *BaseBuilder) genMetricsPort() int32 {
+	port := int64(9567)
+	options := r.jfsSetting.Options
+
+	for _, option := range options {
+		if strings.HasPrefix(option, "metrics=") {
+			re := regexp.MustCompile(`metrics=.*:([0-9]{1,6})`)
+			match := re.FindStringSubmatch(option)
+			if len(match) > 0 {
+				port, _ = strconv.ParseInt(match[1], 10, 32)
+			}
+		}
+	}
+
+	return int32(port)
+}
+
+// _genMetadata generates labels & annotations
+func (r *BaseBuilder) _genMetadata() (labels map[string]string, annotations map[string]string) {
+	labels = map[string]string{
+		config.PodTypeKey:          config.PodTypeValue,
+		config.PodUniqueIdLabelKey: r.jfsSetting.UniqueId,
+	}
+	annotations = map[string]string{}
+
+	for k, v := range r.jfsSetting.MountPodLabels {
+		labels[k] = v
+	}
+	for k, v := range r.jfsSetting.MountPodAnnotations {
+		annotations[k] = v
+	}
+	if r.jfsSetting.DeletedDelay != "" {
+		annotations[config.DeleteDelayTimeKey] = r.jfsSetting.DeletedDelay
+	}
+	annotations[config.JuiceFSUUID] = r.jfsSetting.UUID
+	annotations[config.UniqueId] = r.jfsSetting.UniqueId
+	if r.jfsSetting.CleanCache {
+		annotations[config.CleanCache] = "true"
+	}
+	return
+}
+
+// _genJuiceVolumes generates volumes & volumeMounts
+// 1. if encrypt_rsa_key is set, mount secret to /root/.rsa
+// 2. if init_config is set, mount secret to /root/.config
+// 3. configs in secret
+func (r *BaseBuilder) _genJuiceVolumes() ([]corev1.Volume, []corev1.VolumeMount) {
+	volumes := []corev1.Volume{}
+	volumeMounts := []corev1.VolumeMount{}
+	secretName := r.jfsSetting.SecretName
+
+	if r.jfsSetting.EncryptRsaKey != "" {
+		volumes = append(volumes, corev1.Volume{
+			Name: "rsa-key",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secretName,
+					Items: []corev1.KeyToPath{{
+						Key:  "encrypt_rsa_key",
+						Path: "rsa-key.pem",
+					}},
+				},
+			},
+		})
+		volumeMounts = append(volumeMounts,
+			corev1.VolumeMount{
+				Name:      "rsa-key",
+				MountPath: "/root/.rsa",
+			},
+		)
+	}
+	if r.jfsSetting.InitConfig != "" {
+		volumes = append(volumes, corev1.Volume{
+			Name: "init-config",
+			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+				SecretName: secretName,
+				Items: []corev1.KeyToPath{{
+					Key:  "init_config",
+					Path: r.jfsSetting.Name + ".conf",
+				}},
+			}},
+		})
+		volumeMounts = append(volumeMounts,
+			corev1.VolumeMount{
+				Name:      "init-config",
+				MountPath: "/root/.juicefs",
+			},
+		)
+	}
 	i := 1
 	for k, v := range r.jfsSetting.Configs {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
@@ -64,235 +342,5 @@ func (r *Builder) generateJuicePod() *corev1.Pod {
 		})
 		i++
 	}
-
-	pod.Spec.Volumes = volumes
-	pod.Spec.Containers[0].VolumeMounts = volumeMounts
-	pod.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{{
-		SecretRef: &corev1.SecretEnvSource{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: r.jfsSetting.SecretName,
-			},
-		},
-	}}
-	if r.jfsSetting.FormatCmd != "" {
-		initContainer := r.getInitContainer()
-		initContainer.VolumeMounts = append(initContainer.VolumeMounts, volumeMounts...)
-		pod.Spec.InitContainers = []corev1.Container{initContainer}
-	}
-	return pod
-}
-
-func (r *Builder) getVolumes() []corev1.Volume {
-	dir := corev1.HostPathDirectoryOrCreate
-	file := corev1.HostPathFileOrCreate
-	secretName := r.jfsSetting.SecretName
-	volumes := []corev1.Volume{{
-		Name: JfsDirName,
-		VolumeSource: corev1.VolumeSource{
-			HostPath: &corev1.HostPathVolumeSource{
-				Path: config.MountPointPath,
-				Type: &dir,
-			},
-		},
-	}}
-
-	if !config.Immutable {
-		volumes = append(volumes, corev1.Volume{
-			Name: UpdateDBDirName,
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: UpdateDBCfgFile,
-					Type: &file,
-				},
-			}})
-	}
-
-	if r.jfsSetting.FormatCmd != "" {
-		// initContainer will generate xx.conf to share with mount container
-		volumes = append(volumes, corev1.Volume{
-			Name: JfsRootDirName,
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: nil,
-			},
-		})
-	}
-	if r.jfsSetting.EncryptRsaKey != "" {
-		volumes = append(volumes, corev1.Volume{
-			Name: "rsa-key",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: secretName,
-					Items: []corev1.KeyToPath{{
-						Key:  "encrypt_rsa_key",
-						Path: "rsa-key.pem",
-					}},
-				},
-			},
-		})
-	}
-	if config.Webhook {
-		var mode int32 = 0755
-		volumes = append(volumes, corev1.Volume{
-			Name: "jfs-check-mount",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName:  secretName,
-					DefaultMode: utilpointer.Int32Ptr(mode),
-				},
-			},
-		})
-	}
-	if r.jfsSetting.InitConfig != "" {
-		volumes = append(volumes, corev1.Volume{
-			Name: "init-config",
-			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
-				SecretName: secretName,
-				Items: []corev1.KeyToPath{{
-					Key:  "init_config",
-					Path: r.jfsSetting.Name + ".conf",
-				}},
-			}},
-		})
-	}
-	return volumes
-}
-
-func (r *Builder) getVolumeMounts() []corev1.VolumeMount {
-	mp := corev1.MountPropagationBidirectional
-	volumeMounts := []corev1.VolumeMount{{
-		Name:             JfsDirName,
-		MountPath:        config.PodMountBase,
-		MountPropagation: &mp,
-	}}
-
-	if !config.Immutable {
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:             UpdateDBDirName,
-			MountPath:        UpdateDBCfgFile,
-			MountPropagation: &mp,
-		})
-	}
-
-	if r.jfsSetting.FormatCmd != "" {
-		// initContainer will generate xx.conf to share with mount container
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:             JfsRootDirName,
-			MountPath:        "/root/.juicefs",
-			MountPropagation: &mp,
-		})
-	}
-	if r.jfsSetting.EncryptRsaKey != "" {
-		if !r.jfsSetting.IsCe {
-			volumeMounts = append(volumeMounts,
-				corev1.VolumeMount{
-					Name:      "rsa-key",
-					MountPath: "/root/.rsa",
-				},
-			)
-		}
-	}
-	if r.jfsSetting.InitConfig != "" {
-		volumeMounts = append(volumeMounts,
-			corev1.VolumeMount{
-				Name:      "init-config",
-				MountPath: "/root/.juicefs",
-			},
-		)
-	}
-	if config.Webhook {
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "jfs-check-mount",
-			MountPath: checkMountScriptPath,
-			SubPath:   checkMountScriptName,
-		})
-	}
-	return volumeMounts
-}
-
-func (r *Builder) generateCleanCachePod() *corev1.Pod {
-	volumeMountPrefix := "/var/jfsCache"
-	cacheVolumes := []corev1.Volume{}
-	cacheVolumeMounts := []corev1.VolumeMount{}
-
-	hostPathType := corev1.HostPathDirectory
-
-	for idx, cacheDir := range r.jfsSetting.CacheDirs {
-		name := fmt.Sprintf("cachedir-%d", idx)
-
-		hostPathVolume := corev1.Volume{
-			Name: name,
-			VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-				Path: filepath.Join(cacheDir, r.jfsSetting.UUID, "raw"),
-				Type: &hostPathType,
-			}},
-		}
-		cacheVolumes = append(cacheVolumes, hostPathVolume)
-
-		volumeMount := corev1.VolumeMount{
-			Name:      name,
-			MountPath: filepath.Join(volumeMountPrefix, name),
-		}
-		cacheVolumeMounts = append(cacheVolumeMounts, volumeMount)
-	}
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: r.jfsSetting.Attr.Namespace,
-			Labels: map[string]string{
-				config.PodTypeKey: config.PodTypeValue,
-			},
-			Annotations: make(map[string]string),
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:         "jfs-cache-clean",
-				Image:        r.jfsSetting.Attr.Image,
-				Command:      []string{"sh", "-c", "rm -rf /var/jfsCache/*/chunks"},
-				VolumeMounts: cacheVolumeMounts,
-			}},
-			Volumes: cacheVolumes,
-		},
-	}
-	return pod
-}
-
-func (r *Builder) generatePodTemplate() *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: r.jfsSetting.Attr.Namespace,
-			Labels: map[string]string{
-				config.PodTypeKey:          config.PodTypeValue,
-				config.PodUniqueIdLabelKey: r.jfsSetting.UniqueId,
-			},
-			Annotations: make(map[string]string),
-		},
-		Spec: corev1.PodSpec{
-			Containers:         []corev1.Container{r.genCommonContainer()},
-			NodeName:           config.NodeName,
-			HostNetwork:        r.jfsSetting.Attr.HostNetwork,
-			HostAliases:        r.jfsSetting.Attr.HostAliases,
-			HostPID:            r.jfsSetting.Attr.HostPID,
-			HostIPC:            r.jfsSetting.Attr.HostIPC,
-			DNSConfig:          r.jfsSetting.Attr.DNSConfig,
-			DNSPolicy:          r.jfsSetting.Attr.DNSPolicy,
-			ServiceAccountName: r.jfsSetting.ServiceAccountName,
-			ImagePullSecrets:   r.jfsSetting.Attr.ImagePullSecrets,
-			PreemptionPolicy:   r.jfsSetting.Attr.PreemptionPolicy,
-			Tolerations:        r.jfsSetting.Attr.Tolerations,
-		},
-	}
-}
-
-func (r *Builder) genCommonContainer() corev1.Container {
-	isPrivileged := true
-	rootUser := int64(0)
-	return corev1.Container{
-		Name:  config.MountContainerName,
-		Image: r.jfsSetting.Attr.Image,
-		SecurityContext: &corev1.SecurityContext{
-			Privileged: &isPrivileged,
-			RunAsUser:  &rootUser,
-		},
-		Env: []corev1.EnvVar{},
-	}
+	return volumes, volumeMounts
 }

--- a/pkg/juicefs/mount/builder/common.go
+++ b/pkg/juicefs/mount/builder/common.go
@@ -159,7 +159,7 @@ func (r *BaseBuilder) genMountCommand() string {
 
 // genInitContainer: generate init container
 func (r *BaseBuilder) genInitContainer(cnGen func() corev1.Container) *corev1.Container {
-	if r.jfsSetting.SubPath == "" && !util.ContainsString(r.jfsSetting.Options, "read-only") && !util.ContainsString(r.jfsSetting.Options, "ro") && !config.Webhook {
+	if r.jfsSetting.SubPath == "" {
 		// do not need initContainer if no subpath
 		return nil
 	}
@@ -217,6 +217,8 @@ func (r *BaseBuilder) genInitContainer(cnGen func() corev1.Container) *corev1.Co
 			}
 			initCmds = append(initCmds, setQuotaCmd)
 		}
+	} else {
+		return nil
 	}
 	container.Command = []string{"sh", "-c", strings.Join(initCmds, "\n")}
 	return &container

--- a/pkg/juicefs/mount/builder/common.go
+++ b/pkg/juicefs/mount/builder/common.go
@@ -111,18 +111,6 @@ func (r *BaseBuilder) genCommonJuicePod(cnGen func() corev1.Container) *corev1.P
 			{Name: "metrics", ContainerPort: r.genMetricsPort()},
 		}
 	}
-	if initContainer := r.genInitContainer(cnGen); initContainer != nil {
-		// initContainer should have the same volumeMounts as mount container
-		initContainer.VolumeMounts = pod.Spec.Containers[0].VolumeMounts
-		initContainer.EnvFrom = []corev1.EnvFromSource{{
-			SecretRef: &corev1.SecretEnvSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: r.jfsSetting.SecretName,
-				},
-			},
-		}}
-		pod.Spec.InitContainers = []corev1.Container{*initContainer}
-	}
 	return pod
 }
 
@@ -157,73 +145,6 @@ func (r *BaseBuilder) genMountCommand() string {
 	return util.QuoteForShell(cmd)
 }
 
-// genInitContainer: generate init container
-func (r *BaseBuilder) genInitContainer(cnGen func() corev1.Container) *corev1.Container {
-	if r.jfsSetting.SubPath == "" {
-		// do not need initContainer if no subpath
-		return nil
-	}
-	container := cnGen()
-	container.Name = "jfs-init"
-
-	initCmds := []string{
-		r.genInitCommand(),
-	}
-	// create subpath if readonly mount or in webhook mode
-	if util.ContainsString(r.jfsSetting.Options, "read-only") || util.ContainsString(r.jfsSetting.Options, "ro") || config.Webhook {
-		// generate mount command
-		initCmds = append(initCmds,
-			r.getJobCommand(),
-			fmt.Sprintf("if [ ! -d /mnt/jfs/%s ]; then mkdir -m 777 /mnt/jfs/%s; fi;", r.jfsSetting.SubPath, r.jfsSetting.SubPath),
-			"umount /mnt/jfs",
-		)
-		// set quota in webhook mode
-		if config.Webhook && r.capacity > 0 {
-			quotaPath := r.jfsSetting.SubPath
-			var subdir string
-			for _, o := range r.jfsSetting.Options {
-				pair := strings.Split(o, "=")
-				if len(pair) != 2 {
-					continue
-				}
-				if pair[0] == "subdir" {
-					subdir = path.Join("/", pair[1])
-				}
-			}
-			var setQuotaCmd string
-			targetPath := path.Join(subdir, quotaPath)
-			capacity := strconv.FormatInt(r.capacity, 10)
-			if r.jfsSetting.IsCe {
-				// juicefs quota; if [ $? -eq 0 ]; then juicefs quota set ${metaurl} --path ${path} --capacity ${capacity}; fi
-				cmdArgs := []string{
-					config.CeCliPath, "quota; if [ $? -eq 0 ]; then",
-					config.CeCliPath,
-					"quota", "set", "${metaurl}",
-					"--path", targetPath,
-					"--capacity", capacity,
-					"; fi",
-				}
-				setQuotaCmd = strings.Join(cmdArgs, " ")
-			} else {
-				cmdArgs := []string{
-					config.CliPath, "quota; if [ $? -eq 0 ]; then",
-					config.CliPath,
-					"quota", "set", r.jfsSetting.Name,
-					"--path", targetPath,
-					"--capacity", capacity,
-					"; fi",
-				}
-				setQuotaCmd = strings.Join(cmdArgs, " ")
-			}
-			initCmds = append(initCmds, setQuotaCmd)
-		}
-	} else {
-		return nil
-	}
-	container.Command = []string{"sh", "-c", strings.Join(initCmds, "\n")}
-	return &container
-}
-
 // genInitCommand generates init command
 func (r *BaseBuilder) genInitCommand() string {
 	formatCmd := r.jfsSetting.FormatCmd
@@ -232,8 +153,50 @@ func (r *BaseBuilder) genInitCommand() string {
 			formatCmd = formatCmd + " --encrypt-rsa-key=/root/.rsa/rsa-key.pem"
 		}
 	}
+	initCmds := []string{formatCmd}
 
-	return formatCmd
+	// set quota in webhook mode
+	if config.Webhook && r.capacity > 0 {
+		quotaPath := r.jfsSetting.SubPath
+		var subdir string
+		for _, o := range r.jfsSetting.Options {
+			pair := strings.Split(o, "=")
+			if len(pair) != 2 {
+				continue
+			}
+			if pair[0] == "subdir" {
+				subdir = path.Join("/", pair[1])
+			}
+		}
+		var setQuotaCmd string
+		targetPath := path.Join(subdir, quotaPath)
+		capacity := strconv.FormatInt(r.capacity, 10)
+		if r.jfsSetting.IsCe {
+			// juicefs quota; if [ $? -eq 0 ]; then juicefs quota set ${metaurl} --path ${path} --capacity ${capacity}; fi
+			cmdArgs := []string{
+				config.CeCliPath, "quota; if [ $? -eq 0 ]; then",
+				config.CeCliPath,
+				"quota", "set", "${metaurl}",
+				"--path", targetPath,
+				"--capacity", capacity,
+				"; fi",
+			}
+			setQuotaCmd = strings.Join(cmdArgs, " ")
+		} else {
+			cmdArgs := []string{
+				config.CliPath, "quota; if [ $? -eq 0 ]; then",
+				config.CliPath,
+				"quota", "set", r.jfsSetting.Name,
+				"--path", targetPath,
+				"--capacity", capacity,
+				"; fi",
+			}
+			setQuotaCmd = strings.Join(cmdArgs, " ")
+		}
+		initCmds = append(initCmds, setQuotaCmd)
+	}
+
+	return strings.Join(initCmds, "\n")
 }
 
 // genJobCommand generates job command

--- a/pkg/juicefs/mount/builder/container.go
+++ b/pkg/juicefs/mount/builder/container.go
@@ -54,7 +54,7 @@ func (r *ContainerBuilder) NewMountSidecar() *corev1.Pod {
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, volumeMounts...)
 	pod.Spec.Containers[0].Lifecycle.PostStart = &corev1.Handler{
 		Exec: &corev1.ExecAction{Command: []string{"bash", "-c",
-			fmt.Sprintf("time %s %s >> /proc/1/fd/1", checkMountScriptPath, r.jfsSetting.MountPath)}},
+			fmt.Sprintf("time %s %s %s >> /proc/1/fd/1", checkMountScriptPath, r.jfsSetting.MountPath, r.jfsSetting.SubPath)}},
 	}
 	return pod
 }

--- a/pkg/juicefs/mount/builder/container.go
+++ b/pkg/juicefs/mount/builder/container.go
@@ -1,5 +1,5 @@
 /*
- Copyright 2022 Juicedata Inc
+ Copyright 2023 Juicedata Inc
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -17,21 +17,81 @@
 package builder
 
 import (
+	"fmt"
+	"path/filepath"
+
 	corev1 "k8s.io/api/core/v1"
+	utilpointer "k8s.io/utils/pointer"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 )
 
-func (r *Builder) NewMountSidecar() *corev1.Pod {
+type ContainerBuilder struct {
+	PodBuilder
+}
+
+var _ SidecarInterface = &ContainerBuilder{}
+
+func NewContainerBuilder(setting *config.JfsSetting, capacity int64) SidecarInterface {
+	return &ContainerBuilder{
+		PodBuilder{BaseBuilder{
+			jfsSetting: setting,
+			capacity:   capacity,
+		}},
+	}
+}
+
+// NewMountSidecar generates a pod with a juicefs sidecar
+// exactly the same spec as Mount Pod
+func (r *ContainerBuilder) NewMountSidecar() *corev1.Pod {
 	pod := r.NewMountPod("")
-	for i, v := range pod.Spec.Volumes {
-		if v.Name == JfsRootDirName {
-			v = corev1.Volume{
-				Name: v.Name,
-				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
-				},
-			}
-			pod.Spec.Volumes[i] = v
-		}
+	// no annotation and label for sidecar
+	pod.Annotations = map[string]string{}
+	pod.Labels = map[string]string{}
+
+	volumes, volumeMounts := r.genSidecarVolumes()
+	pod.Spec.Volumes = append(pod.Spec.Volumes, volumes...)
+	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, volumeMounts...)
+	pod.Spec.Containers[0].Lifecycle.PostStart = &corev1.Handler{
+		Exec: &corev1.ExecAction{Command: []string{"bash", "-c",
+			fmt.Sprintf("time %s %s >> /proc/1/fd/1", checkMountScriptPath, r.jfsSetting.MountPath)}},
 	}
 	return pod
+}
+
+func (r *ContainerBuilder) OverwriteVolumeMounts(mount *corev1.VolumeMount) {
+	// do not overwrite volumeMounts
+	return
+}
+
+func (r *ContainerBuilder) OverwriteVolumes(volume *corev1.Volume, mountPath string) {
+	// overwrite original volume and use juicefs volume mountpoint instead
+	hostMount := filepath.Join(config.MountPointPath, mountPath, r.jfsSetting.SubPath)
+	volume.VolumeSource = corev1.VolumeSource{
+		HostPath: &corev1.HostPathVolumeSource{
+			Path: hostMount,
+		},
+	}
+}
+
+// genSidecarVolumes generates volumes and volumeMounts for sidecar container
+// extra volumes and volumeMounts are used to check mount status
+func (r *ContainerBuilder) genSidecarVolumes() (volumes []corev1.Volume, volumeMounts []corev1.VolumeMount) {
+	var mode int32 = 0755
+	secretName := r.jfsSetting.SecretName
+	volumes = []corev1.Volume{{
+		Name: "jfs-check-mount",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName:  secretName,
+				DefaultMode: utilpointer.Int32Ptr(mode),
+			},
+		},
+	}}
+	volumeMounts = []corev1.VolumeMount{{
+		Name:      "jfs-check-mount",
+		MountPath: checkMountScriptPath,
+		SubPath:   checkMountScriptName,
+	}}
+	return
 }

--- a/pkg/juicefs/mount/builder/interface.go
+++ b/pkg/juicefs/mount/builder/interface.go
@@ -1,0 +1,26 @@
+/*
+ Copyright 2023 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package builder
+
+import corev1 "k8s.io/api/core/v1"
+
+type SidecarInterface interface {
+	NewMountSidecar() *corev1.Pod
+	NewSecret() corev1.Secret
+	OverwriteVolumes(volume *corev1.Volume, mountPath string)
+	OverwriteVolumeMounts(mount *corev1.VolumeMount)
+}

--- a/pkg/juicefs/mount/builder/job.go
+++ b/pkg/juicefs/mount/builder/job.go
@@ -19,6 +19,7 @@ package builder
 import (
 	"crypto/sha256"
 	"fmt"
+	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -48,7 +49,10 @@ func (r *JobBuilder) NewJobForCreateVolume() *batchv1.Job {
 	jobName := GenJobNameByVolumeId(r.jfsSetting.VolumeId) + "-createvol"
 	job := r.newJob(jobName)
 	jobCmd := r.getCreateVolumeCmd()
-	job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", jobCmd}
+	initCmd := r.genInitCommand()
+	cmd := strings.Join([]string{initCmd, jobCmd}, "\n")
+	job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", cmd}
+
 	klog.Infof("create volume job cmd: %s", jobCmd)
 	return job
 }
@@ -57,7 +61,9 @@ func (r *JobBuilder) NewJobForDeleteVolume() *batchv1.Job {
 	jobName := GenJobNameByVolumeId(r.jfsSetting.VolumeId) + "-delvol"
 	job := r.newJob(jobName)
 	jobCmd := r.getDeleteVolumeCmd()
-	job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", jobCmd}
+	initCmd := r.genInitCommand()
+	cmd := strings.Join([]string{initCmd, jobCmd}, "\n")
+	job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", cmd}
 	klog.Infof("delete volume job cmd: %s", jobCmd)
 	return job
 }

--- a/pkg/juicefs/mount/builder/pod.go
+++ b/pkg/juicefs/mount/builder/pod.go
@@ -72,9 +72,6 @@ func (r *PodBuilder) NewMountPod(podName string) *corev1.Pod {
 	pod.Spec.Volumes = append(pod.Spec.Volumes, mountVolumes...)
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, mountVolumeMounts...)
 
-	if len(pod.Spec.InitContainers) != 0 {
-		pod.Spec.InitContainers[0].VolumeMounts = append(pod.Spec.InitContainers[0].VolumeMounts, mountVolumeMounts...)
-	}
 	return pod
 }
 

--- a/pkg/juicefs/mount/builder/pod.go
+++ b/pkg/juicefs/mount/builder/pod.go
@@ -46,6 +46,10 @@ func (r *PodBuilder) NewMountPod(podName string) *corev1.Pod {
 	cmd := r.genMountCommand()
 	pod.Name = podName
 	pod.Spec.Containers[0].Command = []string{"sh", "-c", cmd}
+	pod.Spec.Containers[0].Env = []corev1.EnvVar{{
+		Name:  "JFS_FOREGROUND",
+		Value: "1",
+	}}
 
 	// generate volumes and volumeMounts only used in mount pod
 	volumes, volumeMounts := r.genPodVolumes()

--- a/pkg/juicefs/mount/builder/pod_test.go
+++ b/pkg/juicefs/mount/builder/pod_test.go
@@ -174,9 +174,6 @@ func Test_getCacheDirVolumes(t *testing.T) {
 	volumeMounts := []corev1.VolumeMount{{
 		Name:      JfsDirName,
 		MountPath: config.PodMountBase,
-	}, {
-		Name:      JfsRootDirName,
-		MountPath: "/root/.juicefs",
 	}}
 
 	volumes := []corev1.Volume{{
@@ -184,20 +181,14 @@ func Test_getCacheDirVolumes(t *testing.T) {
 		VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
 			Path: config.MountPointPath,
 			Type: &dir,
-		}}}, {
-		Name: JfsRootDirName,
-		VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
-			Path: config.JFSConfigPath,
-			Type: &dir,
-		}},
-	}}
+		}}}}
 
 	s, _ := config.ParseSetting(map[string]string{"name": "test"}, nil, optionWithoutCacheDir, true)
 	r.jfsSetting = s
 	cacheVolumes, cacheVolumeMounts := r.genCacheDirVolumes()
 	volumes = append(volumes, cacheVolumes...)
 	volumeMounts = append(volumeMounts, cacheVolumeMounts...)
-	if len(volumes) != 3 || len(volumeMounts) != 3 {
+	if len(volumes) != 2 || len(volumeMounts) != 2 {
 		t.Error("getCacheDirVolumes can't work properly")
 	}
 
@@ -206,7 +197,7 @@ func Test_getCacheDirVolumes(t *testing.T) {
 	cacheVolumes, cacheVolumeMounts = r.genCacheDirVolumes()
 	volumes = append(volumes, cacheVolumes...)
 	volumeMounts = append(volumeMounts, cacheVolumeMounts...)
-	if len(volumes) != 4 || len(volumeMounts) != 4 {
+	if len(volumes) != 3 || len(volumeMounts) != 3 {
 		t.Error("getCacheDirVolumes can't work properly")
 	}
 
@@ -215,7 +206,7 @@ func Test_getCacheDirVolumes(t *testing.T) {
 	cacheVolumes, cacheVolumeMounts = r.genCacheDirVolumes()
 	volumes = append(volumes, cacheVolumes...)
 	volumeMounts = append(volumeMounts, cacheVolumeMounts...)
-	if len(volumes) != 6 || len(volumeMounts) != 6 {
+	if len(volumes) != 5 || len(volumeMounts) != 5 {
 		t.Error("getCacheDirVolumes can't work properly")
 	}
 
@@ -224,7 +215,7 @@ func Test_getCacheDirVolumes(t *testing.T) {
 	cacheVolumes, cacheVolumeMounts = r.genCacheDirVolumes()
 	volumes = append(volumes, cacheVolumes...)
 	volumeMounts = append(volumeMounts, cacheVolumeMounts...)
-	if len(volumes) != 7 || len(volumeMounts) != 7 {
+	if len(volumes) != 6 || len(volumeMounts) != 6 {
 		t.Error("getCacheDirVolumes can't work properly")
 	}
 }

--- a/pkg/juicefs/mount/builder/secret.go
+++ b/pkg/juicefs/mount/builder/secret.go
@@ -31,6 +31,7 @@ const (
 
 var (
 	checkMountScriptContent = `ConditionPathIsMountPoint="$1"
+subpath="$2"
 count=0
 while ! mount | grep $ConditionPathIsMountPoint | grep JuiceFS
 do
@@ -44,6 +45,10 @@ do
 done
 echo "$(date "+%Y-%m-%d %H:%M:%S")"
 echo "succeed in checking mount point $ConditionPathIsMountPoint"
+if [ -n "$subpath" ]; then
+echo "create subpath $subpath"
+mkdir -r 777 $ConditionPathIsMountPoint/$subpath
+fi;
 `
 )
 

--- a/pkg/juicefs/mount/builder/secret.go
+++ b/pkg/juicefs/mount/builder/secret.go
@@ -47,7 +47,7 @@ echo "succeed in checking mount point $ConditionPathIsMountPoint"
 `
 )
 
-func (r *Builder) NewSecret() corev1.Secret {
+func (r *BaseBuilder) NewSecret() corev1.Secret {
 	data := make(map[string]string)
 	if r.jfsSetting.MetaUrl != "" {
 		data["metaurl"] = r.jfsSetting.MetaUrl

--- a/pkg/juicefs/mount/builder/secret.go
+++ b/pkg/juicefs/mount/builder/secret.go
@@ -31,7 +31,6 @@ const (
 
 var (
 	checkMountScriptContent = `ConditionPathIsMountPoint="$1"
-subpath="$2"
 count=0
 while ! mount | grep $ConditionPathIsMountPoint | grep JuiceFS
 do
@@ -45,9 +44,19 @@ do
 done
 echo "$(date "+%Y-%m-%d %H:%M:%S")"
 echo "succeed in checking mount point $ConditionPathIsMountPoint"
-if [ -n "$subpath" ]; then
-echo "create subpath $subpath"
-mkdir -r 777 $ConditionPathIsMountPoint/$subpath
+if [ -n "${subpath}" ]; then
+	echo "create subpath ${subpath}"
+	mkdir -p 777 $ConditionPathIsMountPoint/${subpath}
+	if [ -n "${capacity}" ]; then
+		if [ "${community}" == ce ]; then
+			echo "set quota in ${subpath}"
+			/usr/local/bin/juicefs quota > /dev/null; if [ $? -eq 0 ]; then /usr/local/bin/juicefs quota set ${metaurl} --path ${quotaPath} --capacity ${capacity}; fi; 
+		fi;
+		if [ "${community}" == ee ]; then
+			echo "set quota in ${subpath}"
+			/usr/bin/juicefs quota > /dev/null; if [ $? -eq 0 ]; then /usr/bin/juicefs quota set ${name} --path ${quotaPath} --capacity ${capacity}; fi; 
+		fi;
+	fi;
 fi;
 `
 )

--- a/pkg/juicefs/mount/builder/serverless.go
+++ b/pkg/juicefs/mount/builder/serverless.go
@@ -57,6 +57,10 @@ func (r *ServerlessBuilder) NewMountSidecar() *corev1.Pod {
 		Exec: &corev1.ExecAction{Command: []string{"bash", "-c",
 			fmt.Sprintf("time %s %s >> /proc/1/fd/1", checkMountScriptPath, r.jfsSetting.MountPath)}},
 	}
+	pod.Spec.Containers[0].Env = []corev1.EnvVar{{
+		Name:  "JFS_FOREGROUND",
+		Value: "1",
+	}}
 
 	// generate volumes and volumeMounts only used in serverless sidecar
 	volumes, volumeMounts := r.genServerlessVolumes()

--- a/pkg/juicefs/mount/builder/serverless.go
+++ b/pkg/juicefs/mount/builder/serverless.go
@@ -1,0 +1,166 @@
+/*
+ Copyright 2023 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package builder
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	utilpointer "k8s.io/utils/pointer"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/config"
+)
+
+type ServerlessBuilder struct {
+	PodBuilder
+}
+
+var _ SidecarInterface = &ServerlessBuilder{}
+
+func NewServerlessBuilder(setting *config.JfsSetting, capacity int64) SidecarInterface {
+	return &ServerlessBuilder{
+		PodBuilder{BaseBuilder{
+			jfsSetting: setting,
+			capacity:   capacity,
+		}},
+	}
+}
+
+// NewMountSidecar generates a pod with a juicefs sidecar in serverless mode
+// 1. no hostpath except mount point (the serverless cluster must have this permission.)
+// 2. with privileged container (the serverless cluster must have this permission.)
+// 3. no initContainer
+func (r *ServerlessBuilder) NewMountSidecar() *corev1.Pod {
+	pod := r.genCommonJuicePod(r.genCommonContainer)
+
+	// no annotation and label for sidecar
+	pod.Annotations = map[string]string{}
+	pod.Labels = map[string]string{}
+
+	pod.Spec.Containers[0].Lifecycle.PostStart = &corev1.Handler{
+		Exec: &corev1.ExecAction{Command: []string{"bash", "-c",
+			fmt.Sprintf("time %s %s >> /proc/1/fd/1", checkMountScriptPath, r.jfsSetting.MountPath)}},
+	}
+
+	// generate volumes and volumeMounts only used in serverless sidecar
+	volumes, volumeMounts := r.genServerlessVolumes()
+	pod.Spec.Volumes = append(pod.Spec.Volumes, volumes...)
+	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, volumeMounts...)
+
+	// add cache-dir PVC volume
+	cacheVolumes, cacheVolumeMounts := r.genCacheDirVolumes()
+	pod.Spec.Volumes = append(pod.Spec.Volumes, cacheVolumes...)
+	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, cacheVolumeMounts...)
+
+	// command
+	mountCmd := r.genMountCommand()
+	initCmd := r.genInitCommand()
+	cmd := strings.Join([]string{initCmd, mountCmd}, "\n")
+	pod.Spec.Containers[0].Command = []string{"sh", "-c", cmd}
+
+	return pod
+}
+
+func (r *ServerlessBuilder) OverwriteVolumes(volume *corev1.Volume, mountPath string) {
+	// overwrite original volume and use juicefs volume mountpoint instead
+	hostMount := filepath.Join(config.MountPointPath, mountPath, r.jfsSetting.SubPath)
+	volume.VolumeSource = corev1.VolumeSource{
+		HostPath: &corev1.HostPathVolumeSource{
+			Path: hostMount,
+		},
+	}
+}
+
+func (r *ServerlessBuilder) OverwriteVolumeMounts(mount *corev1.VolumeMount) {
+	// do not overwrite volume mount
+	return
+}
+
+// genServerlessVolumes generates volumes and volumeMounts for serverless sidecar
+// 1. jfs dir: mount point as hostPath, used to propagate the mount point in the mount container to the business container
+// 2. jfs-check-mount: secret volume, used to check if the mount point is mounted
+func (r *ServerlessBuilder) genServerlessVolumes() ([]corev1.Volume, []corev1.VolumeMount) {
+	dir := corev1.HostPathDirectoryOrCreate
+	mp := corev1.MountPropagationBidirectional
+
+	var mode int32 = 0755
+	secretName := r.jfsSetting.SecretName
+	volumes := []corev1.Volume{
+		{
+			Name: JfsDirName,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: config.MountPointPath,
+					Type: &dir,
+				},
+			},
+		},
+		{
+			Name: "jfs-check-mount",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  secretName,
+					DefaultMode: utilpointer.Int32Ptr(mode),
+				},
+			},
+		},
+	}
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:             JfsDirName,
+			MountPath:        config.PodMountBase,
+			MountPropagation: &mp,
+		},
+		{
+			Name:      "jfs-check-mount",
+			MountPath: checkMountScriptPath,
+			SubPath:   checkMountScriptName,
+		},
+	}
+
+	return volumes, volumeMounts
+}
+
+// genCacheDirVolumes: in serverless, only support PVC cache, do not support hostpath cache
+func (r *ServerlessBuilder) genCacheDirVolumes() ([]corev1.Volume, []corev1.VolumeMount) {
+	cacheVolumes := []corev1.Volume{}
+	cacheVolumeMounts := []corev1.VolumeMount{}
+
+	for i, cache := range r.jfsSetting.CachePVCs {
+		name := fmt.Sprintf("cachedir-pvc-%d", i)
+		pvcVolume := corev1.Volume{
+			Name: name,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: cache.PVCName,
+					ReadOnly:  false,
+				},
+			},
+		}
+		cacheVolumes = append(cacheVolumes, pvcVolume)
+		volumeMount := corev1.VolumeMount{
+			Name:      name,
+			ReadOnly:  false,
+			MountPath: cache.Path,
+		}
+		cacheVolumeMounts = append(cacheVolumeMounts, volumeMount)
+	}
+
+	return cacheVolumes, cacheVolumeMounts
+}

--- a/pkg/juicefs/mount/builder/vci-serverless.go
+++ b/pkg/juicefs/mount/builder/vci-serverless.go
@@ -1,0 +1,164 @@
+/*
+ Copyright 2023 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package builder
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	utilpointer "k8s.io/utils/pointer"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/config"
+)
+
+const (
+	VCIANNOKey                = "vke.volcengine.com/burst-to-vci"
+	VCIANNOValue              = "enforce"
+	VCIPropagation            = "vci.vke.volcengine.com/config-bidirectional-mount-propagation"
+	VCIPropagationConfig      = "vke.al.vci-enable-bidirectional-mount-propagation"
+	VCIPropagationConfigValue = "vke.al.vci-enable-bidirectional-mount-propagation"
+)
+
+type VCIBuilder struct {
+	ServerlessBuilder
+	pvc corev1.PersistentVolumeClaim
+	app corev1.Pod
+}
+
+var _ SidecarInterface = &VCIBuilder{}
+
+func NewVCIBuilder(setting *config.JfsSetting, capacity int64, app corev1.Pod, pvc corev1.PersistentVolumeClaim) SidecarInterface {
+	return &VCIBuilder{
+		ServerlessBuilder: ServerlessBuilder{PodBuilder{BaseBuilder{
+			jfsSetting: setting,
+			capacity:   capacity,
+		}}},
+		pvc: pvc,
+		app: app,
+	}
+}
+
+// NewMountSidecar generates a pod with a juicefs sidecar in serverless mode
+// 1. no hostpath
+// 2. without privileged container
+// 3. no propagationBidirectional
+// 3. no initContainer
+// 4. with env JFS_NO_UMOUNT=1
+// 5. annotations for VCI
+func (r *VCIBuilder) NewMountSidecar() *corev1.Pod {
+	pod := r.genCommonJuicePod(r.genNonPrivilegedContainer)
+	// overwrite annotation
+	pod.Annotations = map[string]string{
+		VCIPropagationConfig: VCIPropagationConfigValue,
+		VCIPropagation: fmt.Sprintf(`[{
+			"container": "jfs-mount",
+			"mountPath" : "%s"
+		}]`, r.jfsSetting.MountPath),
+	}
+
+	pod.Spec.Containers[0].Lifecycle.PostStart = &corev1.Handler{
+		Exec: &corev1.ExecAction{Command: []string{"bash", "-c",
+			fmt.Sprintf("time %s %s >> /proc/1/fd/1", checkMountScriptPath, r.jfsSetting.MountPath)}},
+	}
+	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
+		Name:  "JFS_NO_UMOUNT",
+		Value: "1",
+	})
+
+	// generate volumes and volumeMounts only used in VCI serverless sidecar
+	volumes, volumeMounts := r.genVCIServerlessVolumes()
+	pod.Spec.Volumes = append(pod.Spec.Volumes, volumes...)
+	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, volumeMounts...)
+
+	// add cache-dir PVC volume
+	cacheVolumes, cacheVolumeMounts := r.genCacheDirVolumes()
+	pod.Spec.Volumes = append(pod.Spec.Volumes, cacheVolumes...)
+	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, cacheVolumeMounts...)
+
+	// command
+	mountCmd := r.genMountCommand()
+	initCmd := r.genInitCommand()
+	cmd := strings.Join([]string{initCmd, mountCmd}, "\n")
+	pod.Spec.Containers[0].Command = []string{"sh", "-c", cmd}
+
+	return pod
+}
+
+func (r *VCIBuilder) OverwriteVolumes(volume *corev1.Volume, mountPath string) {
+	volume.VolumeSource = corev1.VolumeSource{
+		EmptyDir: &corev1.EmptyDirVolumeSource{},
+	}
+}
+
+func (r *VCIBuilder) OverwriteVolumeMounts(mount *corev1.VolumeMount) {
+	hostToContainer := corev1.MountPropagationHostToContainer
+	mount.MountPropagation = &hostToContainer
+}
+
+// genVCIServerlessVolumes generates volumes and volumeMounts for serverless sidecar
+// 1. jfs dir: mount point as emptyDir, used to propagate the mount point in the mount container to the business container
+// 2. jfs-check-mount: secret volume, used to check if the mount point is mounted
+func (r *VCIBuilder) genVCIServerlessVolumes() ([]corev1.Volume, []corev1.VolumeMount) {
+	var mode int32 = 0755
+	var sharedVolumeName string
+	secretName := r.jfsSetting.SecretName
+
+	// get shared volume name
+	for _, volume := range r.app.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == r.pvc.Name {
+			sharedVolumeName = volume.Name
+		}
+	}
+
+	volumes := []corev1.Volume{
+		{
+			Name: "jfs-check-mount",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  secretName,
+					DefaultMode: utilpointer.Int32Ptr(mode),
+				},
+			},
+		},
+	}
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      sharedVolumeName,
+			MountPath: r.jfsSetting.MountPath,
+		},
+		{
+			Name:      "jfs-check-mount",
+			MountPath: checkMountScriptPath,
+			SubPath:   checkMountScriptName,
+		},
+	}
+
+	return volumes, volumeMounts
+}
+
+func (r *PodBuilder) genNonPrivilegedContainer() corev1.Container {
+	rootUser := int64(0)
+	return corev1.Container{
+		Name:  config.MountContainerName,
+		Image: r.BaseBuilder.jfsSetting.Attr.Image,
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser: &rootUser,
+		},
+		Env: []corev1.EnvVar{},
+	}
+}

--- a/pkg/juicefs/mount/builder/vci-serverless.go
+++ b/pkg/juicefs/mount/builder/vci-serverless.go
@@ -75,10 +75,7 @@ func (r *VCIBuilder) NewMountSidecar() *corev1.Pod {
 		Exec: &corev1.ExecAction{Command: []string{"bash", "-c",
 			fmt.Sprintf("time %s %s >> /proc/1/fd/1", checkMountScriptPath, r.jfsSetting.MountPath)}},
 	}
-	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
-		Name:  "JFS_NO_UMOUNT",
-		Value: "1",
-	})
+	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, []corev1.EnvVar{{Name: "JFS_NO_UMOUNT", Value: "1"}, {Name: "JFS_FOREGROUND", Value: "1"}}...)
 
 	// generate volumes and volumeMounts only used in VCI serverless sidecar
 	volumes, volumeMounts := r.genVCIServerlessVolumes()

--- a/pkg/juicefs/mount/builder/vci-serverless.go
+++ b/pkg/juicefs/mount/builder/vci-serverless.go
@@ -69,18 +69,6 @@ func (r *VCIBuilder) NewMountSidecar() *corev1.Pod {
 			"mountPath" : "%s"
 		}]`, r.jfsSetting.MountPath),
 	}
-	if len(pod.Spec.InitContainers) != 0 {
-		pod.Annotations = map[string]string{
-			VCIPropagationConfig: VCIPropagationConfigValue,
-			VCIPropagation: fmt.Sprintf(`[{
-			"container": "jfs-mount",
-			"mountPath" : "%s"
-		}, {
-			"container": "jfs-init",
-			"mountPath" : "/mnt/jfs"
-		}]`, r.jfsSetting.MountPath),
-		}
-	}
 
 	pod.Spec.Containers[0].Lifecycle.PostStart = &corev1.Handler{
 		Exec: &corev1.ExecAction{Command: []string{"bash", "-c",

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -221,7 +221,7 @@ func (p *PodMount) JUmount(ctx context.Context, target, podName string) error {
 
 func (p *PodMount) JCreateVolume(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) error {
 	var exist *batchv1.Job
-	r := builder.NewBuilder(jfsSetting, 0)
+	r := builder.NewJobBuilder(jfsSetting, 0)
 	job := r.NewJobForCreateVolume()
 	exist, err := p.K8sClient.GetJob(ctx, job.Name, job.Namespace)
 	if err != nil && k8serrors.IsNotFound(err) {
@@ -253,7 +253,7 @@ func (p *PodMount) JCreateVolume(ctx context.Context, jfsSetting *jfsConfig.JfsS
 
 func (p *PodMount) JDeleteVolume(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) error {
 	var exist *batchv1.Job
-	r := builder.NewBuilder(jfsSetting, 0)
+	r := builder.NewJobBuilder(jfsSetting, 0)
 	job := r.NewJobForDeleteVolume()
 	exist, err := p.K8sClient.GetJob(ctx, job.Name, job.Namespace)
 	if err != nil && k8serrors.IsNotFound(err) {
@@ -323,7 +323,7 @@ func (p *PodMount) createOrAddRef(ctx context.Context, podName string, jfsSettin
 	defer lock.Unlock()
 
 	jfsSetting.SecretName = podName + "-secret"
-	r := builder.NewBuilder(jfsSetting, 0)
+	r := builder.NewPodBuilder(jfsSetting, 0)
 	secret := r.NewSecret()
 	key := util.GetReferenceKey(jfsSetting.TargetPath)
 
@@ -544,7 +544,7 @@ func (p *PodMount) CleanCache(ctx context.Context, image string, id string, volu
 	jfsSetting.VolumeId = volumeId
 	jfsSetting.CacheDirs = cacheDirs
 	jfsSetting.UUID = id
-	r := builder.NewBuilder(jfsSetting, 0)
+	r := builder.NewJobBuilder(jfsSetting, 0)
 	job := r.NewJobForCleanCache()
 	klog.V(6).Infof("Clean cache job: %v", job)
 	_, err = p.K8sClient.GetJob(ctx, job.Name, job.Namespace)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -275,7 +275,9 @@ func GetReferenceKey(target string) string {
 
 // ParseMntPath return mntPath, volumeId (/jfs/volumeId, volumeId err)
 func ParseMntPath(cmd string) (string, string, error) {
-	args := strings.Fields(cmd)
+	cmds := strings.Split(cmd, "\n")
+	mountCmd := cmds[len(cmds)-1]
+	args := strings.Fields(mountCmd)
 	if len(args) < 3 || !strings.HasPrefix(args[2], config.PodMountBase) {
 		return "", "", fmt.Errorf("err cmd:%s", cmd)
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -158,28 +158,46 @@ func TestParseMntPath(t *testing.T) {
 	}{
 		{
 			name:    "get sourcePath from pod cmd success",
+			args:    args{cmd: "/usr/local/bin/juicefs format --storage=s3 --bucket=http://juicefs-bucket.minio.default.svc.cluster.local:9000 --access-key=minioadmin --secret-key=${secretkey} ${metaurl} ce-secret\n/bin/mount.juicefs redis://127.0.0.1/6379 /jfs/pvc-xxx"},
+			want:    "/jfs/pvc-xxx",
+			want1:   "pvc-xxx",
+			wantErr: false,
+		},
+		{
+			name:    "without init cmd",
 			args:    args{cmd: "/bin/mount.juicefs redis://127.0.0.1/6379 /jfs/pvc-xxx"},
 			want:    "/jfs/pvc-xxx",
 			want1:   "pvc-xxx",
 			wantErr: false,
 		},
 		{
+			name: "with create subpath",
+			args: args{cmd: "/usr/local/bin/juicefs format --storage=s3 --bucket=http://juicefs-bucket.minio.default.svc.cluster.local:9000 --access-key=minioadmin --secret-key=${secretkey} ${metaurl} ce-secret\n" +
+				"/bin/mount.juicefs ${metaurl} /mnt/jfs -o buffer-size=300,cache-size=100,enable-xattr\n" +
+				"if [ ! -d /mnt/jfs/pvc-fb2ec20c-474f-4804-9504-966da4af9b73 ]; then mkdir -m 777 /mnt/jfs/pvc-fb2ec20c-474f-4804-9504-966da4af9b73; fi;\n" +
+				"umount /mnt/jfs\n" +
+				"/bin/mount.juicefs redis://127.0.0.1/6379 /jfs/pvc-xxx"},
+			want:    "/jfs/pvc-xxx",
+			want1:   "pvc-xxx",
+			wantErr: false,
+		},
+		{
 			name:    "err-pod cmd args <3",
-			args:    args{cmd: "/bin/mount.juicefs redis://127.0.0.1/6379"},
+			args:    args{cmd: "/usr/local/bin/juicefs format --storage=s3 --bucket=http://juicefs-bucket.minio.default.svc.cluster.local:9000 --access-key=minioadmin --secret-key=${secretkey} ${metaurl} ce-secret\n/bin/mount.juicefs redis://127.0.0.1/6379"},
 			want:    "",
 			want1:   "",
 			wantErr: true,
 		},
 		{
 			name:    "err-cmd sourcePath no MountBase prefix",
-			args:    args{cmd: "/bin/mount.juicefs redis://127.0.0.1/6379 /err-jfs/pvc-xxx"},
+			args:    args{cmd: "/usr/local/bin/juicefs format --storage=s3 --bucket=http://juicefs-bucket.minio.default.svc.cluster.local:9000 --access-key=minioadmin --secret-key=${secretkey} ${metaurl} ce-secret\n/bin/mount.juicefs redis://127.0.0.1/6379 /err-jfs/pvc-xxx"},
 			want:    "",
 			want1:   "",
 			wantErr: true,
 		},
 		{
 			name:    "err-cmd sourcePath length err",
-			args:    args{cmd: "/bin/mount.juicefs redis://127.0.0.1/6379 /jfs"},
+			args:    args{cmd: "/usr/local/bin/juicefs format --storage=s3 --bucket=http://juicefs-bucket.minio.default.svc.cluster.local:9000 --access-key=minioadmin --secret-key=${secretkey} ${metaurl} ce-secret\n/bin/mount.juicefs redis://127.0.0.1/6379 /jfs"},
 			want:    "",
 			want1:   "",
 			wantErr: true,

--- a/pkg/webhook/handler/handler.go
+++ b/pkg/webhook/handler/handler.go
@@ -37,6 +37,15 @@ type SidecarHandler struct {
 	Client *k8sclient.K8sClient
 	// A decoder will be automatically injected
 	decoder *admission.Decoder
+	// is in serverless environment
+	serverless bool
+}
+
+func NewSidecarHandler(client *k8sclient.K8sClient, serverless bool) *SidecarHandler {
+	return &SidecarHandler{
+		Client:     client,
+		serverless: serverless,
+	}
 }
 
 func (s *SidecarHandler) Handle(ctx context.Context, request admission.Request) admission.Response {
@@ -72,7 +81,7 @@ func (s *SidecarHandler) Handle(ctx context.Context, request admission.Request) 
 	}
 
 	jfs := juicefs.NewJfsProvider(nil, s.Client)
-	sidecarMutate := mutate.NewSidecarMutate(s.Client, jfs, pair)
+	sidecarMutate := mutate.NewSidecarMutate(s.Client, jfs, s.serverless, pair)
 	klog.Infof("[SidecarHandler] start injecting juicefs client as sidecar in pod [%s] namespace [%s].", pod.Name, pod.Namespace)
 	out, err := sidecarMutate.Mutate(ctx, pod)
 	if err != nil {

--- a/pkg/webhook/handler/mutate/sidecar.go
+++ b/pkg/webhook/handler/mutate/sidecar.go
@@ -124,6 +124,10 @@ func (s *SidecarMutate) mutate(ctx context.Context, pod *corev1.Pod, pair util.P
 	s.injectAnnotation(out, mountPod.Annotations)
 	// inject container
 	s.injectContainer(out, mountPod.Spec.Containers[0])
+	// inject initContainer
+	if len(mountPod.Spec.InitContainers) != 0 {
+		s.injectInitContainer(out, mountPod.Spec.InitContainers[0])
+	}
 
 	return
 }
@@ -202,6 +206,10 @@ func (s *SidecarMutate) GetSettings(pv corev1.PersistentVolume) (secrets, volCtx
 
 func (s *SidecarMutate) injectContainer(pod *corev1.Pod, container corev1.Container) {
 	pod.Spec.Containers = append([]corev1.Container{container}, pod.Spec.Containers...)
+}
+
+func (s *SidecarMutate) injectInitContainer(pod *corev1.Pod, container corev1.Container) {
+	pod.Spec.InitContainers = append([]corev1.Container{container}, pod.Spec.Containers...)
 }
 
 func (s *SidecarMutate) injectVolume(pod *corev1.Pod, build builder.SidecarInterface, volumes []corev1.Volume, mountPath string, pair util.PVPair) {

--- a/pkg/webhook/handler/mutate/sidecar.go
+++ b/pkg/webhook/handler/mutate/sidecar.go
@@ -124,10 +124,6 @@ func (s *SidecarMutate) mutate(ctx context.Context, pod *corev1.Pod, pair util.P
 	s.injectAnnotation(out, mountPod.Annotations)
 	// inject container
 	s.injectContainer(out, mountPod.Spec.Containers[0])
-	// inject initContainer
-	if len(mountPod.Spec.InitContainers) != 0 {
-		s.injectInitContainer(out, mountPod.Spec.InitContainers[0])
-	}
 
 	return
 }
@@ -144,13 +140,6 @@ func (s *SidecarMutate) Deduplicate(pod, mountPod *corev1.Pod, index int) {
 	if !conflict {
 		// if container name not conflict, do not check others
 		return
-	}
-
-	// deduplicate initContainer name
-	for _, c := range pod.Spec.InitContainers {
-		if c.Name == mountPod.Spec.InitContainers[0].Name {
-			mountPod.Spec.InitContainers[0].Name = fmt.Sprintf("%s-%d", c.Name, index)
-		}
 	}
 
 	// deduplicate volume name
@@ -213,10 +202,6 @@ func (s *SidecarMutate) GetSettings(pv corev1.PersistentVolume) (secrets, volCtx
 
 func (s *SidecarMutate) injectContainer(pod *corev1.Pod, container corev1.Container) {
 	pod.Spec.Containers = append([]corev1.Container{container}, pod.Spec.Containers...)
-}
-
-func (s *SidecarMutate) injectInitContainer(pod *corev1.Pod, container corev1.Container) {
-	pod.Spec.InitContainers = append([]corev1.Container{container}, pod.Spec.InitContainers...)
 }
 
 func (s *SidecarMutate) injectVolume(pod *corev1.Pod, build builder.SidecarInterface, volumes []corev1.Volume, mountPath string, pair util.PVPair) {

--- a/pkg/webhook/handler/mutate/sidecar.go
+++ b/pkg/webhook/handler/mutate/sidecar.go
@@ -146,6 +146,13 @@ func (s *SidecarMutate) Deduplicate(pod, mountPod *corev1.Pod, index int) {
 		return
 	}
 
+	// deduplicate initContainer name
+	for _, c := range pod.Spec.InitContainers {
+		if c.Name == mountPod.Spec.InitContainers[0].Name {
+			mountPod.Spec.InitContainers[0].Name = fmt.Sprintf("%s-%d", c.Name, index)
+		}
+	}
+
 	// deduplicate volume name
 	for i, mv := range mountPod.Spec.Volumes {
 		if mv.Name == builder.UpdateDBDirName || mv.Name == builder.JfsDirName {
@@ -209,7 +216,7 @@ func (s *SidecarMutate) injectContainer(pod *corev1.Pod, container corev1.Contai
 }
 
 func (s *SidecarMutate) injectInitContainer(pod *corev1.Pod, container corev1.Container) {
-	pod.Spec.InitContainers = append([]corev1.Container{container}, pod.Spec.Containers...)
+	pod.Spec.InitContainers = append([]corev1.Container{container}, pod.Spec.InitContainers...)
 }
 
 func (s *SidecarMutate) injectVolume(pod *corev1.Pod, build builder.SidecarInterface, volumes []corev1.Volume, mountPath string, pair util.PVPair) {

--- a/pkg/webhook/handler/mutate/sidecar_test.go
+++ b/pkg/webhook/handler/mutate/sidecar_test.go
@@ -190,39 +190,6 @@ func TestSidecarMutate_injectVolume(t *testing.T) {
 	}
 }
 
-func TestSidecarMutate_injectInitContainer(t *testing.T) {
-	type args struct {
-		pod       *corev1.Pod
-		container corev1.Container
-	}
-	tests := []struct {
-		name                 string
-		args                 args
-		wantInitContainerLen int
-	}{
-		{
-			name: "test inject init container",
-			args: args{
-				pod: &corev1.Pod{},
-				container: corev1.Container{
-					Name:  "format",
-					Image: "juicedata/mount:latest",
-				},
-			},
-			wantInitContainerLen: 1,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &SidecarMutate{}
-			s.injectInitContainer(tt.args.pod, tt.args.container)
-			if len(tt.args.pod.Spec.InitContainers) != tt.wantInitContainerLen {
-				t.Errorf("injectInitContainer() = %v, want %v", tt.args.pod.Spec.InitContainers, tt.wantInitContainerLen)
-			}
-		})
-	}
-}
-
 func TestSidecarMutate_injectContainer(t *testing.T) {
 	type args struct {
 		pod       *corev1.Pod

--- a/pkg/webhook/handler/mutate/sidecar_test.go
+++ b/pkg/webhook/handler/mutate/sidecar_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
+	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs/mount/builder"
 	volconf "github.com/juicedata/juicefs-csi-driver/pkg/webhook/handler/config"
 )
 
@@ -65,6 +66,10 @@ func TestSidecarMutate_injectVolume(t *testing.T) {
 								},
 							},
 						},
+						Containers: []corev1.Container{{
+							Name:         "test",
+							VolumeMounts: []corev1.VolumeMount{{Name: "app-volume", MountPath: "data"}},
+						}},
 					},
 				},
 				volumes: []corev1.Volume{{
@@ -128,6 +133,10 @@ func TestSidecarMutate_injectVolume(t *testing.T) {
 								},
 							},
 						},
+						Containers: []corev1.Container{{
+							Name:         "test",
+							VolumeMounts: []corev1.VolumeMount{{Name: "app-volume", MountPath: "data"}},
+						}},
 					},
 				},
 				volumes: []corev1.Volume{{
@@ -155,7 +164,8 @@ func TestSidecarMutate_injectVolume(t *testing.T) {
 			s := &SidecarMutate{
 				jfsSetting: tt.fields.jfsSetting,
 			}
-			s.injectVolume(tt.args.pod, tt.args.volumes, tt.args.mountPath, tt.fields.pair)
+			r := builder.NewContainerBuilder(tt.fields.jfsSetting, 0)
+			s.injectVolume(tt.args.pod, r, tt.args.volumes, tt.args.mountPath, tt.fields.pair)
 			if len(tt.args.pod.Spec.Volumes) != len(tt.wantPodVolume) {
 				t.Errorf("injectVolume() = %v, want %v", tt.args.pod.Spec.Volumes, tt.wantPodVolume)
 			}

--- a/pkg/webhook/handler/register.go
+++ b/pkg/webhook/handler/register.go
@@ -24,13 +24,16 @@ import (
 	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
 )
 
-const HandlerPath = "/juicefs/inject-v1-pod"
+const (
+	SidecarPath    = "/juicefs/inject-v1-pod"
+	ServerlessPath = "/juicefs/serverless/inject-v1-pod"
+)
 
 // Register registers the handlers to the manager
 func Register(mgr manager.Manager, client *k8sclient.K8sClient) {
 	server := mgr.GetWebhookServer()
-	server.Register(HandlerPath, &webhook.Admission{Handler: &SidecarHandler{
-		Client: client,
-	}})
-	klog.Infof("Registered webhook handler path %s", HandlerPath)
+	server.Register(SidecarPath, &webhook.Admission{Handler: NewSidecarHandler(client, false)})
+	klog.Infof("Registered webhook handler path %s for sidecar", SidecarPath)
+	server.Register(ServerlessPath, &webhook.Admission{Handler: NewSidecarHandler(client, true)})
+	klog.Infof("Registered webhook handler path %s for serverless", ServerlessPath)
 }

--- a/scripts/juicefs-csi-webhook-install.sh
+++ b/scripts/juicefs-csi-webhook-install.sh
@@ -462,6 +462,41 @@ metadata:
     app.kubernetes.io/instance: juicefs-csi-driver
     app.kubernetes.io/name: juicefs-csi-driver
     app.kubernetes.io/version: master
+  name: juicefs-admission-serverless-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    caBundle: CA_BUNDLE
+    service:
+      name: juicefs-admission-webhook
+      namespace: kube-system
+      path: /juicefs/serverless/inject-v1-pod
+  failurePolicy: Fail
+  name: sidecar.inject.serverless.juicefs.com
+  namespaceSelector:
+    matchLabels:
+      juicefs.com/enable-serverless-injection: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+  timeoutSeconds: 20
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
   name: juicefs-admission-webhook
 webhooks:
 - admissionReviewVersions:
@@ -879,6 +914,41 @@ metadata:
 spec:
   attachRequired: false
   podInfoOnMount: true
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
+  name: juicefs-admission-serverless-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    caBundle: CA_BUNDLE
+    service:
+      name: juicefs-admission-webhook
+      namespace: kube-system
+      path: /juicefs/serverless/inject-v1-pod
+  failurePolicy: Fail
+  name: sidecar.inject.serverless.juicefs.com
+  namespaceSelector:
+    matchLabels:
+      juicefs.com/enable-serverless-injection: "true"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+  timeoutSeconds: 20
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration


### PR DESCRIPTION
1. when in serverless environment, do not mount hostPath except mount point. Set `juicefs.com/enable-serverless-injection: "true"` in namespace to use.
2. support VCI serverless. Set `juicefs.com/enable-serverless-injection: "true"` in namespace and `vke.volcengine.com/burst-to-vci: enfore` in pod to use.
    -  do not mount hostPath
    -  container is not privileged
    -  no propagationBidirectional mountPropagation
    -  no initContainer
    -  with env JFS_NO_UMOUNT=1
    -  annotations for VCI