### PR TITLE
fix: exit if mount manager fails to start

### DIFF
--- a/cmd/app/mount_manager.go
+++ b/cmd/app/mount_manager.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"context"
+	"os"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -114,6 +115,6 @@ func (m *MountManager) Start(ctx context.Context) {
 	klog.Info("Mount manager started.")
 	if err := m.mgr.Start(ctx); err != nil {
 		klog.Errorf("Mount manager start error: %v", err)
-		return
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
If `LeaderElection` is used, the program must be exited immediately after `Start` returns, otherwise components that need leader election might continue to run after the leader lock was lost.