### PR TITLE
expose basic prometheus metrics

### DIFF
--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/juicedata/juicefs-csi-driver/pkg/driver"
 	k8s "github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -143,6 +144,14 @@ func controllerRun() {
 			port++
 		}
 	}()
+	registerer, registry := util.NewPrometheus(config.NodeName)
+	http.Handle("/metrics", promhttp.HandlerFor(
+		registry,
+		promhttp.HandlerOpts{
+			// Opt into OpenMetrics to support exemplars.
+			EnableOpenMetrics: true,
+		},
+	))
 
 	// enable mount manager in csi controller
 	if config.MountManager {
@@ -172,7 +181,7 @@ func controllerRun() {
 		}()
 	}
 
-	drv, err := driver.NewDriver(endpoint, nodeID, leaderElection, leaderElectionNamespace, leaderElectionLeaseDuration)
+	drv, err := driver.NewDriver(endpoint, nodeID, leaderElection, leaderElectionNamespace, leaderElectionLeaseDuration, registerer)
 	if err != nil {
 		klog.Fatalln(err)
 	}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -28,6 +28,8 @@ import (
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Driver struct
@@ -44,7 +46,7 @@ type Driver struct {
 func NewDriver(endpoint string, nodeID string,
 	leaderElection bool,
 	leaderElectionNamespace string,
-	leaderElectionLeaseDuration time.Duration) (*Driver, error) {
+	leaderElectionLeaseDuration time.Duration, reg prometheus.Registerer) (*Driver, error) {
 	klog.Infof("Driver: %v version %v commit %v date %v", config.DriverName, driverVersion, gitCommit, buildDate)
 
 	var k8sClient *k8sclient.K8sClient
@@ -61,7 +63,7 @@ func NewDriver(endpoint string, nodeID string,
 		return nil, err
 	}
 
-	ns, err := newNodeService(nodeID, k8sClient)
+	ns, err := newNodeService(nodeID, k8sClient, reg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -38,6 +38,9 @@ import (
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 	k8s "github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 )
 
 const (
@@ -447,4 +450,13 @@ func ImageResol(image string) (hasCE, hasEE bool) {
 		return true, false
 	}
 	return true, true
+}
+
+func NewPrometheus(nodeName string) (prometheus.Registerer, *prometheus.Registry) {
+	registry := prometheus.NewRegistry() // replace default so only JuiceFS metrics are exposed
+	registerer := prometheus.WrapRegistererWithPrefix("juicefs_",
+		prometheus.WrapRegistererWith(prometheus.Labels{"node_name": nodeName}, registry))
+	registerer.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	registerer.MustRegister(collectors.NewGoCollector())
+	return registerer, registry
 }


### PR DESCRIPTION
related: https://github.com/juicedata/juicefs-csi-driver/issues/832

TODOs:

* assign prometheus scrape annotations to node service
* change listen port to a "stable" one, rather than 6060 but might increase due to `port++`
* define more useful metrics
* fix tests at last