### PR TITLE
bring CacheClientConf to sidecar mode as well

### DIFF
--- a/cmd/app/webhook.go
+++ b/cmd/app/webhook.go
@@ -77,6 +77,12 @@ func NewWebhookManager(certDir string, webhookPort int, leaderElection bool,
 		klog.V(5).Infof("Could not create k8s client %v", err)
 		return nil, err
 	}
+	if config.CacheClientConf {
+		if err := (mountctrl.NewSecretController(k8sClient)).SetupWithManager(mgr); err != nil {
+			klog.Errorf("Register secret controller error: %v", err)
+			return nil, err
+		}
+	}
 	return &WebhookManager{
 		mgr:    mgr,
 		client: k8sClient,

--- a/pkg/juicefs/mount/builder/serverless.go
+++ b/pkg/juicefs/mount/builder/serverless.go
@@ -160,6 +160,26 @@ func (r *ServerlessBuilder) genServerlessVolumes() ([]corev1.Volume, []corev1.Vo
 		},
 	}
 
+	if r.jfsSetting.InitConfig != "" {
+		volumes = append(volumes, corev1.Volume{
+			Name: "init-config",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secretName,
+					Items: []corev1.KeyToPath{{
+						Key:  "initconfig",
+						Path: r.jfsSetting.Name + ".conf",
+					}},
+				},
+			},
+		})
+		volumeMounts = append(volumeMounts,
+			corev1.VolumeMount{
+				Name:      "init-config",
+				MountPath: config.ROConfPath,
+			},
+		)
+	}
 	return volumes, volumeMounts
 }
 


### PR DESCRIPTION
related:

* https://github.com/juicedata/juicefs-csi-driver/pull/850
* https://github.com/juicedata/juicefs-csi-driver/pull/845

local tests to verify that client conf works:

```
$ k logs juicefs-app -c jfs-mount
2024/01/27 07:30:24.897760 juicefs[64] <INFO>: JuiceFS version 5.0.6 (2023-12-25 04eaeb2) [mount.go:629]
2024/01/27 07:30:24.935923 juicefs[64] <INFO>: Cache: /var/jfsCache/chaos-ee-test capacity: 102400 MB [disk_cache.go:1074]
2024/01/27 07:30:24.936634 juicefs[64] <INFO>: Mounting volume chaos-ee-test at /jfs/vrbzic ... [mount_unix.go:651]
OK, chaos-ee-test is ready at /jfs/vrbzic.
JuiceFS:chaos-ee-test on /jfs/vrbzic type fuse.juicefs (rw,nosuid,nodev,relatime,user_id=0,group_id=0,default_permissions,allow_other)
2024-01-27 07:30:25
succeed in checking mount point /jfs/vrbzic
2024/01/27 07:30:29.631847 juicefs[37] <INFO>: watching /jfs/vrbzic, pid 64 [mount_unix.go:112]

$ keti juicefs-app -- bash
Defaulted container "jfs-mount" out of: jfs-mount, app
root@juicefs-app:/app# curl -m1 juicefs.com
curl: (28) Connection timed out after 1000 milliseconds

$ ls -alh /etc/juicefs/
total 4.0K
drwxrwxrwt 3 root root  100 Jan 27 07:30 .
drwxr-xr-x 1 root root 4.0K Jan 27 07:30 ..
drwxr-xr-x 2 root root   60 Jan 27 07:30 ..2024_01_27_07_30_21.815758126
lrwxrwxrwx 1 root root   31 Jan 27 07:30 ..data -> ..2024_01_27_07_30_21.815758126
lrwxrwxrwx 1 root root   25 Jan 27 07:30 chaos-ee-test.conf -> ..data/chaos-ee-test.conf
```