### PR TITLE
Allow set mountpod to zero resources

### DIFF
--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -519,7 +519,7 @@ func ParsePodResources(cpuLimit, memoryLimit, cpuRequest, memoryRequest string) 
 			return corev1.ResourceRequirements{}, err
 		}
 		q := podLimit[corev1.ResourceCPU]
-		if res := q.Cmp(*resource.NewQuantity(0, resource.DecimalSI)); res <= 0 {
+		if res := q.Cmp(*resource.NewQuantity(0, resource.DecimalSI)); res < 0 {
 			delete(podLimit, corev1.ResourceCPU)
 		}
 	}
@@ -528,7 +528,7 @@ func ParsePodResources(cpuLimit, memoryLimit, cpuRequest, memoryRequest string) 
 			return corev1.ResourceRequirements{}, err
 		}
 		q := podLimit[corev1.ResourceMemory]
-		if res := q.Cmp(*resource.NewQuantity(0, resource.DecimalSI)); res <= 0 {
+		if res := q.Cmp(*resource.NewQuantity(0, resource.DecimalSI)); res < 0 {
 			delete(podLimit, corev1.ResourceMemory)
 		}
 	}
@@ -537,7 +537,7 @@ func ParsePodResources(cpuLimit, memoryLimit, cpuRequest, memoryRequest string) 
 			return corev1.ResourceRequirements{}, err
 		}
 		q := podRequest[corev1.ResourceCPU]
-		if res := q.Cmp(*resource.NewQuantity(0, resource.DecimalSI)); res <= 0 {
+		if res := q.Cmp(*resource.NewQuantity(0, resource.DecimalSI)); res < 0 {
 			delete(podRequest, corev1.ResourceCPU)
 		}
 	}
@@ -546,7 +546,7 @@ func ParsePodResources(cpuLimit, memoryLimit, cpuRequest, memoryRequest string) 
 			return corev1.ResourceRequirements{}, err
 		}
 		q := podRequest[corev1.ResourceMemory]
-		if res := q.Cmp(*resource.NewQuantity(0, resource.DecimalSI)); res <= 0 {
+		if res := q.Cmp(*resource.NewQuantity(0, resource.DecimalSI)); res < 0 {
 			delete(podRequest, corev1.ResourceMemory)
 		}
 	}

--- a/pkg/config/setting_test.go
+++ b/pkg/config/setting_test.go
@@ -728,6 +728,16 @@ func Test_parsePodResources(t *testing.T) {
 		Limits:   podLimit,
 		Requests: podRequest,
 	}
+	zeroResources := corev1.ResourceRequirements{
+		Limits: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceCPU:    resource.MustParse("0"),
+			corev1.ResourceMemory: resource.MustParse("0"),
+		},
+		Requests: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceCPU:    resource.MustParse("0"),
+			corev1.ResourceMemory: resource.MustParse("0"),
+		},
+	}
 	type args struct {
 		cpuLimit      string
 		memoryLimit   string
@@ -752,12 +762,23 @@ func Test_parsePodResources(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "test-nil",
+			name: "test-zero",
 			args: args{
-				cpuLimit:      "-1",
+				cpuLimit:      "0",
 				memoryLimit:   "0",
 				cpuRequest:    "0",
 				memoryRequest: "0",
+			},
+			want:    zeroResources,
+			wantErr: false,
+		},
+		{
+			name: "test-nil",
+			args: args{
+				cpuLimit:      "-1",
+				memoryLimit:   "-1",
+				cpuRequest:    "-1",
+				memoryRequest: "-1",
 			},
 			want: corev1.ResourceRequirements{
 				Limits:   map[corev1.ResourceName]resource.Quantity{},


### PR DESCRIPTION
after https://github.com/juicedata/juicefs-csi-driver/pull/771 when resource is set smaller than 0, will not set resource request/limit

maybe some people want to set it to 0 resources. we should allow this

