### PR TITLE
feat: abort fuse connections if mountpod stuck in terminating state

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -125,6 +125,9 @@ const (
 	DeleteDelayTimeKey = "juicefs-delete-delay"
 	DeleteDelayAtKey   = "juicefs-delete-at"
 
+	// MountPointDevMinorKey mount pod annotation key to record the minor number from the fuse mountpoint.
+	MountPointDevMinorKey = "juicefs/mountpoint-dev-minor"
+
 	// default value
 	DefaultMountPodCpuLimit   = "2000m"
 	DefaultMountPodMemLimit   = "5Gi"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -125,9 +125,6 @@ const (
 	DeleteDelayTimeKey = "juicefs-delete-delay"
 	DeleteDelayAtKey   = "juicefs-delete-at"
 
-	// MountPointDevMinorKey mount pod annotation key to record the minor number from the fuse mountpoint.
-	MountPointDevMinorKey = "juicefs/mountpoint-dev-minor"
-
 	// default value
 	DefaultMountPodCpuLimit   = "2000m"
 	DefaultMountPodMemLimit   = "5Gi"

--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -291,7 +291,7 @@ func (p *PodDriver) podDeletedHandler(ctx context.Context, pod *corev1.Pod) erro
 		return err
 	}
 
-	go p.checkingMountPodStuck(pod)
+	go p.checkMountPodStuck(pod)
 
 	// pod with resource error
 	if util.IsPodResourceError(pod) {
@@ -717,7 +717,7 @@ func (p *PodDriver) OverwirteMountPodResourcesWithPVC(ctx context.Context, pod *
 	return nil
 }
 
-// checkingMountPodStuck check mount pod is stuck or not
+// checkMountPodStuck check mount pod is stuck or not
 // maybe fuse deadlock issue, they symptoms are:
 //
 // 1. pod in terminating state
@@ -729,7 +729,7 @@ func (p *PodDriver) OverwirteMountPodResourcesWithPVC(ctx context.Context, pod *
 // we can do this to abort fuse connection:
 //
 //	echo 1 >> /sys/fs/fuse/connections/$dev_minor/abort
-func (p *PodDriver) checkingMountPodStuck(pod *corev1.Pod) {
+func (p *PodDriver) checkMountPodStuck(pod *corev1.Pod) {
 	if pod == nil || getPodStatus(pod) != podDeleted {
 		return
 	}

--- a/pkg/controller/pod_driver_test.go
+++ b/pkg/controller/pod_driver_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/utils/mount"
 
 	jfsConfig "github.com/juicedata/juicefs-csi-driver/pkg/config"
+	"github.com/juicedata/juicefs-csi-driver/pkg/driver/mocks"
 	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util"
 )
@@ -431,10 +432,10 @@ func TestPodDriver_podReadyHandler(t *testing.T) {
 				Exec:      k8sexec.New(),
 			})
 			outputs := []OutputCell{
-				{Values: Params{nil, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
 				{Values: Params{nil, os.NewSyscallError("", syscall.ENOTCONN)}},
-				{Values: Params{nil, nil}},
-				{Values: Params{nil, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
 			}
 			patch1 := ApplyFuncSeq(os.Stat, outputs)
 			defer patch1.Reset()
@@ -456,8 +457,8 @@ func TestPodDriver_podReadyHandler(t *testing.T) {
 				Exec:      k8sexec.New(),
 			})
 			outputs := []OutputCell{
-				{Values: Params{nil, nil}},
-				{Values: Params{nil, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
 			}
 			patch1 := ApplyFuncSeq(os.Stat, outputs)
 			defer patch1.Reset()
@@ -474,8 +475,8 @@ func TestPodDriver_podReadyHandler(t *testing.T) {
 				Exec:      k8sexec.New(),
 			})
 			outputs := []OutputCell{
-				{Values: Params{nil, nil}},
-				{Values: Params{nil, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
 			}
 			patch2 := ApplyFuncSeq(os.Stat, outputs)
 			defer patch2.Reset()
@@ -488,7 +489,7 @@ func TestPodDriver_podReadyHandler(t *testing.T) {
 				Exec:      k8sexec.New(),
 			})
 			outputs := []OutputCell{
-				{Values: Params{nil, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
 				{Values: Params{nil, notExistsErr}},
 			}
 			patch1 := ApplyFuncSeq(os.Stat, outputs)
@@ -502,10 +503,10 @@ func TestPodDriver_podReadyHandler(t *testing.T) {
 				Exec:      k8sexec.New(),
 			})
 			outputs := []OutputCell{
-				{Values: Params{nil, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
 				{Values: Params{nil, os.NewSyscallError("", syscall.ENOTCONN)}},
-				{Values: Params{nil, nil}},
-				{Values: Params{nil, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
 			}
 			patch1 := ApplyFuncSeq(os.Stat, outputs)
 			defer patch1.Reset()
@@ -593,9 +594,9 @@ func TestPodDriver_podReadyHandler(t *testing.T) {
 				Exec:      k8sexec.New(),
 			})
 			outputs := []OutputCell{
-				{Values: Params{nil, nil}},
-				{Values: Params{nil, nil}},
-				{Values: Params{nil, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
 				{Values: Params{nil, os.NewSyscallError("", syscall.ENOTCONN)}},
 			}
 			patch1 := ApplyFuncSeq(os.Stat, outputs)
@@ -615,7 +616,7 @@ func TestPodDriver_podReadyHandler(t *testing.T) {
 				Exec:      k8sexec.New(),
 			})
 			outputs := []OutputCell{
-				{Values: Params{nil, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
 				{Values: Params{nil, volErr}},
 			}
 			patch1 := ApplyFuncSeq(os.Stat, outputs)
@@ -633,7 +634,7 @@ func TestPodDriver_podReadyHandler(t *testing.T) {
 				Exec:      k8sexec.New(),
 			})
 			outputs := []OutputCell{
-				{Values: Params{nil, nil}},
+				{Values: Params{mocks.FakeFileInfoIno1{}, nil}},
 			}
 			patch1 := ApplyFuncSeq(os.Stat, outputs)
 			defer patch1.Reset()

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -407,6 +407,7 @@ func (p *PodMount) waitUtilMountReady(ctx context.Context, jfsSetting *jfsConfig
 		}
 		if st, ok := finfo.Sys().(*syscall.Stat_t); ok {
 			if st.Ino == 1 {
+				util.MountPointDevMinorTable[jfsSetting.MountPath] = util.DevMinor(st.Dev)
 				klog.V(5).Infof("Mount point %v is ready, mountpod: %s", jfsSetting.MountPath, podName)
 				return nil
 			}

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -407,7 +407,7 @@ func (p *PodMount) waitUtilMountReady(ctx context.Context, jfsSetting *jfsConfig
 		}
 		if st, ok := finfo.Sys().(*syscall.Stat_t); ok {
 			if st.Ino == 1 {
-				util.MountPointDevMinorTable[jfsSetting.MountPath] = util.DevMinor(st.Dev)
+				util.MountPointDevMinorTable.Store(jfsSetting.MountPath, util.DevMinor(st.Dev))
 				klog.V(5).Infof("Mount point %v is ready, mountpod: %s", jfsSetting.MountPath, podName)
 				return nil
 			}

--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -34,10 +34,6 @@ var (
 	MountPointDevMinorTable sync.Map
 )
 
-func init() {
-	MountPointDevMinorTable = sync.Map{}
-}
-
 func IsPodReady(pod *corev1.Pod) bool {
 	conditionsTrue := 0
 	for _, cond := range pod.Status.Conditions {

--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,11 +31,11 @@ import (
 )
 
 var (
-	MountPointDevMinorTable map[string]uint32
+	MountPointDevMinorTable sync.Map
 )
 
 func init() {
-	MountPointDevMinorTable = make(map[string]uint32)
+	MountPointDevMinorTable = sync.Map{}
 }
 
 func IsPodReady(pod *corev1.Pod) bool {

--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -29,6 +29,14 @@ import (
 	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
 )
 
+var (
+	MountPointDevMinorTable map[string]uint32
+)
+
+func init() {
+	MountPointDevMinorTable = make(map[string]uint32)
+}
+
 func IsPodReady(pod *corev1.Pod) bool {
 	conditionsTrue := 0
 	for _, cond := range pod.Status.Conditions {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -466,3 +466,10 @@ func NewPrometheus(nodeName string) (prometheus.Registerer, *prometheus.Registry
 	registerer := prometheus.WrapRegistererWithPrefix("juicefs_", prometheus.WrapRegistererWith(prometheus.Labels{"node_name": nodeName}, registry))
 	return registerer, registry
 }
+
+// DevMinor returns the minor component of a Linux device number.
+func DevMinor(dev uint64) uint32 {
+	minor := dev & 0xff
+	minor |= (dev >> 12) & 0xffffff00
+	return uint32(minor)
+}


### PR DESCRIPTION
when mountpod ready, add `devMinor` to csi-node memory

when mountpod deleted, check if stuck in terminating state

if stuck, create a job to execute this `echo 1 > /sys/fs/fuse/connections/$dev_minor/abort` to abort fuse connections.
