### PR TITLE
feat: parse storageClass parameters

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -82,6 +82,9 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 	// set volume context
 	volCtx := make(map[string]string)
 	for k, v := range req.Parameters {
+		if strings.HasPrefix(v, "$") {
+			klog.Warningf("CreateVolume: volume %s parameters %s uses template pattern, please enable provisioner in CSI Controller, not works in default mode.", volumeId, k)
+		}
 		volCtx[k] = v
 	}
 	// return error if set readonly in dynamic provisioner


### PR DESCRIPTION
#853

storageClass parameters now respect template values like this

```yaml
...
parameters:
  juicefs/mount-cpu-limit: ${.pvc.annotations.csi.juicefs.com/mount-cpu-limit}
  juicefs/mount-memory-limit: ${.pvc.annotations.csi.juicefs.com/mount-memory-limit}
  juicefs/mount-cpu-request: ${.pvc.annotations.csi.juicefs.com/mount-cpu-request}
  juicefs/mount-memory-request: ${.pvc.annotations.csi.juicefs.com/mount-memory-request}
```