### PR TITLE
fix: make driver version easy to print

### DIFF
--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -126,15 +126,6 @@ func parseControllerConfig() {
 
 func controllerRun() {
 	parseControllerConfig()
-
-	if version {
-		info, err := driver.GetVersionJSON()
-		if err != nil {
-			klog.Fatalln(err)
-		}
-		fmt.Println(info)
-		os.Exit(0)
-	}
 	if nodeID == "" {
 		klog.Fatalln("nodeID must be provided")
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,11 +18,13 @@ package main
 
 import (
 	goflag "flag"
+	"fmt"
 	_ "net/http/pprof"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/juicedata/juicefs-csi-driver/pkg/driver"
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
 )
@@ -54,6 +56,15 @@ func main() {
 		Use:   "juicefs-csi",
 		Short: "juicefs csi driver",
 		Run: func(cmd *cobra.Command, args []string) {
+			if version {
+				info, err := driver.GetVersionJSON()
+				if err != nil {
+					klog.Fatalln(err)
+				}
+				fmt.Println(info)
+				os.Exit(0)
+			}
+
 			run()
 		},
 	}

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -124,15 +124,6 @@ func parseNodeConfig() {
 
 func nodeRun() {
 	parseNodeConfig()
-
-	if version {
-		info, err := driver.GetVersionJSON()
-		if err != nil {
-			klog.Fatalln(err)
-		}
-		fmt.Println(info)
-		os.Exit(0)
-	}
 	if nodeID == "" {
 		klog.Fatalln("nodeID must be provided")
 	}


### PR DESCRIPTION
before
```sh
➜  POD_NAME=csi-node JUICEFS_MOUNT_NAMESPACE=asa ./bin/juicefs-csi-driver --version
I0313 10:44:05.279016  895493 main.go:98] Run CSI node
{
  "driverVersion": "v0.23.5-1-g8683789-dirty",
  "gitCommit": "8683789e04933959963662fee0f02a8b35c37fa1",
  "buildDate": "2024-03-13T02:36:09Z",
  "goVersion": "go1.22.1",
  "compiler": "gc",
  "platform": "linux/amd64"
}
```

after

```sh
➜  ./bin/juicefs-csi-driver --version
{
  "driverVersion": "v0.23.5-1-g8683789-dirty",
  "gitCommit": "8683789e04933959963662fee0f02a8b35c37fa1",
  "buildDate": "2024-03-13T02:36:09Z",
  "goVersion": "go1.22.1",
  "compiler": "gc",
  "platform": "linux/amd64"
}
```