### PR TITLE
Add retry logic for reconciler of polling kubelet & ignore `No mount point specified` error  in preStop

### DIFF
--- a/pkg/controller/mountinfo.go
+++ b/pkg/controller/mountinfo.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
 	k8sMount "k8s.io/utils/mount"
 )
 
@@ -59,6 +60,7 @@ func (mit *mountInfoTable) setPodsStatus(podList *corev1.PodList) {
 		if pod.DeletionTimestamp != nil {
 			deleted = true
 		}
+		klog.V(6).Infof("set pod %s deleted status %v", pod.Name, deleted)
 		mit.deletedPods[string(pod.UID)] = deleted
 	}
 }

--- a/pkg/controller/pod_controller.go
+++ b/pkg/controller/pod_controller.go
@@ -81,6 +81,7 @@ func (m *PodController) Reconcile(ctx context.Context, request reconcile.Request
 	}
 	uniqueId := mountPod.Annotations[config.UniqueId]
 	for _, p := range pvs {
+		p := p
 		if p.Spec.CSI == nil || p.Spec.CSI.Driver != config.DriverName {
 			continue
 		}

--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -130,12 +130,6 @@ func (p *PodDriver) checkAnnotations(ctx context.Context, pod *corev1.Pod) error
 	lock.Lock()
 	defer lock.Unlock()
 
-	// Add a 10s delay to avoid misjudgment of deletion due to cache reasons when the pod is just created
-	if time.Now().Before(pod.GetCreationTimestamp().Time.Add(10 * time.Second)) {
-		klog.V(5).Infof("[PodDriver] pod %s is just created, skip check annotations", pod.Name)
-		return nil
-	}
-
 	delAnnotations := []string{}
 	var existTargets int
 	for k, target := range pod.Annotations {

--- a/pkg/juicefs/mount/builder/common.go
+++ b/pkg/juicefs/mount/builder/common.go
@@ -98,8 +98,8 @@ func (r *BaseBuilder) genCommonJuicePod(cnGen func() corev1.Container) *corev1.P
 	pod.Spec.Containers[0].Resources = r.jfsSetting.Resources
 	pod.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
 		PreStop: &corev1.Handler{
-			Exec: &corev1.ExecAction{Command: []string{"sh", "-c", fmt.Sprintf(
-				"umount %s -l && rmdir %s", r.jfsSetting.MountPath, r.jfsSetting.MountPath)}},
+			Exec: &corev1.ExecAction{Command: []string{"sh", "-c", "+e", fmt.Sprintf(
+				"umount %s -l; rmdir %s; exit 0", r.jfsSetting.MountPath, r.jfsSetting.MountPath)}},
 		},
 	}
 

--- a/pkg/juicefs/mount/builder/pod_test.go
+++ b/pkg/juicefs/mount/builder/pod_test.go
@@ -117,7 +117,7 @@ var (
 				},
 				Lifecycle: &corev1.Lifecycle{
 					PreStop: &corev1.Handler{
-						Exec: &corev1.ExecAction{Command: []string{"sh", "-c", fmt.Sprintf("umount %s -l && rmdir %s", "/jfs/default-imagenet", "/jfs/default-imagenet")}},
+						Exec: &corev1.ExecAction{Command: []string{"sh", "-c", "+e", fmt.Sprintf("umount %s -l; rmdir %s; exit 0", "/jfs/default-imagenet", "/jfs/default-imagenet")}},
 					},
 				},
 				Ports: []corev1.ContainerPort{


### PR DESCRIPTION
- Add retry logic for reconciler of polling kubelet
- fix for-range case in api-server reconciler
- ignore errors in preStop hook