### PR TITLE
fix default ee version tag

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -55,7 +55,10 @@ jobs:
         if [ ${{ env.ee_juicefs_latest_tag }} ]; then
           echo "JUICEFS_EE_LATEST_VERSION=${{ env.ee_juicefs_latest_tag }}" >> $GITHUB_ENV
         else
-          JUICEFS_EE_LATEST_VERSION=$(curl -sSL https://juicefs.com/static/Linux/mount -o juicefs-ee && chmod +x juicefs-ee && ./juicefs-ee -V | cut -d' ' -f3)
+          curl -sSL https://juicefs.com/static/Linux/mount -o juicefs-ee && chmod +x juicefs-ee
+          version=$(./juicefs-ee version | cut -d' ' -f3)
+          hash=$(./juicefs-ee version | awk -F '[()]' '{print $2}' | awk '{print $NF}')
+          JUICEFS_EE_LATEST_VERSION=${version}-${hash}
           echo "JUICEFS_EE_LATEST_VERSION=$JUICEFS_EE_LATEST_VERSION" >> $GITHUB_ENV
         fi
         

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -52,8 +52,8 @@ jobs:
           echo "JUICEFS_CE_LATEST_VERSION=$JUICEFS_CE_LATEST_VERSION" >> $GITHUB_ENV
         fi
         
-        if [ ${{ env.ee_juicefs_latest_tag }} ]; then
-          echo "JUICEFS_EE_LATEST_VERSION=${{ env.ee_juicefs_latest_tag }}" >> $GITHUB_ENV
+        if [ ${{ env.EE_JUICEFS_LATEST_VERSION }} ]; then
+          echo "JUICEFS_EE_LATEST_VERSION=${{ env.EE_JUICEFS_LATEST_VERSION }}" >> $GITHUB_ENV
         else
           curl -sSL https://juicefs.com/static/Linux/mount -o juicefs-ee && chmod +x juicefs-ee
           version=$(./juicefs-ee version | cut -d' ' -f3)


### PR DESCRIPTION
after this [pr](https://github.com/juicedata/juicefs-csi-driver/pull/797/files) 

the image version format is changed to `${version}-${hash}` style in build mount image workflow

but the old format is still used for releases workflow