### PR TITLE
cache auth results and use as client conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ bin/
 vendor/
 profile.cov
 Secret-*
-secret*
 /deploy-dev/
 .idea
 .DS_Store

--- a/cmd/app/mount_manager.go
+++ b/cmd/app/mount_manager.go
@@ -105,6 +105,10 @@ func (m *MountManager) Start(ctx context.Context) {
 		klog.Errorf("Register job controller error: %v", err)
 		return
 	}
+	if err := (mountctrl.NewSecretController(m.client)).SetupWithManager(m.mgr); err != nil {
+		klog.Errorf("Register secret controller error: %v", err)
+		return
+	}
 	klog.Info("Mount manager started.")
 	if err := m.mgr.Start(ctx); err != nil {
 		klog.Errorf("Mount manager start error: %v", err)

--- a/deploy/kubernetes/base/resources.yaml
+++ b/deploy/kubernetes/base/resources.yaml
@@ -32,7 +32,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "create", "update", "patch", "delete"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["pods", "pods/log"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,6 +60,8 @@ var (
 	CeCliPath       = "/usr/local/bin/juicefs"
 	CeMountPath     = "/bin/mount.juicefs"
 	JfsMountPath    = "/sbin/mount.juicefs"
+	ClientConfPath  = "/root/.juicefs"
+	ROConfPath      = "/etc/juicefs"
 )
 
 const (

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -81,7 +81,7 @@ type JfsSetting struct {
 	Options    []string // mount options
 	FormatCmd  string   // format or auth
 	SubPath    string   // subPath which is to be created or deleted
-	SecretName string   // secret name which is set env in pod
+	SecretName string   // secret with JuiceFS volume credentials
 
 	Attr PodAttr
 }

--- a/pkg/controller/secret_controller.go
+++ b/pkg/controller/secret_controller.go
@@ -1,0 +1,135 @@
+/*
+ Copyright 2023 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/config"
+	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs"
+	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+)
+
+type SecretController struct {
+	*k8sclient.K8sClient
+}
+
+func NewSecretController(client *k8sclient.K8sClient) *SecretController {
+	return &SecretController{client}
+}
+
+func (m *SecretController) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	klog.V(6).Infof("Receive secret %s %s", request.Name, request.Namespace)
+	secrets, err := m.GetSecret(ctx, request.Name, request.Namespace)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		klog.Errorf("get secret %s error: %v", request.Name, err)
+		return reconcile.Result{}, err
+	}
+	if secrets == nil {
+		klog.V(6).Infof("secret %s has been deleted.", request.Name)
+		return reconcile.Result{}, nil
+	}
+	if _, found := secrets.Data["token"]; !found {
+		klog.V(6).Infof("token not found in secret %s", request.Name)
+		return reconcile.Result{}, nil
+	}
+	if _, found := secrets.Data["name"]; !found {
+		klog.V(6).Infof("name not found in secret %s", request.Name)
+		return reconcile.Result{}, nil
+	}
+	jfs := juicefs.NewJfsProvider(nil, nil)
+	secretsMap := make(map[string]string)
+	for k, v := range secrets.Data {
+		secretsMap[k] = string(v[:])
+	}
+	jfsSetting, err := jfs.Settings(ctx, "", secretsMap, nil, nil)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	output, err := jfs.AuthFs(ctx, secretsMap, jfsSetting, true)
+	klog.V(6).Infof("auth output: %s.", output)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	conf := jfsSetting.Name + ".conf"
+	confPath := filepath.Join(config.ClientConfPath, conf)
+	b, err := os.ReadFile(confPath)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	confs := string(b)
+	secretsMap["initConfig"] = confs
+	secrets.StringData = secretsMap
+	err = m.UpdateSecret(ctx, secrets)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
+}
+
+func (m *SecretController) SetupWithManager(mgr ctrl.Manager) error {
+	c, err := controller.New("mount", mgr, controller.Options{Reconciler: m})
+	if err != nil {
+		return err
+	}
+
+	return c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
+		CreateFunc: func(event event.CreateEvent) bool {
+			secret := event.Object.(*corev1.Secret)
+			klog.V(6).Infof("watch secret %s created", secret.GetName())
+			return true
+		},
+		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
+			secretNew, ok := updateEvent.ObjectNew.(*corev1.Secret)
+			klog.V(6).Infof("watch secret %s updated", secretNew.GetName())
+			if !ok {
+				klog.V(6).Infof("secret.onUpdateFunc Skip object: %v", updateEvent.ObjectNew)
+				return false
+			}
+
+			secretOld, ok := updateEvent.ObjectOld.(*corev1.Secret)
+			if !ok {
+				klog.V(6).Infof("secret.onUpdateFunc Skip object: %v", updateEvent.ObjectOld)
+				return false
+			}
+
+			if secretNew.GetResourceVersion() == secretOld.GetResourceVersion() {
+				klog.V(6).Info("secret.onUpdateFunc Skip due to resourceVersion not changed")
+				return false
+			}
+			return true
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			secret := deleteEvent.Object.(*corev1.Secret)
+			klog.V(6).Infof("watch secret %s deleted", secret.GetName())
+			return true
+		},
+	})
+}

--- a/pkg/controller/secret_controller.go
+++ b/pkg/controller/secret_controller.go
@@ -95,7 +95,7 @@ func (m *SecretController) Reconcile(ctx context.Context, request reconcile.Requ
 }
 
 func (m *SecretController) SetupWithManager(mgr ctrl.Manager) error {
-	c, err := controller.New("mount", mgr, controller.Options{Reconciler: m})
+	c, err := controller.New("secret", mgr, controller.Options{Reconciler: m})
 	if err != nil {
 		return err
 	}

--- a/pkg/juicefs/mocks/mock_juicefs.go
+++ b/pkg/juicefs/mocks/mock_juicefs.go
@@ -37,6 +37,21 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 	return m.recorder
 }
 
+// AuthFs mocks base method.
+func (m *MockInterface) AuthFs(arg0 context.Context, arg1 map[string]string, arg2 *config.JfsSetting, arg3 bool) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthFs", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AuthFs indicates an expected call of AuthFs.
+func (mr *MockInterfaceMockRecorder) AuthFs(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthFs", reflect.TypeOf((*MockInterface)(nil).AuthFs), arg0, arg1, arg2, arg3)
+}
+
 // CreateTarget mocks base method.
 func (m *MockInterface) CreateTarget(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/juicefs/mount/builder/common.go
+++ b/pkg/juicefs/mount/builder/common.go
@@ -19,6 +19,7 @@ package builder
 import (
 	"fmt"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -155,7 +156,12 @@ func (r *BaseBuilder) genInitCommand() string {
 			formatCmd = formatCmd + " --encrypt-rsa-key=/root/.rsa/rsa-key.pem"
 		}
 	}
-
+	if r.jfsSetting.InitConfig != "" {
+		confPath := filepath.Join(config.ROConfPath, r.jfsSetting.Name+".conf")
+		args := []string{"cp", confPath, config.ClientConfPath}
+		confCmd := strings.Join(args, " ")
+		formatCmd = strings.Join([]string{confCmd, formatCmd}, "\n")
+	}
 	return formatCmd
 }
 
@@ -304,7 +310,7 @@ func (r *BaseBuilder) _genJuiceVolumes() ([]corev1.Volume, []corev1.VolumeMount)
 		volumeMounts = append(volumeMounts,
 			corev1.VolumeMount{
 				Name:      "init-config",
-				MountPath: "/root/.juicefs",
+				MountPath: config.ROConfPath,
 			},
 		)
 	}

--- a/tests/sanity/fake_juicefs_provider.go
+++ b/tests/sanity/fake_juicefs_provider.go
@@ -80,6 +80,9 @@ func (j *fakeJfsProvider) JfsCleanupMountPoint(ctx context.Context, mountPath st
 	return nil
 }
 
+func (j *fakeJfsProvider) AuthFs(ctx context.Context, secrets map[string]string, setting *config.JfsSetting, force bool) (string, error) {
+	return "", nil
+}
 func (j *fakeJfsProvider) JfsUnmount(ctx context.Context, volumeId, mountPath string) error {
 	return nil
 }


### PR DESCRIPTION
goal: CSI Driver will continue to work even if connection towards web console is disrupted

implementation:

* CSI Controller will watch all secrets, if a JuiceFS volume credentials is created/updated, it'll run `juicefs auth` within the controller container, and put the client conf file into the `init_config` field inside the Kubernetes secret
* if `init_config` is detected, an extra volume mount will be created inside the mount pod, i.e. `myjfs.conf -> /etc/juicefs/myjfs.conf`
* when mount pod starts, client conf will be copied into `/root/.juicefs`, thus even if auth fails, a valid client conf will be used to ensure continuous service

caveats:

* controller must be up and running for this feature to work, even if dynamic provisioning isn't used
* not yet support the situation where multiple credential secrets use a same JuiceFS Volume, client conf files will overwrite each other

simple tests are run to verify that this actually work:

```
k logs --all-containers -f juicefs-chaos-k8s-001-chaos-ee-test-kybcwp
2024/01/07 07:03:47.875750 juicefs[8] <WARNING>: update config: POST https://juicefs.com/volume/chaos-ee-test/mount: Post "https://juicefs.com/volume/chaos-ee-test/mount": context deadline exceeded (Client.Timeout exceeded while awaiting headers), use existed one [auth.go:616]
2024/01/07 07:03:49.495372 juicefs[54] <INFO>: JuiceFS version 5.0.6 (2023-12-25 04eaeb2) [mount.go:629]
2024/01/07 07:03:49.534196 juicefs[54] <INFO>: Cache: /var/jfsCache/chaos-ee-test capacity: 102400 MB [disk_cache.go:1074]
2024/01/07 07:03:49.534902 juicefs[54] <INFO>: Mounting volume chaos-ee-test at /jfs/chaos-ee-test-kybcwp ... [mount_unix.go:651]
OK, chaos-ee-test is ready at /jfs/chaos-ee-test-kybcwp.
2024/01/07 07:03:54.228262 juicefs[26] <INFO>: watching /jfs/chaos-ee-test-kybcwp, pid 54 [mount_unix.go:112]
```