### PR TITLE
support injecting mountOptions by Node metadata

### DIFF
--- a/pkg/driver/provisioner.go
+++ b/pkg/driver/provisioner.go
@@ -85,7 +85,7 @@ func (j *provisionerService) Provision(ctx context.Context, options provisioncon
 		return nil, provisioncontroller.ProvisioningFinished, fmt.Errorf("claim Selector is not supported")
 	}
 
-	pvMeta := util.NewPVCMeta(*options.PVC)
+	pvMeta := util.NewObjectMeta(*options.PVC, *options.SelectedNode)
 	subPath := options.PVName
 	if options.StorageClass.Parameters["pathPattern"] != "" {
 		subPath = pvMeta.StringParser(options.StorageClass.Parameters["pathPattern"])

--- a/pkg/driver/provisioner.go
+++ b/pkg/driver/provisioner.go
@@ -85,7 +85,7 @@ func (j *provisionerService) Provision(ctx context.Context, options provisioncon
 		return nil, provisioncontroller.ProvisioningFinished, fmt.Errorf("claim Selector is not supported")
 	}
 
-	pvMeta := util.NewObjectMeta(*options.PVC, *options.SelectedNode)
+	pvMeta := util.NewObjectMeta(*options.PVC, options.SelectedNode)
 	subPath := options.PVName
 	if options.StorageClass.Parameters["pathPattern"] != "" {
 		subPath = pvMeta.StringParser(options.StorageClass.Parameters["pathPattern"])

--- a/pkg/util/pvc.go
+++ b/pkg/util/pvc.go
@@ -47,8 +47,8 @@ type ObjectMeta struct {
 	pvc, node *objectMetadata
 }
 
-func NewObjectMeta(pvc v1.PersistentVolumeClaim, node v1.Node) *ObjectMeta {
-	return &ObjectMeta{
+func NewObjectMeta(pvc v1.PersistentVolumeClaim, node *v1.Node) *ObjectMeta {
+	meta := &ObjectMeta{
 		pvc: &objectMetadata{
 			data: map[string]string{
 				"name":      pvc.Name,
@@ -57,15 +57,17 @@ func NewObjectMeta(pvc v1.PersistentVolumeClaim, node v1.Node) *ObjectMeta {
 			labels:      pvc.Labels,
 			annotations: pvc.Annotations,
 		},
-		node: &objectMetadata{
-			data: map[string]string{
-				"name":    node.Name,
-				"podCIDR": node.Spec.PodCIDR,
-			},
-			labels:      node.Labels,
-			annotations: node.Annotations,
-		},
+		node: &objectMetadata{},
 	}
+	if node != nil {
+		meta.node.data = map[string]string{
+			"name":    node.Name,
+			"podCIDR": node.Spec.PodCIDR,
+		}
+		meta.node.labels = node.Labels
+		meta.node.annotations = node.Annotations
+	}
+	return meta
 }
 
 func (meta *ObjectMeta) StringParser(str string) string {

--- a/pkg/util/pvc.go
+++ b/pkg/util/pvc.go
@@ -34,7 +34,7 @@ import (
 )
 
 var (
-	pattern = regexp.MustCompile(`\${\.(PVC|NODE)\.((labels|annotations)\.(.*?)|.*?)}`)
+	pattern = regexp.MustCompile(`\${\.(PVC|pvc|node)\.((labels|annotations)\.(.*?)|.*?)}`)
 )
 
 type objectMetadata struct {
@@ -74,9 +74,9 @@ func (meta *ObjectMeta) StringParser(str string) string {
 	result := pattern.FindAllStringSubmatch(str, -1)
 	for _, r := range result {
 		switch r[1] {
-		case "PVC":
+		case "PVC", "pvc":
 			str = meta.pvc.stringParser(str, r)
-		case "NODE":
+		case "node":
 			str = meta.node.stringParser(str, r)
 		default:
 		}

--- a/pkg/util/pvc_test.go
+++ b/pkg/util/pvc_test.go
@@ -115,6 +115,19 @@ func TestObjectMetadata_StringParser(t *testing.T) {
 			want: "-a",
 		},
 		{
+			name: "test-pvc-lowercase",
+			pvc: fields{
+				data: map[string]string{
+					"name":      "test",
+					"namespace": "default",
+				},
+			},
+			args: args{
+				str: "${.pvc.name}-a",
+			},
+			want: "test-a",
+		},
+		{
 			name: "test-node-name",
 			node: fields{
 				data: map[string]string{
@@ -122,7 +135,7 @@ func TestObjectMetadata_StringParser(t *testing.T) {
 				},
 			},
 			args: args{
-				str: "${.NODE.name}-a",
+				str: "${.node.name}-a",
 			},
 			want: "test-a",
 		},
@@ -135,7 +148,7 @@ func TestObjectMetadata_StringParser(t *testing.T) {
 				},
 			},
 			args: args{
-				str: "${.NODE.podCIDR}-a",
+				str: "${.node.podCIDR}-a",
 			},
 			want: "10.244.0.0/24-a",
 		},
@@ -151,7 +164,7 @@ func TestObjectMetadata_StringParser(t *testing.T) {
 				},
 			},
 			args: args{
-				str: "${.NODE.labels.a.a}-a",
+				str: "${.node.labels.a.a}-a",
 			},
 			want: "b-a",
 		},
@@ -167,7 +180,7 @@ func TestObjectMetadata_StringParser(t *testing.T) {
 				},
 			},
 			args: args{
-				str: "${.NODE.annotations.a.a}-a",
+				str: "${.node.annotations.a.a}-a",
 			},
 			want: "b-a",
 		},
@@ -180,7 +193,7 @@ func TestObjectMetadata_StringParser(t *testing.T) {
 				},
 			},
 			args: args{
-				str: "${.NODE.annotations.a}-a",
+				str: "${.node.annotations.a}-a",
 			},
 			want: "-a",
 		},
@@ -192,7 +205,7 @@ func TestObjectMetadata_StringParser(t *testing.T) {
 				},
 			},
 			args: args{
-				str: "${.NODE.annotations.fs1.juicefs.com/cacheGroup}-a",
+				str: "${.node.annotations.fs1.juicefs.com/cacheGroup}-a",
 			},
 			want: "region-1-a",
 		},

--- a/pkg/util/pvc_test.go
+++ b/pkg/util/pvc_test.go
@@ -184,6 +184,18 @@ func TestObjectMetadata_StringParser(t *testing.T) {
 			},
 			want: "-a",
 		},
+		{
+			name: "test-node-real-annotation",
+			node: fields{
+				annotations: map[string]string{
+					"fs1.juicefs.com/cacheGroup": "region-1",
+				},
+			},
+			args: args{
+				str: "${.NODE.annotations.fs1.juicefs.com/cacheGroup}-a",
+			},
+			want: "region-1-a",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/pvc_test.go
+++ b/pkg/util/pvc_test.go
@@ -37,14 +37,14 @@ func TestPVCMetadata_StringParser(t *testing.T) {
 		str string
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   string
+		name string
+		pvc  fields
+		args args
+		want string
 	}{
 		{
 			name: "test-name",
-			fields: fields{
+			pvc: fields{
 				data: map[string]string{
 					"name":      "test",
 					"namespace": "default",
@@ -57,7 +57,7 @@ func TestPVCMetadata_StringParser(t *testing.T) {
 		},
 		{
 			name: "test-namespace",
-			fields: fields{
+			pvc: fields{
 				data: map[string]string{
 					"name":      "test",
 					"namespace": "default",
@@ -70,7 +70,7 @@ func TestPVCMetadata_StringParser(t *testing.T) {
 		},
 		{
 			name: "test-label",
-			fields: fields{
+			pvc: fields{
 				data: map[string]string{
 					"name":      "test",
 					"namespace": "default",
@@ -86,7 +86,7 @@ func TestPVCMetadata_StringParser(t *testing.T) {
 		},
 		{
 			name: "test-annotation",
-			fields: fields{
+			pvc: fields{
 				data: map[string]string{
 					"name":      "test",
 					"namespace": "default",
@@ -102,7 +102,7 @@ func TestPVCMetadata_StringParser(t *testing.T) {
 		},
 		{
 			name: "test-nil",
-			fields: fields{
+			pvc: fields{
 				data: map[string]string{
 					"name":      "test",
 					"namespace": "default",
@@ -116,10 +116,12 @@ func TestPVCMetadata_StringParser(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			meta := &PVCMetadata{
-				data:        tt.fields.data,
-				labels:      tt.fields.labels,
-				annotations: tt.fields.annotations,
+			meta := &ObjectMeta{
+				pvc: &objectMetadata{
+					data:        tt.pvc.data,
+					labels:      tt.pvc.labels,
+					annotations: tt.pvc.annotations,
+				},
 			}
 			if got := meta.StringParser(tt.args.str); got != tt.want {
 				t.Errorf("StringParser() = %v, want %v", got, tt.want)
@@ -347,10 +349,12 @@ func TestResolveSecret(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			meta := &PVCMetadata{
-				data:        tt.fields.data,
-				labels:      tt.fields.labels,
-				annotations: tt.fields.annotations,
+			meta := &ObjectMeta{
+				pvc: &objectMetadata{
+					data:        tt.fields.data,
+					labels:      tt.fields.labels,
+					annotations: tt.fields.annotations,
+				},
 			}
 			if got := meta.ResolveSecret(tt.args.str, tt.args.pvname); got != tt.want {
 				t.Errorf("ResolveSecret() = %v, want %v", got, tt.want)


### PR DESCRIPTION
In #759 , we supported injecting `mountOptions` by PVC metadata.

This PR supports injecting `mountOptions` by Node metadata.