### PR TITLE
fix: cut the pod key if the length is greater than `maxPodLabelKeyLen…

### DIFF
--- a/pkg/dashboard/pod.go
+++ b/pkg/dashboard/pod.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
+	"github.com/juicedata/juicefs-csi-driver/pkg/util"
 )
 
 type PodExtra struct {
@@ -489,7 +490,7 @@ func (api *API) listMountPodOf(ctx context.Context, pod *corev1.Pod) ([]*corev1.
 	}
 	mountPods := make([]*corev1.Pod, 0)
 	for _, pv := range pvs {
-		key := fmt.Sprintf("%s-%s", config.JuiceFSMountPod, pv.Spec.CSI.VolumeHandle)
+		key := util.CutPodLabelKey(fmt.Sprintf("%s-%s", config.JuiceFSMountPod, pv.Spec.CSI.VolumeHandle))
 		mountPodName, ok := pod.Annotations[key]
 		if !ok {
 			// old app pod

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -529,8 +529,9 @@ func (p *PodMount) setMountLabel(ctx context.Context, uniqueId, mountPodName str
 	}
 
 	klog.Infof("setMountAnnotation: set mount info %s/%s in pod %s", jfsConfig.Namespace, mountPodName, podName)
+	key := util.CutPodLabelKey(fmt.Sprintf("%s-%s", jfsConfig.JuiceFSMountPod, uniqueId))
 	return util.AddPodAnnotation(ctx, p.K8sClient, pod, map[string]string{
-		fmt.Sprintf("%s-%s", jfsConfig.JuiceFSMountPod, uniqueId): fmt.Sprintf("%s/%s", jfsConfig.Namespace, mountPodName),
+		key: fmt.Sprintf("%s/%s", jfsConfig.Namespace, mountPodName),
 	})
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -42,6 +42,7 @@ import (
 
 const (
 	maxListTries                         = 3
+	maxPodLabelKeyLength                 = 63
 	expectedAtLeastNumFieldsPerMountInfo = 10
 	procMountInfoPath                    = "/proc/self/mountinfo"
 )
@@ -447,4 +448,12 @@ func ImageResol(image string) (hasCE, hasEE bool) {
 		return true, false
 	}
 	return true, true
+}
+
+// CutPodLabelKey removes the suffix of the key if the length is greater than `maxPodLabelKeyLength`
+func CutPodLabelKey(key string) string {
+	if len(key) > maxPodLabelKeyLength {
+		return key[:maxPodLabelKeyLength]
+	}
+	return key
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -625,3 +625,22 @@ func TestImageResol(t *testing.T) {
 		})
 	}
 }
+
+func TestCutPodLabelKey(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{"normal length of key label", "label_key_1", "label_key_1"},
+		{"longest length of key label ", "label_key_test-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "label_key_test-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CutPodLabelKey(tt.key); got != tt.want {
+				t.Errorf("CutPodLabelKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fix: #854 