### PR TITLE
expose basic prometheus metrics

### DIFF
--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -139,7 +139,7 @@ func controllerRun() {
 	}
 
 	go func() {
-		http.ListenAndServe(fmt.Sprintf("localhost:%d", config.WebPort), nil)
+		http.ListenAndServe(fmt.Sprintf(":%d", config.WebPort), nil)
 	}()
 	registerer, registry := util.NewPrometheus(config.NodeName)
 	http.Handle("/metrics", promhttp.HandlerFor(

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -139,11 +139,7 @@ func controllerRun() {
 	}
 
 	go func() {
-		port := 6060
-		for {
-			http.ListenAndServe(fmt.Sprintf("localhost:%d", port), nil)
-			port++
-		}
+		http.ListenAndServe(fmt.Sprintf("localhost:%d", config.WebPort), nil)
 	}()
 	registerer, registry := util.NewPrometheus(config.NodeName)
 	http.Handle("/metrics", promhttp.HandlerFor(

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -138,17 +138,32 @@ func controllerRun() {
 		klog.Fatalln("nodeID must be provided")
 	}
 
+	// http server for pprof
 	go func() {
-		http.ListenAndServe(fmt.Sprintf(":%d", config.WebPort), nil)
+		port := 6060
+		for {
+			http.ListenAndServe(fmt.Sprintf("localhost:%d", port), nil)
+			port++
+		}
 	}()
+
 	registerer, registry := util.NewPrometheus(config.NodeName)
-	http.Handle("/metrics", promhttp.HandlerFor(
-		registry,
-		promhttp.HandlerOpts{
-			// Opt into OpenMetrics to support exemplars.
-			EnableOpenMetrics: true,
-		},
-	))
+	// http server for metrics
+	go func() {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.HandlerFor(
+			registry,
+			promhttp.HandlerOpts{
+				// Opt into OpenMetrics to support exemplars.
+				EnableOpenMetrics: true,
+			},
+		))
+		server := &http.Server{
+			Addr:    fmt.Sprintf(":%d", config.WebPort),
+			Handler: mux,
+		}
+		server.ListenAndServe()
+	}()
 
 	// enable mount manager in csi controller
 	if config.MountManager {

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -137,11 +137,7 @@ func nodeRun() {
 	}
 
 	go func() {
-		port := 6060
-		for {
-			http.ListenAndServe(fmt.Sprintf("localhost:%d", port), nil)
-			port++
-		}
+		http.ListenAndServe(fmt.Sprintf("localhost:%d", config.WebPort), nil)
 	}()
 	registerer, registry := util.NewPrometheus(config.NodeName)
 	http.Handle("/metrics", promhttp.HandlerFor(

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -137,7 +137,7 @@ func nodeRun() {
 	}
 
 	go func() {
-		http.ListenAndServe(fmt.Sprintf("localhost:%d", config.WebPort), nil)
+		http.ListenAndServe(fmt.Sprintf(":%d", config.WebPort), nil)
 	}()
 	registerer, registry := util.NewPrometheus(config.NodeName)
 	http.Handle("/metrics", promhttp.HandlerFor(

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -142,10 +142,10 @@ func MustGetWebPort() int {
 	value, exists := os.LookupEnv("JUICEFS_CSI_WEB_PORT")
 	if exists {
 		port, err := strconv.Atoi(value)
-		if err != nil {
-			klog.Fatalf("Fail to parse JUICEFS_CSI_WEB_PORT %s, %v", value, err)
+		if err == nil {
+			return port
 		}
-		return port
+		klog.Errorf("Fail to parse JUICEFS_CSI_WEB_PORT %s: %v", value, err)
 	}
 	return 8080
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,9 @@ package config
 
 import (
 	"hash/fnv"
+	"k8s.io/klog"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -25,14 +28,15 @@ import (
 )
 
 var (
-	ByProcess          = false // csi driver runs juicefs in process or not
-	FormatInPod        = false // put format/auth in pod (only in k8s)
-	Provisioner        = false // provisioner in controller
-	CacheClientConf    = false // cache client config files and use directly in mount containers
-	MountManager       = false // manage mount pod in controller (only in k8s)
-	Webhook            = false // inject juicefs client as sidecar in pod (only in k8s)
-	Immutable          = false // csi driver is running in an immutable environment
-	EnableNodeSelector = false // arrange mount pod to node with node selector instead nodeName
+	WebPort            = MustGetWebPort() // web port used by metrics & pprof
+	ByProcess          = false            // csi driver runs juicefs in process or not
+	FormatInPod        = false            // put format/auth in pod (only in k8s)
+	Provisioner        = false            // provisioner in controller
+	CacheClientConf    = false            // cache client config files and use directly in mount containers
+	MountManager       = false            // manage mount pod in controller (only in k8s)
+	Webhook            = false            // inject juicefs client as sidecar in pod (only in k8s)
+	Immutable          = false            // csi driver is running in an immutable environment
+	EnableNodeSelector = false            // arrange mount pod to node with node selector instead nodeName
 
 	DriverName         = "csi.juicefs.com"
 	NodeName           = ""
@@ -132,4 +136,16 @@ func GetPodLock(podName string) *sync.Mutex {
 	h.Write([]byte(podName))
 	index := int(h.Sum32())
 	return &PodLocks[index%1024]
+}
+
+func MustGetWebPort() int {
+	value, exists := os.LookupEnv("JUICEFS_CSI_WEB_PORT")
+	if exists {
+		port, err := strconv.Atoi(value)
+		if err != nil {
+			klog.Fatalf("Fail to parse JUICEFS_CSI_WEB_PORT %s, %v", value, err)
+		}
+		return port
+	}
+	return 6060
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	WebPort            = MustGetWebPort() // web port used by metrics & pprof
+	WebPort            = MustGetWebPort() // web port used by metrics
 	ByProcess          = false            // csi driver runs juicefs in process or not
 	FormatInPod        = false            // put format/auth in pod (only in k8s)
 	Provisioner        = false            // provisioner in controller
@@ -147,5 +147,5 @@ func MustGetWebPort() int {
 		}
 		return port
 	}
-	return 6060
+	return 8080
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -68,7 +68,7 @@ func NewDriver(endpoint string, nodeID string,
 		return nil, err
 	}
 
-	ps, err := newProvisionerService(k8sClient, leaderElection, leaderElectionNamespace, leaderElectionLeaseDuration)
+	ps, err := newProvisionerService(k8sClient, leaderElection, leaderElectionNamespace, leaderElectionLeaseDuration, reg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -28,6 +28,8 @@ import (
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Driver struct
@@ -44,7 +46,7 @@ type Driver struct {
 func NewDriver(endpoint string, nodeID string,
 	leaderElection bool,
 	leaderElectionNamespace string,
-	leaderElectionLeaseDuration time.Duration) (*Driver, error) {
+	leaderElectionLeaseDuration time.Duration, reg prometheus.Registerer) (*Driver, error) {
 	klog.Infof("Driver: %v version %v commit %v date %v", config.DriverName, driverVersion, gitCommit, buildDate)
 
 	var k8sClient *k8sclient.K8sClient
@@ -61,7 +63,7 @@ func NewDriver(endpoint string, nodeID string,
 		return nil, err
 	}
 
-	ns, err := newNodeService(nodeID, k8sClient)
+	ns, err := newNodeService(nodeID, k8sClient, reg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 	k8s "github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+	"github.com/juicedata/juicefs-csi-driver/pkg/util"
 )
 
 func TestNewDriver(t *testing.T) {
@@ -62,7 +63,8 @@ func TestNewDriver(t *testing.T) {
 			})
 			defer patch5.Reset()
 
-			driver, err := NewDriver(endpoint, nodeId, false, "", time.Second)
+			registerer, _ := util.NewPrometheus(config.NodeName)
+			driver, err := NewDriver(endpoint, nodeId, false, "", time.Second, registerer)
 			So(err, ShouldBeNil)
 			if driver.endpoint != endpoint {
 				t.Fatalf("expected driver endpoint: %s, got: %s", endpoint, driver.endpoint)
@@ -94,7 +96,8 @@ func TestNewDriver(t *testing.T) {
 			})
 			defer patch4.Reset()
 
-			_, err := NewDriver(endpoint, nodeId, false, "", time.Second)
+			registerer, _ := util.NewPrometheus(config.NodeName)
+			_, err := NewDriver(endpoint, nodeId, false, "", time.Second, registerer)
 			So(err, ShouldNotBeNil)
 		})
 		Convey("by process", func() {
@@ -114,7 +117,8 @@ func TestNewDriver(t *testing.T) {
 			})
 			defer patch4.Reset()
 
-			_, err := NewDriver(endpoint, nodeId, false, "", time.Second)
+			registerer, _ := util.NewPrometheus(config.NodeName)
+			_, err := NewDriver(endpoint, nodeId, false, "", time.Second, registerer)
 			So(err, ShouldBeNil)
 		})
 	})

--- a/pkg/driver/fakes.go
+++ b/pkg/driver/fakes.go
@@ -19,12 +19,16 @@ package driver
 import (
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs"
 	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+	"github.com/juicedata/juicefs-csi-driver/pkg/util"
 )
 
 // NewFakeDriver creates a new mock driver used for testing
 func NewFakeDriver(endpoint string, fakeProvider juicefs.Interface) *Driver {
+	registerer, _ := util.NewPrometheus(config.NodeName)
+	metrics := newMetrics(registerer)
 	return &Driver{
 		endpoint: endpoint,
 		controllerService: controllerService{
@@ -35,6 +39,7 @@ func NewFakeDriver(endpoint string, fakeProvider juicefs.Interface) *Driver {
 			juicefs:   fakeProvider,
 			nodeID:    "fake-node-id",
 			k8sClient: &k8sclient.K8sClient{Interface: fake.NewSimpleClientset()},
+			metrics:   metrics,
 		},
 	}
 }

--- a/pkg/driver/fakes.go
+++ b/pkg/driver/fakes.go
@@ -28,7 +28,7 @@ import (
 // NewFakeDriver creates a new mock driver used for testing
 func NewFakeDriver(endpoint string, fakeProvider juicefs.Interface) *Driver {
 	registerer, _ := util.NewPrometheus(config.NodeName)
-	metrics := newMetrics(registerer)
+	metrics := newNodeMetrics(registerer)
 	return &Driver{
 		endpoint: endpoint,
 		controllerService: controllerService{

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -70,6 +70,7 @@ func newMetrics(reg prometheus.Registerer) *nodeServiceManagerMetrics {
 		Help: "number of volume delete errors",
 	})
 	reg.MustRegister(metrics.volumeDelErrors)
+	klog.V(6).Infof("prometheus registered to %v", reg)
 	return metrics
 }
 

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -49,17 +49,16 @@ type nodeService struct {
 	juicefs   juicefs.Interface
 	nodeID    string
 	k8sClient *k8sclient.K8sClient
-	metrics   *nodeServiceManagerMetrics
+	metrics   *nodeMetrics
 }
 
-// nodeService Metrics
-type nodeServiceManagerMetrics struct {
+type nodeMetrics struct {
 	volumeErrors    prometheus.Counter
 	volumeDelErrors prometheus.Counter
 }
 
-func newMetrics(reg prometheus.Registerer) *nodeServiceManagerMetrics {
-	metrics := &nodeServiceManagerMetrics{}
+func newNodeMetrics(reg prometheus.Registerer) *nodeMetrics {
+	metrics := &nodeMetrics{}
 	metrics.volumeErrors = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "volume_errors",
 		Help: "number of volume errors",
@@ -70,7 +69,6 @@ func newMetrics(reg prometheus.Registerer) *nodeServiceManagerMetrics {
 		Help: "number of volume delete errors",
 	})
 	reg.MustRegister(metrics.volumeDelErrors)
-	klog.V(6).Infof("prometheus registered to %v", reg)
 	return metrics
 }
 
@@ -79,7 +77,7 @@ func newNodeService(nodeID string, k8sClient *k8sclient.K8sClient, reg prometheu
 		Interface: mount.New(""),
 		Exec:      k8sexec.New(),
 	}
-	metrics := newMetrics(reg)
+	metrics := newNodeMetrics(reg)
 	jfsProvider := juicefs.NewJfsProvider(mounter, k8sClient)
 	return &nodeService{
 		SafeFormatAndMount: *mounter,
@@ -151,18 +149,18 @@ func (d *nodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	klog.V(5).Infof("NodePublishVolume: mounting juicefs with secret %+v, options %v", reflect.ValueOf(secrets).MapKeys(), mountOptions)
 	jfs, err := d.juicefs.JfsMount(ctx, volumeID, target, secrets, volCtx, mountOptions)
 	if err != nil {
-		d.metrics.volumeErrors.Add(1)
+		d.metrics.volumeErrors.Inc()
 		return nil, status.Errorf(codes.Internal, "Could not mount juicefs: %v", err)
 	}
 
 	bindSource, err := jfs.CreateVol(ctx, volumeID, volCtx["subPath"])
 	if err != nil {
-		d.metrics.volumeErrors.Add(1)
+		d.metrics.volumeErrors.Inc()
 		return nil, status.Errorf(codes.Internal, "Could not create volume: %s, %v", volumeID, err)
 	}
 
 	if err := jfs.BindTarget(ctx, bindSource, target); err != nil {
-		d.metrics.volumeErrors.Add(1)
+		d.metrics.volumeErrors.Inc()
 		return nil, status.Errorf(codes.Internal, "Could not bind %q at %q: %v", bindSource, target, err)
 	}
 
@@ -220,7 +218,7 @@ func (d *nodeService) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 
 	err := d.juicefs.JfsUnmount(ctx, volumeId, target)
 	if err != nil {
-		d.metrics.volumeDelErrors.Add(1)
+		d.metrics.volumeDelErrors.Inc()
 		return nil, status.Errorf(codes.Internal, "Could not unmount %q: %v", target, err)
 	}
 

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -48,6 +48,8 @@ func TestNodePublishVolume(t *testing.T) {
 			Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 		},
 	}
+	registerer, _ := util.NewPrometheus(config.NodeName)
+	metrics := newMetrics(registerer)
 	testCases := []struct {
 		name     string
 		testFunc func(t *testing.T)
@@ -78,11 +80,11 @@ func TestNodePublishVolume(t *testing.T) {
 						mockJuicefs := mocks.NewMockInterface(mockCtl)
 						mockJuicefs.EXPECT().JfsMount(context.TODO(), volumeId, targetPath, secret, volumeCtx, []string{"ro"}).Return(mockJfs, nil)
 						mockJuicefs.EXPECT().CreateTarget(context.TODO(), targetPath).Return(nil)
-
 						juicefsDriver := &nodeService{
 							juicefs:   mockJuicefs,
 							nodeID:    "fake_node_id",
 							k8sClient: &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
+							metrics:   metrics,
 						}
 
 						req := &csi.NodePublishVolumeRequest{
@@ -130,6 +132,7 @@ func TestNodePublishVolume(t *testing.T) {
 							juicefs:   mockJuicefs,
 							nodeID:    "fake_node_id",
 							k8sClient: &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
+							metrics:   metrics,
 						}
 
 						req := &csi.NodePublishVolumeRequest{
@@ -176,6 +179,7 @@ func TestNodePublishVolume(t *testing.T) {
 							juicefs:   mockJuicefs,
 							nodeID:    "fake_node_id",
 							k8sClient: &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
+							metrics:   metrics,
 						}
 
 						stdVolCapWithMount := &csi.VolumeCapability{
@@ -226,6 +230,7 @@ func TestNodePublishVolume(t *testing.T) {
 							juicefs:   mockJuicefs,
 							nodeID:    "fake_node_id",
 							k8sClient: &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
+							metrics:   metrics,
 						}
 
 						req := &csi.NodePublishVolumeRequest{
@@ -268,6 +273,7 @@ func TestNodePublishVolume(t *testing.T) {
 							juicefs:   mockJuicefs,
 							nodeID:    "fake_node_id",
 							k8sClient: &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
+							metrics:   metrics,
 						}
 
 						req := &csi.NodePublishVolumeRequest{
@@ -311,6 +317,7 @@ func TestNodePublishVolume(t *testing.T) {
 							juicefs:   mockJuicefs,
 							nodeID:    "fake_node_id",
 							k8sClient: &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
+							metrics:   metrics,
 						}
 
 						req := &csi.NodePublishVolumeRequest{
@@ -354,6 +361,7 @@ func TestNodePublishVolume(t *testing.T) {
 							juicefs:   jfs,
 							nodeID:    "fake_node_id",
 							k8sClient: client,
+							metrics:   metrics,
 						}
 
 						req := &csi.NodePublishVolumeRequest{
@@ -385,6 +393,7 @@ func TestNodePublishVolume(t *testing.T) {
 					juicefs:   mockJuicefs,
 					nodeID:    "fake_node_id",
 					k8sClient: &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
+					metrics:   metrics,
 				}
 
 				req := &csi.NodePublishVolumeRequest{
@@ -410,6 +419,7 @@ func TestNodePublishVolume(t *testing.T) {
 					juicefs:   mockJuicefs,
 					nodeID:    "fake_node_id",
 					k8sClient: &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
+					metrics:   metrics,
 				}
 
 				req := &csi.NodePublishVolumeRequest{
@@ -435,6 +445,7 @@ func TestNodePublishVolume(t *testing.T) {
 					juicefs:   mockJuicefs,
 					nodeID:    "fake_node_id",
 					k8sClient: &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
+					metrics:   metrics,
 				}
 
 				invalidVolumeCaps := &csi.VolumeCapability{
@@ -464,6 +475,8 @@ func TestNodePublishVolume(t *testing.T) {
 }
 
 func TestNodeUnpublishVolume(t *testing.T) {
+	registerer, _ := util.NewPrometheus(config.NodeName)
+	metrics := newMetrics(registerer)
 	Convey("Test NodeUnpublishVolume", t, func() {
 		Convey("test normal", func() {
 			targetPath := "/test/path"
@@ -479,6 +492,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				juicefs:   mockJuicefs,
 				nodeID:    "fake_node_id",
 				k8sClient: &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
+				metrics:   metrics,
 			}
 
 			req := &csi.NodeUnpublishVolumeRequest{
@@ -505,6 +519,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				juicefs:   mockJuicefs,
 				nodeID:    "fake_node_id",
 				k8sClient: &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
+				metrics:   metrics,
 			}
 
 			req := &csi.NodeUnpublishVolumeRequest{
@@ -522,6 +537,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				juicefs:   nil,
 				nodeID:    "fake_node_id",
 				k8sClient: &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
+				metrics:   metrics,
 			}
 
 			req := &csi.NodeUnpublishVolumeRequest{
@@ -572,12 +588,15 @@ func Test_nodeService_NodeGetCapabilities(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	registerer, _ := util.NewPrometheus(config.NodeName)
+	metrics := newMetrics(registerer)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &nodeService{
 				juicefs:   tt.fields.juicefs,
 				nodeID:    tt.fields.nodeID,
 				k8sClient: tt.fields.k8sClient,
+				metrics:   metrics,
 			}
 			got, err := d.NodeGetCapabilities(tt.args.ctx, tt.args.req)
 			if (err != nil) != tt.wantErr {
@@ -618,12 +637,15 @@ func Test_nodeService_NodeGetInfo(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	registerer, _ := util.NewPrometheus(config.NodeName)
+	metrics := newMetrics(registerer)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &nodeService{
 				juicefs:   tt.fields.juicefs,
 				nodeID:    tt.fields.nodeID,
 				k8sClient: tt.fields.k8sClient,
+				metrics:   metrics,
 			}
 			got, err := d.NodeGetInfo(tt.args.ctx, tt.args.req)
 			if (err != nil) != tt.wantErr {
@@ -681,12 +703,15 @@ func Test_nodeService_NodeExpandVolume(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	registerer, _ := util.NewPrometheus(config.NodeName)
+	metrics := newMetrics(registerer)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &nodeService{
 				juicefs:   tt.fields.juicefs,
 				nodeID:    tt.fields.nodeID,
 				k8sClient: tt.fields.k8sClient,
+				metrics:   metrics,
 			}
 			got, err := d.NodeExpandVolume(tt.args.ctx, tt.args.req)
 			if (err != nil) != tt.wantErr {
@@ -725,12 +750,15 @@ func Test_nodeService_NodeGetVolumeStats(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	registerer, _ := util.NewPrometheus(config.NodeName)
+	metrics := newMetrics(registerer)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &nodeService{
 				juicefs:   tt.fields.juicefs,
 				nodeID:    tt.fields.nodeID,
 				k8sClient: tt.fields.k8sClient,
+				metrics:   metrics,
 			}
 			got, err := d.NodeGetVolumeStats(tt.args.ctx, tt.args.req)
 			if (err != nil) != tt.wantErr {
@@ -769,12 +797,15 @@ func Test_nodeService_NodeStageVolume(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	registerer, _ := util.NewPrometheus(config.NodeName)
+	metrics := newMetrics(registerer)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &nodeService{
 				juicefs:   tt.fields.juicefs,
 				nodeID:    tt.fields.nodeID,
 				k8sClient: tt.fields.k8sClient,
+				metrics:   metrics,
 			}
 			got, err := d.NodeStageVolume(tt.args.ctx, tt.args.req)
 			if (err != nil) != tt.wantErr {
@@ -813,12 +844,15 @@ func Test_nodeService_NodeUnstageVolume(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	registerer, _ := util.NewPrometheus(config.NodeName)
+	metrics := newMetrics(registerer)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &nodeService{
 				juicefs:   tt.fields.juicefs,
 				nodeID:    tt.fields.nodeID,
 				k8sClient: tt.fields.k8sClient,
+				metrics:   metrics,
 			}
 			got, err := d.NodeUnstageVolume(tt.args.ctx, tt.args.req)
 			if (err != nil) != tt.wantErr {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -32,9 +32,11 @@ import (
 	k8sexec "k8s.io/utils/exec"
 	"k8s.io/utils/mount"
 
+	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs"
 	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs/mocks"
 	k8s "github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+	"github.com/juicedata/juicefs-csi-driver/pkg/util"
 )
 
 func TestNodePublishVolume(t *testing.T) {
@@ -647,7 +649,8 @@ func Test_newNodeService(t *testing.T) {
 				return []byte(""), nil
 			})
 			defer patch3.Reset()
-			_, err := newNodeService("test", nil)
+			registerer, _ := util.NewPrometheus(config.NodeName)
+			_, err := newNodeService("test", nil, registerer)
 			So(err, ShouldBeNil)
 		})
 	})

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -49,7 +49,7 @@ func TestNodePublishVolume(t *testing.T) {
 		},
 	}
 	registerer, _ := util.NewPrometheus(config.NodeName)
-	metrics := newMetrics(registerer)
+	metrics := newNodeMetrics(registerer)
 	testCases := []struct {
 		name     string
 		testFunc func(t *testing.T)
@@ -476,7 +476,7 @@ func TestNodePublishVolume(t *testing.T) {
 
 func TestNodeUnpublishVolume(t *testing.T) {
 	registerer, _ := util.NewPrometheus(config.NodeName)
-	metrics := newMetrics(registerer)
+	metrics := newNodeMetrics(registerer)
 	Convey("Test NodeUnpublishVolume", t, func() {
 		Convey("test normal", func() {
 			targetPath := "/test/path"
@@ -589,7 +589,7 @@ func Test_nodeService_NodeGetCapabilities(t *testing.T) {
 		},
 	}
 	registerer, _ := util.NewPrometheus(config.NodeName)
-	metrics := newMetrics(registerer)
+	metrics := newNodeMetrics(registerer)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &nodeService{
@@ -638,7 +638,7 @@ func Test_nodeService_NodeGetInfo(t *testing.T) {
 		},
 	}
 	registerer, _ := util.NewPrometheus(config.NodeName)
-	metrics := newMetrics(registerer)
+	metrics := newNodeMetrics(registerer)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &nodeService{
@@ -704,7 +704,7 @@ func Test_nodeService_NodeExpandVolume(t *testing.T) {
 		},
 	}
 	registerer, _ := util.NewPrometheus(config.NodeName)
-	metrics := newMetrics(registerer)
+	metrics := newNodeMetrics(registerer)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &nodeService{
@@ -751,7 +751,7 @@ func Test_nodeService_NodeGetVolumeStats(t *testing.T) {
 		},
 	}
 	registerer, _ := util.NewPrometheus(config.NodeName)
-	metrics := newMetrics(registerer)
+	metrics := newNodeMetrics(registerer)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &nodeService{
@@ -798,7 +798,7 @@ func Test_nodeService_NodeStageVolume(t *testing.T) {
 		},
 	}
 	registerer, _ := util.NewPrometheus(config.NodeName)
-	metrics := newMetrics(registerer)
+	metrics := newNodeMetrics(registerer)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &nodeService{
@@ -845,7 +845,7 @@ func Test_nodeService_NodeUnstageVolume(t *testing.T) {
 		},
 	}
 	registerer, _ := util.NewPrometheus(config.NodeName)
-	metrics := newMetrics(registerer)
+	metrics := newNodeMetrics(registerer)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &nodeService{

--- a/pkg/driver/provisioner.go
+++ b/pkg/driver/provisioner.go
@@ -35,6 +35,7 @@ import (
 	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs"
 	k8s "github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type provisionerService struct {
@@ -43,20 +44,37 @@ type provisionerService struct {
 	leaderElection              bool
 	leaderElectionNamespace     string
 	leaderElectionLeaseDuration time.Duration
+	metrics                     *provisionerMetrics
+}
+
+type provisionerMetrics struct {
+	provisionErrors prometheus.Counter
+}
+
+func newProvisionerMetrics(reg prometheus.Registerer) *provisionerMetrics {
+	metrics := &provisionerMetrics{}
+	metrics.provisionErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "provision_errors",
+		Help: "number of provision errors",
+	})
+	reg.MustRegister(metrics.provisionErrors)
+	return metrics
 }
 
 func newProvisionerService(k8sClient *k8s.K8sClient, leaderElection bool,
-	leaderElectionNamespace string, leaderElectionLeaseDuration time.Duration) (provisionerService, error) {
+	leaderElectionNamespace string, leaderElectionLeaseDuration time.Duration, reg prometheus.Registerer) (provisionerService, error) {
 	jfs := juicefs.NewJfsProvider(nil, k8sClient)
 	if leaderElectionNamespace == "" {
 		leaderElectionNamespace = config.Namespace
 	}
+	metrics := newProvisionerMetrics(reg)
 	return provisionerService{
 		juicefs:                     jfs,
 		K8sClient:                   k8sClient,
 		leaderElection:              leaderElection,
 		leaderElectionNamespace:     leaderElectionNamespace,
 		leaderElectionLeaseDuration: leaderElectionLeaseDuration,
+		metrics:                     metrics,
 	}, nil
 }
 
@@ -106,6 +124,7 @@ func (j *provisionerService) Provision(ctx context.Context, options provisioncon
 	for _, am := range options.PVC.Spec.AccessModes {
 		if am == corev1.ReadOnlyMany {
 			if options.StorageClass.Parameters["pathPattern"] == "" {
+				j.metrics.provisionErrors.Inc()
 				return nil, provisioncontroller.ProvisioningFinished, status.Errorf(codes.InvalidArgument, "Dynamic mounting uses the sub-path named pv name as data isolation, so read-only mode cannot be used.")
 			} else {
 				klog.Warningf("Volume is set readonly, please make sure the subpath %s exists.", subPath)
@@ -123,6 +142,7 @@ func (j *provisionerService) Provision(ctx context.Context, options provisioncon
 	secret, err := j.K8sClient.GetSecret(ctx, scParams[config.ProvisionerSecretName], scParams[config.ProvisionerSecretNamespace])
 	if err != nil {
 		klog.Errorf("[PVCReconciler]: Get Secret error: %v", err)
+		j.metrics.provisionErrors.Inc()
 		return nil, provisioncontroller.ProvisioningFinished, errors.New("unable to provision new pv: " + err.Error())
 	}
 	// set volume context

--- a/pkg/juicefs/mount/pod_mount_test.go
+++ b/pkg/juicefs/mount/pod_mount_test.go
@@ -484,6 +484,7 @@ func TestUmountTarget(t *testing.T) {
 					Interface: fakeClient,
 				},
 			}
+			t.Logf("PodMount %T %v", p, p)
 			podName := GenPodNameByUniqueId("ttt", true)
 			p.K8sClient.CreatePod(context.TODO(), &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -39,6 +39,9 @@ import (
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 	k8s "github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 )
 
 const (
@@ -464,4 +467,13 @@ func GetDiskUsage(path string) (uint64, uint64, uint64, uint64) {
 		klog.Errorf("GetDiskUsage: syscall.Statfs failed: %v", err)
 		return 1, 1, 1, 1
 	}
+}
+
+func NewPrometheus(nodeName string) (prometheus.Registerer, *prometheus.Registry) {
+	registry := prometheus.NewRegistry() // replace default so only JuiceFS metrics are exposed
+	registerer := prometheus.WrapRegistererWithPrefix("juicefs_",
+		prometheus.WrapRegistererWith(prometheus.Labels{"node_name": nodeName}, registry))
+	registerer.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	registerer.MustRegister(collectors.NewGoCollector())
+	return registerer, registry
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -41,7 +41,6 @@ import (
 	k8s "github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/collectors"
 )
 
 const (
@@ -471,9 +470,6 @@ func GetDiskUsage(path string) (uint64, uint64, uint64, uint64) {
 
 func NewPrometheus(nodeName string) (prometheus.Registerer, *prometheus.Registry) {
 	registry := prometheus.NewRegistry() // replace default so only JuiceFS metrics are exposed
-	registerer := prometheus.WrapRegistererWithPrefix("juicefs_",
-		prometheus.WrapRegistererWith(prometheus.Labels{"node_name": nodeName}, registry))
-	registerer.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
-	registerer.MustRegister(collectors.NewGoCollector())
+	registerer := prometheus.WrapRegistererWithPrefix("juicefs_", prometheus.WrapRegistererWith(prometheus.Labels{"node_name": nodeName}, registry))
 	return registerer, registry
 }


### PR DESCRIPTION
related: https://github.com/juicedata/juicefs-csi-driver/issues/832

currently, only these 2 simple metrics are added to monitor csi-node:

```
# HELP juicefs_provision_errors number of provision errors
# TYPE juicefs_provision_errors counter
juicefs_provision_errors{node_name="chaos-k8s-001"} 0
# HELP juicefs_volume_del_errors number of volume delete errors
# TYPE juicefs_volume_del_errors counter
juicefs_volume_del_errors{node_name="chaos-k8s-001"} 0
# HELP juicefs_volume_errors number of volume errors
# TYPE juicefs_volume_errors counter
juicefs_volume_errors{node_name="chaos-k8s-001"} 0
```