### PR TITLE
quota: Support NodeGetVolumeStats with statfs

### DIFF
--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -553,10 +553,20 @@ func Test_nodeService_NodeGetCapabilities(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "test",
-			fields:  fields{},
-			args:    args{},
-			want:    &csi.NodeGetCapabilitiesResponse{},
+			name:   "test",
+			fields: fields{},
+			args:   args{},
+			want: &csi.NodeGetCapabilitiesResponse{
+				Capabilities: []*csi.NodeServiceCapability{
+					{
+						Type: &csi.NodeServiceCapability_Rpc{
+							Rpc: &csi.NodeServiceCapability_RPC{
+								Type: csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
+							},
+						},
+					},
+				},
+			},
 			wantErr: false,
 		},
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -31,6 +31,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -447,4 +448,20 @@ func ImageResol(image string) (hasCE, hasEE bool) {
 		return true, false
 	}
 	return true, true
+}
+
+func GetDiskUsage(path string) (uint64, uint64, uint64, uint64) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err == nil {
+		// in bytes
+		blockSize := uint64(stat.Bsize)
+		totalSize := blockSize * stat.Blocks
+		freeSize := blockSize * stat.Bfree
+		totalFiles := stat.Files
+		freeFiles := stat.Ffree
+		return totalSize, freeSize, totalFiles, freeFiles
+	} else {
+		klog.Errorf("GetDiskUsage: syscall.Statfs failed: %v", err)
+		return 1, 1, 1, 1
+	}
 }


### PR DESCRIPTION
Use quota get cmd to obtain the used and total size of PersistentVolume (subdir + subpath).
Not support static PersistentVolume.


This commit is related to https://github.com/juicedata/juicefs-csi-driver/issues/736
