### PR TITLE
introduce feature flag --cache-client-conf

### DIFF
--- a/cmd/app/mount_manager.go
+++ b/cmd/app/mount_manager.go
@@ -105,9 +105,11 @@ func (m *MountManager) Start(ctx context.Context) {
 		klog.Errorf("Register job controller error: %v", err)
 		return
 	}
-	if err := (mountctrl.NewSecretController(m.client)).SetupWithManager(m.mgr); err != nil {
-		klog.Errorf("Register secret controller error: %v", err)
-		return
+	if config.CacheClientConf {
+		if err := (mountctrl.NewSecretController(m.client)).SetupWithManager(m.mgr); err != nil {
+			klog.Errorf("Register secret controller error: %v", err)
+			return
+		}
 	}
 	klog.Info("Mount manager started.")
 	if err := m.mgr.Start(ctx); err != nil {

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -47,6 +47,7 @@ func parseControllerConfig() {
 	config.ByProcess = process
 	config.Webhook = webhook
 	config.Provisioner = provisioner
+	config.CacheClientConf = cacheConf
 	config.FormatInPod = formatInPod
 	if os.Getenv("DRIVER_NAME") != "" {
 		config.DriverName = os.Getenv("DRIVER_NAME")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,6 +35,7 @@ var (
 	process     bool
 
 	provisioner bool
+	cacheConf   bool
 	webhook     bool
 	certDir     string
 	webhookPort int
@@ -67,6 +68,7 @@ func main() {
 
 	// controller flags
 	cmd.Flags().BoolVar(&provisioner, "provisioner", false, "Enable provisioner in controller. default false.")
+	cmd.Flags().BoolVar(&cacheConf, "cache-client-conf", false, "Cache client config file. default false.")
 	cmd.Flags().BoolVar(&webhook, "webhook", false, "Enable webhook in controller. default false.")
 	cmd.Flags().StringVar(&certDir, "webhook-cert-dir", "/etc/webhook/certs", "Admission webhook cert/key dir.")
 	cmd.Flags().IntVar(&webhookPort, "webhook-port", 9444, "Admission webhook cert/key dir.")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,7 @@ var (
 	ByProcess          = false // csi driver runs juicefs in process or not
 	FormatInPod        = false // put format/auth in pod (only in k8s)
 	Provisioner        = false // provisioner in controller
+	CacheClientConf    = false // cache client config files and use directly in mount containers
 	MountManager       = false // manage mount pod in controller (only in k8s)
 	Webhook            = false // inject juicefs client as sidecar in pod (only in k8s)
 	Immutable          = false // csi driver is running in an immutable environment

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -361,6 +361,7 @@ func (j *juicefs) Settings(ctx context.Context, volumeID string, secrets, volCtx
 			jfsSetting.FormatCmd = res
 		}
 		jfsSetting.UUID = secrets["name"]
+		jfsSetting.InitConfig = secrets["initconfig"]
 	} else {
 		noUpdate := false
 		if secrets["storage"] == "" || secrets["bucket"] == "" {

--- a/pkg/juicefs/mount/builder/common.go
+++ b/pkg/juicefs/mount/builder/common.go
@@ -269,7 +269,7 @@ func (r *BaseBuilder) _genMetadata() (labels map[string]string, annotations map[
 
 // _genJuiceVolumes generates volumes & volumeMounts
 // 1. if encrypt_rsa_key is set, mount secret to /root/.rsa
-// 2. if init_config is set, mount secret to /root/.config
+// 2. if initconfig is set, mount secret to /etc/juicefs
 // 3. configs in secret
 func (r *BaseBuilder) _genJuiceVolumes() ([]corev1.Volume, []corev1.VolumeMount) {
 	volumes := []corev1.Volume{}
@@ -302,7 +302,7 @@ func (r *BaseBuilder) _genJuiceVolumes() ([]corev1.Volume, []corev1.VolumeMount)
 			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
 				SecretName: secretName,
 				Items: []corev1.KeyToPath{{
-					Key:  "init_config",
+					Key:  "initconfig",
 					Path: r.jfsSetting.Name + ".conf",
 				}},
 			}},

--- a/pkg/juicefs/mount/builder/secret.go
+++ b/pkg/juicefs/mount/builder/secret.go
@@ -83,7 +83,7 @@ func (r *BaseBuilder) NewSecret() corev1.Secret {
 		data["encrypt_rsa_key"] = r.jfsSetting.EncryptRsaKey
 	}
 	if r.jfsSetting.InitConfig != "" {
-		data["init_config"] = r.jfsSetting.InitConfig
+		data["initconfig"] = r.jfsSetting.InitConfig
 	}
 	replacer := strings.NewReplacer("¬", "`")
 	data[checkMountScriptName] = replacer.Replace(checkMountScriptContent)


### PR DESCRIPTION
* use `--cache-client-conf` as feature flag for https://github.com/juicedata/juicefs-csi-driver/pull/845
* use initconfig instead of init_config in both secrets (the secret created by user, and the one created by csi driver)
* do not modify secret once initconfig has been set