### PR TITLE
fix: faster auto recover mountpoint

### DIFF
--- a/pkg/controller/pod_driver_test.go
+++ b/pkg/controller/pod_driver_test.go
@@ -692,6 +692,10 @@ func TestPodDriver_podDeletedHandler(t *testing.T) {
 				return true, nil
 			})
 			defer patch7.Reset()
+			patch8 := ApplyFunc(os.Stat, func(name string) (os.FileInfo, error) {
+				return mocks.FakeFileInfoIno1{}, nil
+			})
+			defer patch8.Reset()
 
 			d := NewPodDriver(&k8sclient.K8sClient{Interface: fake.NewSimpleClientset()}, mount.SafeFormatAndMount{
 				Interface: mount.New(""),
@@ -732,6 +736,10 @@ func TestPodDriver_podDeletedHandler(t *testing.T) {
 				return true, nil
 			})
 			defer patch7.Reset()
+			patch8 := ApplyFunc(os.Stat, func(name string) (os.FileInfo, error) {
+				return mocks.FakeFileInfoIno1{}, nil
+			})
+			defer patch8.Reset()
 
 			d := NewPodDriver(&k8sclient.K8sClient{Interface: fake.NewSimpleClientset()}, mount.SafeFormatAndMount{
 				Interface: mount.New(""),

--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -242,7 +242,7 @@ func WaitUtilMountReady(ctx context.Context, podName, mntPath string, timeout ti
 			if err == context.Canceled || err == context.DeadlineExceeded {
 				break
 			}
-			klog.V(6).Infof("mount path %v not ready, mountpod: %s, err: %v", mntPath, podName, err)
+			klog.V(6).Infof("Mount path %v is not ready, mountpod: %s, err: %v", mntPath, podName, err)
 			time.Sleep(time.Millisecond * 500)
 			continue
 		}


### PR DESCRIPTION
when mountpod recreated/restart, it is possible that the mountpoint may not be ready yet. At this time, the recovery will be skipped and will wait for the next reconciler (now is 10m)

needed to continuously monitor the mount point when rebuilding the mountpod, and as soon as it is ready, immediately recover


fix https://github.com/juicedata/juicefs-csi-driver/issues/917