### PR TITLE
fix: delete mountpod when it enter the completed state

### DIFF
--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -61,6 +61,15 @@ func IsPodError(pod *corev1.Pod) bool {
 	return containError(pod.Status.ContainerStatuses)
 }
 
+func IsPodCompleted(pod *corev1.Pod) bool {
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.State.Terminated != nil && status.State.Terminated.Reason == "Completed" {
+			return true
+		}
+	}
+	return false
+}
+
 func IsPodResourceError(pod *corev1.Pod) bool {
 	if pod.Status.Phase == corev1.PodFailed {
 		if strings.Contains(pod.Status.Reason, "OutOf") {


### PR DESCRIPTION
when a mountpod enter completed state, we need to consider this an abnormal event that needs to be deleted and enter the recovery process