### PR TITLE
fix: get pod by pv volumeHandle

### DIFF
--- a/pkg/controller/pod_controller.go
+++ b/pkg/controller/pod_controller.go
@@ -85,7 +85,6 @@ func (m *PodController) Reconcile(ctx context.Context, request reconcile.Request
 		}
 		if uniqueId != "" && (p.Spec.CSI.VolumeHandle == uniqueId || p.Spec.StorageClassName == uniqueId) {
 			relatedPVs = append(relatedPVs, &p)
-			break
 		}
 	}
 	for _, pv := range relatedPVs {

--- a/pkg/controller/pod_controller.go
+++ b/pkg/controller/pod_controller.go
@@ -71,8 +71,8 @@ func (m *PodController) Reconcile(ctx context.Context, request reconcile.Request
 	}
 
 	// get app pod list
-	var pv *corev1.PersistentVolume
-	var pvcNamespace string
+	relatedPVs := []*corev1.PersistentVolume{}
+	pvcNamespaces := []string{}
 	pvs, err := m.K8sClient.ListPersistentVolumes(ctx, nil, nil)
 	if err != nil {
 		klog.Errorf("doReconcile ListPV: %v", err)
@@ -84,16 +84,19 @@ func (m *PodController) Reconcile(ctx context.Context, request reconcile.Request
 			continue
 		}
 		if uniqueId != "" && (p.Spec.CSI.VolumeHandle == uniqueId || p.Spec.StorageClassName == uniqueId) {
-			pv = &p
+			relatedPVs = append(relatedPVs, &p)
 			break
 		}
 	}
-	if pv != nil {
-		if pv.Spec.ClaimRef != nil {
-			pvcNamespace = pv.Spec.ClaimRef.Namespace
+	for _, pv := range relatedPVs {
+		if pv != nil {
+			if pv.Spec.ClaimRef != nil {
+				pvcNamespaces = append(pvcNamespaces, pv.Spec.ClaimRef.Namespace)
+			}
 		}
 	}
-	if pvcNamespace == "" {
+
+	if len(pvcNamespaces) == 0 {
 		klog.Errorf("can not get pvc based on mount pod %s/%s: %v", mountPod.Namespace, mountPod.Name, err)
 		return reconcile.Result{}, err
 	}
@@ -104,10 +107,14 @@ func (m *PodController) Reconcile(ctx context.Context, request reconcile.Request
 			Operator: metav1.LabelSelectorOpExists,
 		}},
 	}
-	podList, err := m.K8sClient.ListPod(ctx, pvcNamespace, &labelSelector, nil)
-	if err != nil {
-		klog.Errorf("doReconcile ListPod: %v", err)
-		return reconcile.Result{}, err
+	podLists := []corev1.Pod{}
+	for _, pvcNamespace := range pvcNamespaces {
+		podList, err := m.K8sClient.ListPod(ctx, pvcNamespace, &labelSelector, nil)
+		if err != nil {
+			klog.Errorf("doReconcile ListPod: %v", err)
+			return reconcile.Result{}, err
+		}
+		podLists = append(podLists, podList...)
 	}
 
 	mounter := mount.SafeFormatAndMount{
@@ -117,7 +124,7 @@ func (m *PodController) Reconcile(ctx context.Context, request reconcile.Request
 
 	podDriver := NewPodDriver(m.K8sClient, mounter)
 	podDriver.SetMountInfo(*mit)
-	podDriver.mit.setPodsStatus(&corev1.PodList{Items: podList})
+	podDriver.mit.setPodsStatus(&corev1.PodList{Items: podLists})
 
 	err = podDriver.Run(ctx, mountPod)
 	if err != nil {
@@ -141,7 +148,10 @@ func (m *PodController) Reconcile(ctx context.Context, request reconcile.Request
 			RequeueAfter: requeueAfter,
 		}, nil
 	}
-	return reconcile.Result{}, nil
+	return reconcile.Result{
+		Requeue:      true,
+		RequeueAfter: 10 * time.Minute,
+	}, nil
 }
 
 func (m *PodController) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/controller/pod_controller.go
+++ b/pkg/controller/pod_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -86,6 +87,9 @@ func (m *PodController) Reconcile(ctx context.Context, request reconcile.Request
 		if uniqueId != "" && (p.Spec.CSI.VolumeHandle == uniqueId || p.Spec.StorageClassName == uniqueId) {
 			relatedPVs = append(relatedPVs, &p)
 		}
+	}
+	if len(relatedPVs) == 0 {
+		return reconcile.Result{}, fmt.Errorf("can not get pv by uniqueId %s, mount pod: %s", uniqueId, mountPod.Name)
 	}
 	for _, pv := range relatedPVs {
 		if pv != nil {

--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -130,9 +130,11 @@ func (p *PodDriver) checkAnnotations(ctx context.Context, pod *corev1.Pod) error
 	var existTargets int
 	for k, target := range pod.Annotations {
 		if k == util.GetReferenceKey(target) {
-			_, exists := p.mit.deletedPods[getPodUid(target)]
+			targetUid := getPodUid(target)
+			_, exists := p.mit.deletedPods[targetUid]
 			if !exists { // only it is not in pod lists can be seen as deleted
 				// target pod is deleted
+				klog.V(5).Infof("[PodDriver] get app pod %s deleted in annotations of mount pod, remove its ref.", targetUid)
 				delAnnotations = append(delAnnotations, k)
 				continue
 			}


### PR DESCRIPTION
1. get all pvc when multiple pvs has the same volumeHandle when list app pods
2. requeue mount pod periodically to avoid leaking in both kubelet polling and apiserver watching