### PR TITLE
feat: introduce global config

### DIFF
--- a/.github/scripts/config.py
+++ b/.github/scripts/config.py
@@ -49,3 +49,5 @@ JOBs = []
 PODS = []
 PVCs = []
 PVs = []
+
+CONFIG_NAME = "juicefs-csi-driver-config"

--- a/.github/scripts/e2e-test.py
+++ b/.github/scripts/e2e-test.py
@@ -50,6 +50,7 @@ from test_case import (
     test_multi_pvc,
     test_mountpod_recreated,
     test_validate_pv,
+    test_config,
 )
 from util import die, mount_on_host, umount, clean_juicefs_volume, deploy_secret_and_sc, check_do_test
 
@@ -85,6 +86,7 @@ if __name__ == "__main__":
                 test_dynamic_expand()
                 test_multi_pvc()
                 test_mountpod_recreated()
+                test_config()
                 if without_kubelet:
                     test_pod_resource_err()
 
@@ -111,6 +113,7 @@ if __name__ == "__main__":
                 test_quota_using_storage_rw()
                 test_dynamic_expand()
                 test_multi_pvc()
+                test_config()
                 if without_kubelet:
                     test_pod_resource_err()
 
@@ -136,6 +139,7 @@ if __name__ == "__main__":
                 test_quota_using_storage_rw()
                 test_dynamic_expand()
                 test_multi_pvc()
+                test_config()
                 if without_kubelet:
                     test_pod_resource_err()
 

--- a/.github/scripts/e2e-test.py
+++ b/.github/scripts/e2e-test.py
@@ -113,7 +113,6 @@ if __name__ == "__main__":
                 test_quota_using_storage_rw()
                 test_dynamic_expand()
                 test_multi_pvc()
-                test_config()
                 if without_kubelet:
                     test_pod_resource_err()
 

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -83,22 +83,21 @@ func parseControllerConfig() {
 	config.Namespace = os.Getenv("JUICEFS_MOUNT_NAMESPACE")
 	config.MountPointPath = os.Getenv("JUICEFS_MOUNT_PATH")
 	config.JFSConfigPath = os.Getenv("JUICEFS_CONFIG_PATH")
-	config.MountLabels = os.Getenv("JUICEFS_MOUNT_LABELS")
 
 	if mountPodImage := os.Getenv("JUICEFS_CE_MOUNT_IMAGE"); mountPodImage != "" {
-		config.CEMountImage = mountPodImage
+		config.DefaultCEMountImage = mountPodImage
 	}
 	if mountPodImage := os.Getenv("JUICEFS_EE_MOUNT_IMAGE"); mountPodImage != "" {
-		config.EEMountImage = mountPodImage
+		config.DefaultEEMountImage = mountPodImage
 	}
 	if mountPodImage := os.Getenv("JUICEFS_MOUNT_IMAGE"); mountPodImage != "" {
 		// check if it's CE or EE
 		hasCE, hasEE := util.ImageResol(mountPodImage)
 		if hasCE {
-			config.CEMountImage = mountPodImage
+			config.DefaultCEMountImage = mountPodImage
 		}
 		if hasEE {
-			config.EEMountImage = mountPodImage
+			config.DefaultEEMountImage = mountPodImage
 		}
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 	"github.com/juicedata/juicefs-csi-driver/pkg/driver"
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
@@ -35,6 +36,7 @@ var (
 	nodeID      string
 	formatInPod bool
 	process     bool
+	configPath  string
 
 	provisioner       bool
 	cacheConf         bool
@@ -73,6 +75,7 @@ func main() {
 	cmd.PersistentFlags().StringVar(&nodeID, "nodeid", "", "Node ID")
 	cmd.PersistentFlags().BoolVar(&formatInPod, "format-in-pod", false, "Put format/auth in pod")
 	cmd.PersistentFlags().BoolVar(&process, "by-process", false, "CSI Driver run juicefs in process or not. default false.")
+	cmd.PersistentFlags().StringVar(&configPath, "config", "", "Paths to a csi config file. default empty")
 
 	cmd.PersistentFlags().BoolVar(&leaderElection, "leader-election", false, "Enables leader election. If leader election is enabled, additional RBAC rules are required. ")
 	cmd.PersistentFlags().StringVar(&leaderElectionNamespace, "leader-election-namespace", "", "Namespace where the leader election resource lives. Defaults to the pod namespace if not set.")
@@ -100,6 +103,11 @@ func main() {
 }
 
 func run() {
+	if configPath != "" {
+		if err := config.StartConfigReloader(configPath); err != nil {
+			klog.Fatalf("fail to load config: %v", err)
+		}
+	}
 	podName := os.Getenv("POD_NAME")
 	if strings.Contains(podName, "csi-controller") {
 		klog.Info("Run CSI controller")

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -56,14 +56,11 @@ func parseNodeConfig() {
 			klog.Errorf("cannot parse JUICEFS_IMMUTABLE: %v", err)
 		}
 	}
-	config.EnableNodeSelector = os.Getenv("ENABLE_NODE_SELECTOR") == "1"
 	config.NodeName = os.Getenv("NODE_NAME")
 	config.Namespace = os.Getenv("JUICEFS_MOUNT_NAMESPACE")
 	config.PodName = os.Getenv("POD_NAME")
 	config.MountPointPath = os.Getenv("JUICEFS_MOUNT_PATH")
 	config.JFSConfigPath = os.Getenv("JUICEFS_CONFIG_PATH")
-	config.MountLabels = os.Getenv("JUICEFS_MOUNT_LABELS")
-
 	config.HostIp = os.Getenv("HOST_IP")
 	config.KubeletPort = os.Getenv("KUBELET_PORT")
 	jfsMountPriorityName := os.Getenv("JUICEFS_MOUNT_PRIORITY_NAME")
@@ -90,19 +87,19 @@ func parseNodeConfig() {
 	}
 
 	if mountPodImage := os.Getenv("JUICEFS_CE_MOUNT_IMAGE"); mountPodImage != "" {
-		config.CEMountImage = mountPodImage
+		config.DefaultCEMountImage = mountPodImage
 	}
 	if mountPodImage := os.Getenv("JUICEFS_EE_MOUNT_IMAGE"); mountPodImage != "" {
-		config.EEMountImage = mountPodImage
+		config.DefaultEEMountImage = mountPodImage
 	}
 	if mountPodImage := os.Getenv("JUICEFS_MOUNT_IMAGE"); mountPodImage != "" {
 		// check if it's CE or EE
 		hasCE, hasEE := util.ImageResol(mountPodImage)
 		if hasCE {
-			config.CEMountImage = mountPodImage
+			config.DefaultCEMountImage = mountPodImage
 		}
 		if hasEE {
-			config.EEMountImage = mountPodImage
+			config.DefaultEEMountImage = mountPodImage
 		}
 	}
 

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -384,6 +384,27 @@ subjects:
   namespace: kube-system
 ---
 apiVersion: v1
+data:
+  config.yaml: |-
+    mountPodPatch:
+      - lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - +e
+              - umount ${MOUNT_POINT} -l; rmdir ${MOUNT_POINT}; exit 0
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
+  name: juicefs-csi-driver-config
+  namespace: kube-system
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -632,6 +653,7 @@ spec:
         - --nodeid=$(NODE_NAME)
         - --v=5
         - --enable-manager=true
+        - --config=/etc/config/config.yaml
         env:
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
@@ -701,6 +723,8 @@ spec:
         - mountPath: /root/.juicefs
           mountPropagation: Bidirectional
           name: jfs-root-dir
+        - mountPath: /etc/config
+          name: juicefs-config
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -761,6 +785,10 @@ spec:
           path: /var/lib/juicefs/config
           type: DirectoryOrCreate
         name: jfs-root-dir
+      - configMap:
+          defaultMode: 420
+          name: juicefs-csi-driver-config
+        name: juicefs-config
 ---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver

--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -511,6 +511,7 @@ spec:
         - --nodeid=$(NODE_NAME)
         - --leader-election
         - --v=5
+        - --config=/etc/config/config.yaml
         env:
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -565,6 +566,8 @@ spec:
         - mountPath: /root/.juicefs
           mountPropagation: Bidirectional
           name: jfs-root-dir
+        - mountPath: /etc/config
+          name: juicefs-config
       - args:
         - --csi-address=$(ADDRESS)
         - --timeout=60s
@@ -619,6 +622,10 @@ spec:
           path: /var/lib/juicefs/config
           type: DirectoryOrCreate
         name: jfs-root-dir
+      - configMap:
+          defaultMode: 420
+          name: juicefs-csi-driver-config
+        name: juicefs-config
   volumeClaimTemplates: []
 ---
 apiVersion: apps/v1

--- a/deploy/k8s_before_v1_18.yaml
+++ b/deploy/k8s_before_v1_18.yaml
@@ -511,6 +511,7 @@ spec:
         - --nodeid=$(NODE_NAME)
         - --leader-election
         - --v=5
+        - --config=/etc/config/config.yaml
         env:
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -565,6 +566,8 @@ spec:
         - mountPath: /root/.juicefs
           mountPropagation: Bidirectional
           name: jfs-root-dir
+        - mountPath: /etc/config
+          name: juicefs-config
       - args:
         - --csi-address=$(ADDRESS)
         - --timeout=60s
@@ -619,6 +622,10 @@ spec:
           path: /var/lib/juicefs/config
           type: DirectoryOrCreate
         name: jfs-root-dir
+      - configMap:
+          defaultMode: 420
+          name: juicefs-csi-driver-config
+        name: juicefs-config
   volumeClaimTemplates: []
 ---
 apiVersion: apps/v1

--- a/deploy/k8s_before_v1_18.yaml
+++ b/deploy/k8s_before_v1_18.yaml
@@ -384,6 +384,27 @@ subjects:
   namespace: kube-system
 ---
 apiVersion: v1
+data:
+  config.yaml: |-
+    mountPodPatch:
+      - lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - +e
+              - umount ${MOUNT_POINT} -l; rmdir ${MOUNT_POINT}; exit 0
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
+  name: juicefs-csi-driver-config
+  namespace: kube-system
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -632,6 +653,7 @@ spec:
         - --nodeid=$(NODE_NAME)
         - --v=5
         - --enable-manager=true
+        - --config=/etc/config/config.yaml
         env:
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
@@ -701,6 +723,8 @@ spec:
         - mountPath: /root/.juicefs
           mountPropagation: Bidirectional
           name: jfs-root-dir
+        - mountPath: /etc/config
+          name: juicefs-config
       - args:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -761,6 +785,10 @@ spec:
           path: /var/lib/juicefs/config
           type: DirectoryOrCreate
         name: jfs-root-dir
+      - configMap:
+          defaultMode: 420
+          name: juicefs-csi-driver-config
+        name: juicefs-config
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver

--- a/deploy/kubernetes/base/resources.yaml
+++ b/deploy/kubernetes/base/resources.yaml
@@ -313,6 +313,23 @@ spec:
   attachRequired: false
   podInfoOnMount: true
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: juicefs-csi-driver-config
+  namespace: kube-system
+data:
+  config.yaml: |-
+    mountPodPatch:
+      - lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - +e
+              - umount ${MOUNT_POINT} -l; rmdir ${MOUNT_POINT}; exit 0
+---
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
@@ -483,6 +500,7 @@ spec:
             - --nodeid=$(NODE_NAME)
             - --v=5
             - --enable-manager=true
+            - --config=/etc/config/config.yaml
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
@@ -522,6 +540,8 @@ spec:
             - mountPath: /root/.juicefs
               mountPropagation: Bidirectional
               name: jfs-root-dir
+            - mountPath: /etc/config
+              name: juicefs-config
           lifecycle:
             preStop:
               exec:
@@ -595,6 +615,10 @@ spec:
             path: /var/lib/juicefs/config
             type: DirectoryOrCreate
           name: jfs-root-dir
+        - configMap:
+            defaultMode: 420
+            name: juicefs-csi-driver-config
+          name: juicefs-config
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/deploy/kubernetes/base/resources.yaml
+++ b/deploy/kubernetes/base/resources.yaml
@@ -363,6 +363,7 @@ spec:
             - --nodeid=$(NODE_NAME)
             - --leader-election
             - --v=5
+            - --config=/etc/config/config.yaml
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -394,6 +395,8 @@ spec:
             - name: webhook-certs
               mountPath: /etc/webhook/certs
               readOnly: true
+            - mountPath: /etc/config
+              name: juicefs-config
           ports:
             - name: healthz
               containerPort: 9909
@@ -465,6 +468,10 @@ spec:
         - name: webhook-certs
           secret:
             secretName: juicefs-webhook-certs
+        - configMap:
+            defaultMode: 420
+            name: juicefs-csi-driver-config
+          name: juicefs-config
 ---
 # Node Service
 kind: DaemonSet

--- a/deploy/kubernetes/csi-ci/pod-mount-share/daemonset.yaml
+++ b/deploy/kubernetes/csi-ci/pod-mount-share/daemonset.yaml
@@ -14,6 +14,7 @@ spec:
             - --nodeid=$(NODE_NAME)
             - --v=6
             - --enable-manager=true
+            - --config=/etc/config/config.yaml
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock

--- a/deploy/kubernetes/csi-ci/pod-mount-share/statefulset.yaml
+++ b/deploy/kubernetes/csi-ci/pod-mount-share/statefulset.yaml
@@ -15,6 +15,7 @@ spec:
             - --leader-election
             - --cache-client-conf
             - --v=6
+            - --config=/etc/config/config.yaml
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/kubernetes/csi-ci/pod-provisioner/daemonset.yaml
+++ b/deploy/kubernetes/csi-ci/pod-provisioner/daemonset.yaml
@@ -14,3 +14,4 @@ spec:
             - --nodeid=$(NODE_NAME)
             - --v=6
             - --enable-manager=true
+            - --config=/etc/config/config.yaml

--- a/deploy/kubernetes/csi-ci/pod-provisioner/statefulset.yaml
+++ b/deploy/kubernetes/csi-ci/pod-provisioner/statefulset.yaml
@@ -15,5 +15,6 @@ spec:
             - --leader-election
             - --v=6
             - --provisioner=true
+            - --config=/etc/config/config.yaml
         - name: csi-provisioner
           $patch: delete

--- a/deploy/kubernetes/csi-ci/pod/daemonset.yaml
+++ b/deploy/kubernetes/csi-ci/pod/daemonset.yaml
@@ -14,3 +14,4 @@ spec:
             - --nodeid=$(NODE_NAME)
             - --v=6
             - --enable-manager=true
+            - --config=/etc/config/config.yaml

--- a/deploy/kubernetes/csi-ci/pod/statefulset.yaml
+++ b/deploy/kubernetes/csi-ci/pod/statefulset.yaml
@@ -14,3 +14,4 @@ spec:
             - --nodeid=$(NODE_NAME)
             - --leader-election
             - --v=6
+            - --config=/etc/config/config.yaml

--- a/deploy/kubernetes/csi-ci/process/daemonset.yaml
+++ b/deploy/kubernetes/csi-ci/process/daemonset.yaml
@@ -14,3 +14,4 @@ spec:
             - --nodeid=$(NODE_NAME)
             - --v=6
             - --by-process=true
+            - --config=/etc/config/config.yaml

--- a/deploy/kubernetes/csi-ci/process/statefulset.yaml
+++ b/deploy/kubernetes/csi-ci/process/statefulset.yaml
@@ -15,3 +15,4 @@ spec:
             - --leader-election
             - --v=6
             - --by-process=true
+            - --config=/etc/config/config.yaml

--- a/deploy/kubernetes/csi-ci/webhook-provisioner/statefulset.yaml
+++ b/deploy/kubernetes/csi-ci/webhook-provisioner/statefulset.yaml
@@ -16,5 +16,6 @@ spec:
             - --v=6
             - --webhook=true
             - --provisioner=true
+            - --config=/etc/config/config.yaml
         - name: csi-provisioner
           $patch: delete

--- a/deploy/kubernetes/csi-ci/webhook/statefulset.yaml
+++ b/deploy/kubernetes/csi-ci/webhook/statefulset.yaml
@@ -16,3 +16,4 @@ spec:
             - --v=6
             - --webhook=true
             - --validating-webhook=true
+            - --config=/etc/config/config.yaml

--- a/deploy/kubernetes/csi-ci/without-kubelet/pod-mount-share/daemonset.yaml
+++ b/deploy/kubernetes/csi-ci/without-kubelet/pod-mount-share/daemonset.yaml
@@ -14,6 +14,7 @@ spec:
             - --nodeid=$(NODE_NAME)
             - --v=6
             - --enable-manager=true
+            - --config=/etc/config/config.yaml
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock

--- a/deploy/kubernetes/csi-ci/without-kubelet/pod-mount-share/statefulset.yaml
+++ b/deploy/kubernetes/csi-ci/without-kubelet/pod-mount-share/statefulset.yaml
@@ -15,6 +15,7 @@ spec:
             - --leader-election
             - --cache-client-conf
             - --v=6
+            - --config=/etc/config/config.yaml
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/kubernetes/csi-ci/without-kubelet/pod-provisioner/daemonset.yaml
+++ b/deploy/kubernetes/csi-ci/without-kubelet/pod-provisioner/daemonset.yaml
@@ -14,6 +14,7 @@ spec:
             - --nodeid=$(NODE_NAME)
             - --v=6
             - --enable-manager=true
+            - --config=/etc/config/config.yaml
           env:
             - name: KUBELET_PORT
               $patch: delete

--- a/deploy/kubernetes/csi-ci/without-kubelet/pod-provisioner/statefulset.yaml
+++ b/deploy/kubernetes/csi-ci/without-kubelet/pod-provisioner/statefulset.yaml
@@ -15,5 +15,6 @@ spec:
             - --leader-election
             - --v=6
             - --provisioner=true
+            - --config=/etc/config/config.yaml
         - name: csi-provisioner
           $patch: delete

--- a/deploy/kubernetes/csi-ci/without-kubelet/pod/daemonset.yaml
+++ b/deploy/kubernetes/csi-ci/without-kubelet/pod/daemonset.yaml
@@ -14,6 +14,7 @@ spec:
             - --nodeid=$(NODE_NAME)
             - --v=6
             - --enable-manager=true
+            - --config=/etc/config/config.yaml
           env:
             - name: KUBELET_PORT
               $patch: delete

--- a/deploy/kubernetes/csi-ci/without-kubelet/pod/statefulset.yaml
+++ b/deploy/kubernetes/csi-ci/without-kubelet/pod/statefulset.yaml
@@ -14,3 +14,4 @@ spec:
             - --nodeid=$(NODE_NAME)
             - --leader-election
             - --v=6
+            - --config=/etc/config/config.yaml

--- a/deploy/kubernetes/release/statefulset.yaml
+++ b/deploy/kubernetes/release/statefulset.yaml
@@ -17,6 +17,8 @@ spec:
             - mountPath: /root/.juicefs
               mountPropagation: Bidirectional
               name: jfs-root-dir
+            - mountPath: /etc/config
+              name: juicefs-config
             - name: webhook-certs
               $patch: delete
       volumes:

--- a/deploy/kubernetes/webhook-with-certmanager/statefulset.yaml
+++ b/deploy/kubernetes/webhook-with-certmanager/statefulset.yaml
@@ -16,3 +16,4 @@ spec:
             - --v=5
             - --webhook=true
             - --validating-webhook=true
+            - --config=/etc/config/config.yaml

--- a/deploy/kubernetes/webhook/statefulset.yaml
+++ b/deploy/kubernetes/webhook/statefulset.yaml
@@ -16,3 +16,4 @@ spec:
             - --v=5
             - --webhook=true
             - --validating-webhook=true
+            - --config=/etc/config/config.yaml

--- a/deploy/webhook-with-certmanager.yaml
+++ b/deploy/webhook-with-certmanager.yaml
@@ -294,6 +294,27 @@ subjects:
   namespace: kube-system
 ---
 apiVersion: v1
+data:
+  config.yaml: |-
+    mountPodPatch:
+      - lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - +e
+              - umount ${MOUNT_POINT} -l; rmdir ${MOUNT_POINT}; exit 0
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
+  name: juicefs-csi-driver-config
+  namespace: kube-system
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:

--- a/deploy/webhook-with-certmanager.yaml
+++ b/deploy/webhook-with-certmanager.yaml
@@ -443,6 +443,7 @@ spec:
         - --v=5
         - --webhook=true
         - --validating-webhook=true
+        - --config=/etc/config/config.yaml
         env:
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -500,6 +501,8 @@ spec:
         - mountPath: /etc/webhook/certs
           name: webhook-certs
           readOnly: true
+        - mountPath: /etc/config
+          name: juicefs-config
       - args:
         - --csi-address=$(ADDRESS)
         - --timeout=60s
@@ -557,6 +560,10 @@ spec:
       - name: webhook-certs
         secret:
           secretName: juicefs-webhook-certs
+      - configMap:
+          defaultMode: 420
+          name: juicefs-csi-driver-config
+        name: juicefs-config
   volumeClaimTemplates: []
 ---
 apiVersion: cert-manager.io/v1

--- a/deploy/webhook.yaml
+++ b/deploy/webhook.yaml
@@ -307,6 +307,27 @@ subjects:
 ---
 apiVersion: v1
 data:
+  config.yaml: |-
+    mountPodPatch:
+      - lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - +e
+              - umount ${MOUNT_POINT} -l; rmdir ${MOUNT_POINT}; exit 0
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
+  name: juicefs-csi-driver-config
+  namespace: kube-system
+---
+apiVersion: v1
+data:
   ca.crt: CA_BUNDLE
   tls.crt: TLS_CRT
   tls.key: TLS_KEY

--- a/deploy/webhook.yaml
+++ b/deploy/webhook.yaml
@@ -471,6 +471,7 @@ spec:
         - --v=5
         - --webhook=true
         - --validating-webhook=true
+        - --config=/etc/config/config.yaml
         env:
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -528,6 +529,8 @@ spec:
         - mountPath: /etc/webhook/certs
           name: webhook-certs
           readOnly: true
+        - mountPath: /etc/config
+          name: juicefs-config
       - args:
         - --csi-address=$(ADDRESS)
         - --timeout=60s
@@ -585,6 +588,10 @@ spec:
       - name: webhook-certs
         secret:
           secretName: juicefs-webhook-certs
+      - configMap:
+          defaultMode: 420
+          name: juicefs-csi-driver-config
+        name: juicefs-config
   volumeClaimTemplates: []
 ---
 apiVersion: storage.k8s.io/v1

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -1,30 +1,49 @@
-reconcileTimeout: "5s"
+# Set this to `true` to arrange mount pod to node with node selector instead nodeName
+enableNodeSelector: true
 
-## supoort template parse
-# ${MOUNT_POINT}
-# ${VOLUME_ID}
-# ${SUB_PATH}
+# The `mountPodPatch` section defines the mount pod spec
+# Each item will respect the pvcSelector and be merged in order as the final configuration
+# if `pvcSelector` is not set, the configuration will be match any pvcs
+# command support template rendering, such as ${MOUNT_POINT}, ${SUB_PATH}, ${VOLUME_ID}
 mountPodPatch:
-  # selector is nil, mean all pod will be patched
-  - ceMountImage: juicedata/mount:ce-v1.1.2
-    eeMountImage: juicedata/mount:ee-5.0.16-c62bb16
-  # only matched selector PVC will patch livenessProbe
-  - pvcSelector:
-      matchLabels:
-        app: need-liveness-pvc
-    livenessProbe:
-      exec:
-        command:
-        - stat
-        - ${MOUNT_POINT}/${SUB_PATH}
-      failureThreshold: 3
-      initialDelaySeconds: 5
-      periodSeconds: 5
-      successThreshold: 1
-      timeoutSeconds: 1
-  # only matched selector PVC will use hostNetwork
-  - pvcSelector:
-      matchLabels:
-        app: need-hostnetwrok-pvc
-    hostNetwork: true # omit will extend csi node value
-    hostPID: false # omit will extend csi node value   
+  - lifecycle:
+      preStop:
+        exec:
+          command:
+          - sh
+          - -c
+          - +e
+          - umount -l ${MOUNT_POINT}; rmdir ${MOUNT_POINT}; exit 0
+
+  # Example configurations:
+  # - pvcSelector:
+  #     matchLabels:
+  #       disable-host-network: "true"
+  #   hostNetwork: false
+
+  # - pvcSelector:
+  #     matchLabels:
+  #       apply-labels: "true"
+  #   labels:
+  #     custom-labels: "asasasa"
+
+  # - pvcSelector:
+  #     matchLabels:
+  #       apply-resources: "true"
+  #   resources:
+  #     requests:
+  #       cpu: 100m
+  #       memory: 512Mi
+
+  # - pvcSelector:
+  #     matchLabels:
+  #       apply-liveness: "true"
+  #   livenessProbe:
+  #     exec:
+  #       command:
+  #       - stat
+  #       - ${MOUNT_POINT}/${SUB_PATH}
+  #     failureThreshold: 3
+  #     initialDelaySeconds: 10
+  #     periodSeconds: 5
+  #     successThreshold: 1

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -1,4 +1,4 @@
-# Set this to `true` to arrange mount pod to node with node selector instead nodeName
+# Set to true to schedule mount pod to node with via nodeSelector, rather than nodeName
 enableNodeSelector: true
 
 # The mountPodPatch section defines the mount pod spec

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -1,10 +1,10 @@
 # Set this to `true` to arrange mount pod to node with node selector instead nodeName
 enableNodeSelector: true
 
-# The `mountPodPatch` section defines the mount pod spec
-# Each item will respect the pvcSelector and be merged in order as the final configuration
-# if `pvcSelector` is not set, the configuration will be match any pvcs
-# command support template rendering, such as ${MOUNT_POINT}, ${SUB_PATH}, ${VOLUME_ID}
+# The mountPodPatch section defines the mount pod spec
+# Each item will be recursively merged into PVC settings according to its pvcSelector
+# If pvcSelector isn't set, the patch will be applied to all PVCs
+# Variable templates are supported, e.g.  ${MOUNT_POINT}, ${SUB_PATH}, ${VOLUME_ID}
 mountPodPatch:
   - lifecycle:
       preStop:

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -1,0 +1,30 @@
+reconcileTimeout: "5s"
+
+## supoort template parse
+# ${MOUNT_POINT}
+# ${VOLUME_ID}
+# ${SUB_PATH}
+mountPodPatch:
+  # selector is nil, mean all pod will be patched
+  - ceMountImage: juicedata/mount:ce-v1.1.2
+    eeMountImage: juicedata/mount:ee-5.0.16-c62bb16
+  # only matched selector PVC will patch livenessProbe
+  - pvcSelector:
+      matchLabels:
+        app: need-liveness-pvc
+    livenessProbe:
+      exec:
+        command:
+        - stat
+        - ${MOUNT_POINT}/${SUB_PATH}
+      failureThreshold: 3
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 1
+  # only matched selector PVC will use hostNetwork
+  - pvcSelector:
+      matchLabels:
+        app: need-hostnetwrok-pvc
+    hostNetwork: true # omit will extend csi node value
+    hostPID: false # omit will extend csi node value   

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,19 @@ module github.com/juicedata/juicefs-csi-driver
 require (
 	github.com/agiledragon/gomonkey/v2 v2.9.0
 	github.com/container-storage-interface/spec v1.5.0
+	github.com/fsnotify/fsnotify v1.5.1
 	github.com/gin-contrib/cors v1.4.0
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-logr/logr v1.2.0
 	github.com/golang/mock v1.6.0
+	github.com/kubernetes-csi/csi-test v1.1.1
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.11.0
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/spf13/cobra v1.1.3
+	github.com/stretchr/testify v1.8.3
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	google.golang.org/grpc v1.56.3
 	k8s.io/api v0.23.0
@@ -30,7 +34,6 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
-	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -44,6 +47,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -58,9 +62,11 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
@@ -86,13 +92,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
-)
-
-require (
-	github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 // indirect
-	github.com/kubernetes-csi/csi-test v1.1.1
-	github.com/prometheus/client_golang v1.11.1 // indirect
-	github.com/smartystreets/assertions v1.1.0 // indirect
 )
 
 go 1.19

--- a/go.sum
+++ b/go.sum
@@ -257,9 +257,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
 github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9xHw=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 h1:l5lAOZEym3oK3SQ2HBHWsJUfbNBiTXJDeW2QDxw9AQ0=
-github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -414,9 +413,8 @@ github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDf
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.5.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
+github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
-github.com/prometheus/client_golang v1.11.1 h1:+4eQaD7vAZ6DsfsxB15hbE0odUjGI5ARs9yskGu1v4s=
-github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -453,9 +451,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
-github.com/smartystreets/assertions v1.1.0 h1:MkTeG1DMwsrdH7QtLXy5W+fUxWq+vmb6cLmyJ7aRtF0=
-github.com/smartystreets/assertions v1.1.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -297,8 +297,11 @@ func LoadConfig(configPath string) error {
 	}
 
 	cfg := newCfg()
-	// FIXME: support env `JUICEFS_MOUNT_LABELS`
-	// FIXME: support env `ENABLE_NODE_SELECTOR` == `1`
+
+	// compatible with old version
+	if os.Getenv("ENABLE_NODE_SELECTOR") == "1" {
+		cfg.EnableNodeSelector = true
+	}
 
 	err = cfg.Unmarshal(data)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -167,15 +167,16 @@ type MountPodPatch struct {
 	CEMountImage string `json:"ceMountImage,omitempty"`
 	EEMountImage string `json:"eeMountImage,omitempty"`
 
-	Image          string            `json:"-"`
-	Labels         map[string]string `json:"labels,omitempty"`
-	Annotations    map[string]string `json:"annotations,omitempty"`
-	HostNetwork    *bool             `json:"hostNetwork,omitempty" `
-	HostPID        *bool             `json:"hostPID,omitempty" `
-	LivenessProbe  *corev1.Probe     `json:"livenessProbe,omitempty"`
-	ReadinessProbe *corev1.Probe     `json:"readinessProbe,omitempty"`
-	StartupProbe   *corev1.Probe     `json:"startupProbe,omitempty"`
-	Lifecycle      *corev1.Lifecycle `json:"lifecycle,omitempty"`
+	Image          string                       `json:"-"`
+	Labels         map[string]string            `json:"labels,omitempty"`
+	Annotations    map[string]string            `json:"annotations,omitempty"`
+	HostNetwork    *bool                        `json:"hostNetwork,omitempty" `
+	HostPID        *bool                        `json:"hostPID,omitempty" `
+	LivenessProbe  *corev1.Probe                `json:"livenessProbe,omitempty"`
+	ReadinessProbe *corev1.Probe                `json:"readinessProbe,omitempty"`
+	StartupProbe   *corev1.Probe                `json:"startupProbe,omitempty"`
+	Lifecycle      *corev1.Lifecycle            `json:"lifecycle,omitempty"`
+	Resources      *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 func (mpp *MountPodPatch) deepCopy() MountPodPatch {
@@ -215,6 +216,9 @@ func (mpp *MountPodPatch) merge(mp MountPodPatch) {
 	}
 	if mp.Annotations != nil {
 		mpp.Annotations = mp.Annotations
+	}
+	if mp.Resources != nil {
+		mpp.Resources = mp.Resources
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,217 @@
+/*
+ Copyright 2024 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func toPtr[T comparable](s T) *T {
+	return &s
+}
+
+func TestLoadConfig(t *testing.T) {
+	// Create a temporary config file
+	configPath := "/tmp/test-config.yaml"
+	defer os.Remove(configPath)
+
+	// Write test data to the config file
+	testData := []byte(`
+CEMountImage: "juicedata/mount:ce-test"
+EEMountImage: "juicedata/mount:ee-test"
+MountPodPatch:
+  - Labels:
+      app: juicefs-mount
+    Annotations:
+      juicefs.com/finalizer: juicefs.com/finalizer
+  - pvcSelector:
+      matchLabels:
+          app: juicefs-mount
+    Labels:
+      app: juicefs-mount
+    Annotations:
+      juicefs.com/finalizer: juicefs.com/finalizer
+`)
+	err := os.WriteFile(configPath, testData, 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test config file: %v", err)
+	}
+
+	// Call the LoadConfig function
+	err = LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+}
+
+func TestGenMountPodPatch(t *testing.T) {
+	testCases := []struct {
+		name          string
+		baseConfig    *Config
+		expectedPatch MountPodPatch
+		setting       JfsSetting
+	}{
+		{
+			name:       "nil selector",
+			baseConfig: &Config{},
+			setting: JfsSetting{
+				MountPath: "/var/lib/juicefs/volume",
+			},
+			expectedPatch: MountPodPatch{
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+			},
+		},
+		{
+			name: "pvc with matched selector",
+			setting: JfsSetting{
+				MountPath: "/var/lib/juicefs/volume",
+				PVC:       &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "juicefs-mount"}}},
+			},
+			baseConfig: &Config{
+				MountPodPatch: []MountPodPatch{
+					{
+						PVCSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "juicefs-mount"},
+						},
+						Labels:      map[string]string{"app": "juicefs-labels"},
+						Annotations: map[string]string{"app": "juicefs-annos"},
+					},
+				},
+			},
+			expectedPatch: MountPodPatch{
+				Labels:      map[string]string{"app": "juicefs-labels"},
+				Annotations: map[string]string{"app": "juicefs-annos"},
+			},
+		},
+		{
+			name: "pvc with unmatched selector",
+			setting: JfsSetting{
+				MountPath: "/var/lib/juicefs/volume",
+				PVC:       &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "juicefs-mount-not-match-any-config"}}},
+			},
+			baseConfig: &Config{
+				MountPodPatch: []MountPodPatch{
+					{
+						PVCSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "juicefs-mount"},
+						},
+						Labels:      map[string]string{"app": "juicefs-labels"},
+						Annotations: map[string]string{"app": "juicefs-annos"},
+					},
+				},
+			},
+			expectedPatch: MountPodPatch{
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+			},
+		},
+		{
+			name: "multi mount pod config",
+			setting: JfsSetting{
+				MountPath: "/var/lib/juicefs/volume",
+				PVC:       &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "juicefs-mount"}}},
+			},
+			baseConfig: &Config{
+				MountPodPatch: []MountPodPatch{
+					{
+						// apply base config
+						Labels:      map[string]string{"app": "apply-base-labels"},
+						Annotations: map[string]string{"app": "apply-base-annos"},
+					},
+					{
+						// apply config with matched selector
+						PVCSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "juicefs-mount"},
+						},
+						HostNetwork: toPtr(false),
+					},
+					{
+						// overwrite annos with matched selector
+						PVCSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "juicefs-mount"},
+						},
+						Annotations: map[string]string{"app": "overwrite-base-config"},
+					},
+					{
+						// overwrite labels with un matched selector
+						PVCSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "juicefs-mount-x"},
+						},
+						Labels: map[string]string{"app": "overwrite-base-config"},
+					},
+				},
+			},
+			expectedPatch: MountPodPatch{
+				HostNetwork: toPtr(false),
+				Labels:      map[string]string{"app": "apply-base-labels"},
+				Annotations: map[string]string{"app": "overwrite-base-config"},
+			},
+		},
+		{
+			name: "parse template",
+			setting: JfsSetting{
+				MountPath: "/jfs/parse_test",
+				SubPath:   "sub_path",
+				VolumeId:  "dd",
+				PVC:       &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "juicefs-mount"}}},
+			},
+			baseConfig: &Config{
+				MountPodPatch: []MountPodPatch{
+					{
+						Lifecycle: &corev1.Lifecycle{
+							PreStop: &corev1.Handler{
+								Exec: &corev1.ExecAction{Command: []string{"sh", "-c", "+e", "umount -l ${MOUNT_POINT}; rmdir ${MOUNT_POINT}; exit 0"}},
+							},
+						},
+						LivenessProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								Exec: &corev1.ExecAction{Command: []string{"sh", "-c", "stat ${MOUNT_POINT}/${SUB_PATH}"}},
+							},
+						},
+					},
+				},
+			},
+			expectedPatch: MountPodPatch{
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+				Lifecycle: &corev1.Lifecycle{
+					PreStop: &corev1.Handler{
+						Exec: &corev1.ExecAction{Command: []string{"sh", "-c", "+e", "umount -l /jfs/parse_test; rmdir /jfs/parse_test; exit 0"}},
+					},
+				},
+				LivenessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						Exec: &corev1.ExecAction{Command: []string{"sh", "-c", "stat /jfs/parse_test/sub_path"}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualPatch := tc.baseConfig.GenMountPodPatch(tc.setting)
+			assert.Equal(t, tc.expectedPatch, actualPatch)
+		})
+	}
+}

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -66,13 +66,9 @@ type JfsSetting struct {
 	Configs       map[string]string `json:"configs_map,omitempty"`
 
 	// put in volCtx
-	MountPodLabels      map[string]string `json:"mount_pod_labels"`
-	MountPodAnnotations map[string]string `json:"mount_pod_annotations"`
-	DeletedDelay        string            `json:"deleted_delay"`
-	CleanCache          bool              `json:"clean_cache"`
-	HostPath            []string          `json:"host_path"`
-	ServiceAccountName  string
-	Resources           corev1.ResourceRequirements
+	DeletedDelay string   `json:"deleted_delay"`
+	CleanCache   bool     `json:"clean_cache"`
+	HostPath     []string `json:"host_path"`
 
 	// mount
 	VolumeId   string   // volumeHandle of PV
@@ -84,7 +80,10 @@ type JfsSetting struct {
 	SubPath    string   // subPath which is to be created or deleted
 	SecretName string   // secret with JuiceFS volume credentials
 
-	Attr PodAttr
+	Attr *PodAttr
+
+	PV  *corev1.PersistentVolume      `json:"-"`
+	PVC *corev1.PersistentVolumeClaim `json:"-"`
 }
 
 type PodAttr struct {
@@ -92,6 +91,16 @@ type PodAttr struct {
 	MountPointPath       string
 	JFSConfigPath        string
 	JFSMountPriorityName string
+	ServiceAccountName   string
+
+	Resources corev1.ResourceRequirements
+
+	Labels         map[string]string `json:"labels,omitempty"`
+	Annotations    map[string]string `json:"annotations,omitempty"`
+	LivenessProbe  *corev1.Probe     `json:"livenessProbe,omitempty"`
+	ReadinessProbe *corev1.Probe     `json:"readinessProbe,omitempty"`
+	StartupProbe   *corev1.Probe     `json:"startupProbe,omitempty"`
+	Lifecycle      *corev1.Lifecycle `json:"lifecycle,omitempty"`
 
 	// inherit from csi
 	Image            string
@@ -128,7 +137,7 @@ type CacheInlineVolume struct {
 	Path string
 }
 
-func ParseSetting(secrets, volCtx map[string]string, options []string, usePod bool) (*JfsSetting, error) {
+func ParseSetting(secrets, volCtx map[string]string, options []string, usePod bool, pv *corev1.PersistentVolume, pvc *corev1.PersistentVolumeClaim) (*JfsSetting, error) {
 	jfsSetting := JfsSetting{
 		Options: []string{},
 	}
@@ -157,6 +166,8 @@ func ParseSetting(secrets, volCtx map[string]string, options []string, usePod bo
 	jfsSetting.ClientConfPath = DefaultClientConfPath
 	jfsSetting.CacheDirs = []string{}
 	jfsSetting.CachePVCs = []CachePVC{}
+	jfsSetting.PV = pv
+	jfsSetting.PVC = pvc
 
 	// parse pvc of cache
 	dirs := []string{}
@@ -297,69 +308,12 @@ func ParseSetting(secrets, volCtx map[string]string, options []string, usePod bo
 		jfsSetting.Envs = env
 	}
 
-	labels := make(map[string]string)
-	if MountLabels != "" {
-		klog.V(6).Infof("Get MountLabels from csi env: %v", MountLabels)
-		if err := parseYamlOrJson(MountLabels, &labels); err != nil {
-			return nil, err
-		}
-	}
-
-	jfsSetting.ServiceAccountName = CSIPod.Spec.ServiceAccountName
-
-	var preemptionPolicy = CSIPod.Spec.PreemptionPolicy
-	if JFSMountPreemptionPolicy != "" {
-		policy := corev1.PreemptionPolicy(JFSMountPreemptionPolicy)
-		preemptionPolicy = &policy
-	}
-	// inherit attr from csi
-	jfsSetting.Attr = PodAttr{
-		Namespace:            Namespace,
-		MountPointPath:       MountPointPath,
-		JFSConfigPath:        JFSConfigPath,
-		JFSMountPriorityName: JFSMountPriorityName,
-		HostNetwork:          CSIPod.Spec.HostNetwork,
-		HostAliases:          CSIPod.Spec.HostAliases,
-		HostPID:              CSIPod.Spec.HostPID,
-		HostIPC:              CSIPod.Spec.HostIPC,
-		DNSConfig:            CSIPod.Spec.DNSConfig,
-		DNSPolicy:            CSIPod.Spec.DNSPolicy,
-		ImagePullSecrets:     CSIPod.Spec.ImagePullSecrets,
-		PreemptionPolicy:     preemptionPolicy,
-		Tolerations:          CSIPod.Spec.Tolerations,
-	}
-	if jfsSetting.IsCe {
-		jfsSetting.Attr.Image = CEMountImage
-	} else {
-		jfsSetting.Attr.Image = EEMountImage
-	}
-
-	if volCtx != nil && volCtx[mountPodImageKey] != "" {
-		jfsSetting.Attr.Image = volCtx[mountPodImageKey]
-	}
-
-	// set default resource limit & request
-	jfsSetting.Resources = getDefaultResource()
-
 	if volCtx != nil {
 		// subPath
 		if volCtx["subPath"] != "" {
 			jfsSetting.SubPath = volCtx["subPath"]
 		}
 
-		cpuLimit := volCtx[MountPodCpuLimitKey]
-		memoryLimit := volCtx[MountPodMemLimitKey]
-		cpuRequest := volCtx[MountPodCpuRequestKey]
-		memoryRequest := volCtx[MountPodMemRequestKey]
-		jfsSetting.Resources, err = ParsePodResources(cpuLimit, memoryLimit, cpuRequest, memoryRequest)
-		if err != nil {
-			klog.Errorf("Parse resource error: %v", err)
-			return nil, err
-		}
-
-		if volCtx[mountPodServiceAccount] != "" {
-			jfsSetting.ServiceAccountName = volCtx[mountPodServiceAccount]
-		}
 		if volCtx[cleanCache] == "true" {
 			jfsSetting.CleanCache = true
 		}
@@ -369,25 +323,6 @@ func ParseSetting(secrets, volCtx map[string]string, options []string, usePod bo
 				return nil, fmt.Errorf("can't parse delay time %s", delay)
 			}
 			jfsSetting.DeletedDelay = delay
-		}
-
-		labelString := volCtx[mountPodLabelKey]
-		annotationSting := volCtx[mountPodAnnotationKey]
-		ctxLabel := make(map[string]string)
-		if labelString != "" {
-			if err := parseYamlOrJson(labelString, &ctxLabel); err != nil {
-				return nil, err
-			}
-		}
-		for k, v := range ctxLabel {
-			labels[k] = v
-		}
-		if annotationSting != "" {
-			annos := make(map[string]string)
-			if err := parseYamlOrJson(annotationSting, &annos); err != nil {
-				return nil, err
-			}
-			jfsSetting.MountPodAnnotations = annos
 		}
 
 		var hostPaths []string
@@ -401,10 +336,108 @@ func ParseSetting(secrets, volCtx map[string]string, options []string, usePod bo
 			jfsSetting.HostPath = hostPaths
 		}
 	}
-	if len(labels) != 0 {
-		jfsSetting.MountPodLabels = labels
+
+	attr, err := GenPodAttrWithCfg(jfsSetting, volCtx)
+	if err != nil {
+		return nil, fmt.Errorf("GenPodAttrWithCfg error: %v", err)
 	}
+	jfsSetting.Attr = attr
 	return &jfsSetting, nil
+}
+
+func GenPodAttrWithCfg(setting JfsSetting, volCtx map[string]string) (*PodAttr, error) {
+	var err error
+	var attr *PodAttr
+	if setting.Attr != nil {
+		attr = setting.Attr
+	} else {
+		attr = &PodAttr{
+			Namespace:            Namespace,
+			MountPointPath:       MountPointPath,
+			JFSConfigPath:        JFSConfigPath,
+			JFSMountPriorityName: JFSMountPriorityName,
+			HostNetwork:          CSIPod.Spec.HostNetwork,
+			HostAliases:          CSIPod.Spec.HostAliases,
+			HostPID:              CSIPod.Spec.HostPID,
+			HostIPC:              CSIPod.Spec.HostIPC,
+			DNSConfig:            CSIPod.Spec.DNSConfig,
+			DNSPolicy:            CSIPod.Spec.DNSPolicy,
+			ImagePullSecrets:     CSIPod.Spec.ImagePullSecrets,
+			Tolerations:          CSIPod.Spec.Tolerations,
+			PreemptionPolicy:     CSIPod.Spec.PreemptionPolicy,
+			ServiceAccountName:   CSIPod.Spec.ServiceAccountName,
+			Resources:            getDefaultResource(),
+			Labels:               make(map[string]string),
+			Annotations:          make(map[string]string),
+		}
+	}
+
+	if setting.IsCe {
+		attr.Image = DefaultCEMountImage
+	} else {
+		attr.Image = DefaultEEMountImage
+	}
+
+	if JFSMountPreemptionPolicy != "" {
+		policy := corev1.PreemptionPolicy(JFSMountPreemptionPolicy)
+		attr.PreemptionPolicy = &policy
+	}
+
+	if volCtx != nil {
+		if v, ok := volCtx[mountPodImageKey]; ok && v != "" {
+			attr.Image = v
+		}
+		if v, ok := volCtx[mountPodServiceAccount]; ok && v != "" {
+			attr.ServiceAccountName = v
+		}
+		cpuLimit := volCtx[MountPodCpuLimitKey]
+		memoryLimit := volCtx[MountPodMemLimitKey]
+		cpuRequest := volCtx[MountPodCpuRequestKey]
+		memoryRequest := volCtx[MountPodMemRequestKey]
+		attr.Resources, err = ParsePodResources(cpuLimit, memoryLimit, cpuRequest, memoryRequest)
+		if err != nil {
+			klog.Errorf("Parse resource error: %v", err)
+			return nil, err
+		}
+		if v, ok := volCtx[mountPodLabelKey]; ok && v != "" {
+			ctxLabel := make(map[string]string)
+			if err := parseYamlOrJson(v, &ctxLabel); err != nil {
+				return nil, err
+			}
+			for k, v := range ctxLabel {
+				attr.Labels[k] = v
+			}
+		}
+		if v, ok := volCtx[mountPodAnnotationKey]; ok && v != "" {
+			ctxAnno := make(map[string]string)
+			if err := parseYamlOrJson(v, &ctxAnno); err != nil {
+				return nil, err
+			}
+			for k, v := range ctxAnno {
+				attr.Annotations[k] = v
+			}
+		}
+	}
+
+	// overwrite by mountpod patch
+	patch := GlobalConfig.GenMountPodPatch(setting)
+	if patch.Image != "" {
+		attr.Image = patch.Image
+	}
+	if patch.HostPID != nil {
+		attr.HostPID = *patch.HostPID
+	}
+	for k, v := range patch.Labels {
+		attr.Labels[k] = v
+	}
+	for k, v := range patch.Annotations {
+		attr.Annotations[k] = v
+	}
+	attr.Lifecycle = patch.Lifecycle
+	attr.LivenessProbe = patch.LivenessProbe
+	attr.ReadinessProbe = patch.ReadinessProbe
+	attr.StartupProbe = patch.StartupProbe
+	return attr, nil
 }
 
 func ParseAppInfo(volCtx map[string]string) (*AppInfo, error) {

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -434,6 +434,9 @@ func GenPodAttrWithCfg(setting *JfsSetting, volCtx map[string]string) error {
 	for k, v := range patch.Annotations {
 		attr.Annotations[k] = v
 	}
+	if patch.Resources != nil {
+		attr.Resources = *patch.Resources
+	}
 	attr.Lifecycle = patch.Lifecycle
 	attr.LivenessProbe = patch.LivenessProbe
 	attr.ReadinessProbe = patch.ReadinessProbe

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -368,12 +368,11 @@ func GenPodAttrWithCfg(setting *JfsSetting, volCtx map[string]string) error {
 			Labels:               make(map[string]string),
 			Annotations:          make(map[string]string),
 		}
-	}
-
-	if setting.IsCe {
-		attr.Image = DefaultCEMountImage
-	} else {
-		attr.Image = DefaultEEMountImage
+		if setting.IsCe {
+			attr.Image = DefaultCEMountImage
+		} else {
+			attr.Image = DefaultEEMountImage
+		}
 	}
 
 	if JFSMountPreemptionPolicy != "" {

--- a/pkg/config/setting_test.go
+++ b/pkg/config/setting_test.go
@@ -59,11 +59,10 @@ func TestParseSecret(t *testing.T) {
 	}
 
 	type args struct {
-		secrets     map[string]string
-		volCtx      map[string]string
-		options     []string
-		usePod      bool
-		MountLabels string
+		secrets map[string]string
+		volCtx  map[string]string
+		options []string
+		usePod  bool
 	}
 	tests := []struct {
 		name    string
@@ -98,10 +97,10 @@ func TestParseSecret(t *testing.T) {
 				Envs:      s,
 				Configs:   map[string]string{},
 				Options:   []string{},
-				Resources: defaultResource,
-				Attr: PodAttr{
+				Attr: &PodAttr{
+					Resources:            defaultResource,
 					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
+					Image:                DefaultEEMountImage,
 					MountPointPath:       MountPointPath,
 					JFSMountPriorityName: JFSMountPriorityName,
 				},
@@ -129,10 +128,10 @@ func TestParseSecret(t *testing.T) {
 				UsePod:    true,
 				CacheDirs: []string{"/var/jfsCache"},
 				CachePVCs: []CachePVC{},
-				Resources: defaultResource,
-				Attr: PodAttr{
+				Attr: &PodAttr{
+					Resources:            defaultResource,
 					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
+					Image:                DefaultEEMountImage,
 					MountPointPath:       MountPointPath,
 					JFSMountPriorityName: JFSMountPriorityName,
 				},
@@ -152,10 +151,10 @@ func TestParseSecret(t *testing.T) {
 				Options:   []string{},
 				CacheDirs: []string{"/var/jfsCache"},
 				CachePVCs: []CachePVC{},
-				Resources: defaultResource,
-				Attr: PodAttr{
+				Attr: &PodAttr{
+					Resources:            defaultResource,
 					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
+					Image:                DefaultEEMountImage,
 					MountPointPath:       MountPointPath,
 					JFSMountPriorityName: JFSMountPriorityName,
 				},
@@ -179,16 +178,16 @@ func TestParseSecret(t *testing.T) {
 				Options:   []string{},
 				CacheDirs: []string{"/var/jfsCache"},
 				CachePVCs: []CachePVC{},
-				Resources: corev1.ResourceRequirements{
-					Limits: map[corev1.ResourceName]resource.Quantity{
-						corev1.ResourceCPU:    resource.MustParse("1"),
-						corev1.ResourceMemory: resource.MustParse(DefaultMountPodMemLimit),
+				Attr: &PodAttr{
+					Resources: corev1.ResourceRequirements{
+						Limits: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse(DefaultMountPodMemLimit),
+						},
+						Requests: defaultResource.Requests,
 					},
-					Requests: defaultResource.Requests,
-				},
-				Attr: PodAttr{
 					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
+					Image:                DefaultEEMountImage,
 					MountPointPath:       MountPointPath,
 					JFSMountPriorityName: JFSMountPriorityName,
 				},
@@ -212,16 +211,16 @@ func TestParseSecret(t *testing.T) {
 				Options:   []string{},
 				CacheDirs: []string{"/var/jfsCache"},
 				CachePVCs: []CachePVC{},
-				Resources: corev1.ResourceRequirements{
-					Limits: map[corev1.ResourceName]resource.Quantity{
-						corev1.ResourceMemory: resource.MustParse("1G"),
-						corev1.ResourceCPU:    resource.MustParse(DefaultMountPodCpuLimit),
+				Attr: &PodAttr{
+					Resources: corev1.ResourceRequirements{
+						Limits: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceMemory: resource.MustParse("1G"),
+							corev1.ResourceCPU:    resource.MustParse(DefaultMountPodCpuLimit),
+						},
+						Requests: defaultResource.Requests,
 					},
-					Requests: defaultResource.Requests,
-				},
-				Attr: PodAttr{
 					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
+					Image:                DefaultEEMountImage,
 					MountPointPath:       MountPointPath,
 					JFSMountPriorityName: JFSMountPriorityName,
 				},
@@ -245,16 +244,16 @@ func TestParseSecret(t *testing.T) {
 				Options:   []string{},
 				CacheDirs: []string{"/var/jfsCache"},
 				CachePVCs: []CachePVC{},
-				Resources: corev1.ResourceRequirements{
-					Requests: map[corev1.ResourceName]resource.Quantity{
-						corev1.ResourceMemory: resource.MustParse("1G"),
-						corev1.ResourceCPU:    resource.MustParse(DefaultMountPodCpuRequest),
+				Attr: &PodAttr{
+					Resources: corev1.ResourceRequirements{
+						Requests: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceMemory: resource.MustParse("1G"),
+							corev1.ResourceCPU:    resource.MustParse(DefaultMountPodCpuRequest),
+						},
+						Limits: defaultResource.Limits,
 					},
-					Limits: defaultResource.Limits,
-				},
-				Attr: PodAttr{
 					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
+					Image:                DefaultEEMountImage,
 					MountPointPath:       MountPointPath,
 					JFSMountPriorityName: JFSMountPriorityName,
 				},
@@ -275,16 +274,16 @@ func TestParseSecret(t *testing.T) {
 				Options:   []string{},
 				CacheDirs: []string{"/var/jfsCache"},
 				CachePVCs: []CachePVC{},
-				Resources: corev1.ResourceRequirements{
-					Requests: map[corev1.ResourceName]resource.Quantity{
-						corev1.ResourceCPU:    resource.MustParse("1"),
-						corev1.ResourceMemory: resource.MustParse(DefaultMountPodMemRequest),
+				Attr: &PodAttr{
+					Resources: corev1.ResourceRequirements{
+						Requests: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse(DefaultMountPodMemRequest),
+						},
+						Limits: defaultResource.Limits,
 					},
-					Limits: defaultResource.Limits,
-				},
-				Attr: PodAttr{
 					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
+					Image:                DefaultEEMountImage,
 					MountPointPath:       MountPointPath,
 					JFSMountPriorityName: JFSMountPriorityName,
 				},
@@ -298,18 +297,18 @@ func TestParseSecret(t *testing.T) {
 				volCtx:  map[string]string{mountPodLabelKey: "a: b"},
 			},
 			want: &JfsSetting{
-				Name:           "test",
-				Source:         "test",
-				MountPodLabels: map[string]string{"a": "b"},
-				Configs:        map[string]string{},
-				Envs:           map[string]string{},
-				Options:        []string{},
-				CacheDirs:      []string{"/var/jfsCache"},
-				CachePVCs:      []CachePVC{},
-				Resources:      defaultResource,
-				Attr: PodAttr{
+				Name:      "test",
+				Source:    "test",
+				Configs:   map[string]string{},
+				Envs:      map[string]string{},
+				Options:   []string{},
+				CacheDirs: []string{"/var/jfsCache"},
+				CachePVCs: []CachePVC{},
+				Attr: &PodAttr{
+					Labels:               map[string]string{"a": "b"},
+					Resources:            defaultResource,
 					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
+					Image:                DefaultEEMountImage,
 					MountPointPath:       MountPointPath,
 					JFSMountPriorityName: JFSMountPriorityName,
 				},
@@ -331,18 +330,18 @@ func TestParseSecret(t *testing.T) {
 				volCtx:  map[string]string{mountPodLabelKey: "{\"a\": \"b\"}"},
 			},
 			want: &JfsSetting{
-				Name:           "test",
-				Source:         "test",
-				MountPodLabels: map[string]string{"a": "b"},
-				Configs:        map[string]string{},
-				Envs:           map[string]string{},
-				Options:        []string{},
-				CacheDirs:      []string{"/var/jfsCache"},
-				CachePVCs:      []CachePVC{},
-				Resources:      defaultResource,
-				Attr: PodAttr{
+				Name:      "test",
+				Source:    "test",
+				Configs:   map[string]string{},
+				Envs:      map[string]string{},
+				Options:   []string{},
+				CacheDirs: []string{"/var/jfsCache"},
+				CachePVCs: []CachePVC{},
+				Attr: &PodAttr{
+					Resources:            defaultResource,
+					Labels:               map[string]string{"a": "b"},
 					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
+					Image:                DefaultEEMountImage,
 					MountPointPath:       MountPointPath,
 					JFSMountPriorityName: JFSMountPriorityName,
 				},
@@ -356,18 +355,18 @@ func TestParseSecret(t *testing.T) {
 				volCtx:  map[string]string{mountPodAnnotationKey: "a: b"},
 			},
 			want: &JfsSetting{
-				Name:                "test",
-				Source:              "test",
-				MountPodAnnotations: map[string]string{"a": "b"},
-				Configs:             map[string]string{},
-				Envs:                map[string]string{},
-				Options:             []string{},
-				CacheDirs:           []string{"/var/jfsCache"},
-				CachePVCs:           []CachePVC{},
-				Resources:           defaultResource,
-				Attr: PodAttr{
+				Name:      "test",
+				Source:    "test",
+				Configs:   map[string]string{},
+				Envs:      map[string]string{},
+				Options:   []string{},
+				CacheDirs: []string{"/var/jfsCache"},
+				CachePVCs: []CachePVC{},
+				Attr: &PodAttr{
+					Annotations:          map[string]string{"a": "b"},
+					Resources:            defaultResource,
 					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
+					Image:                DefaultEEMountImage,
 					MountPointPath:       MountPointPath,
 					JFSMountPriorityName: JFSMountPriorityName,
 				},
@@ -391,20 +390,20 @@ func TestParseSecret(t *testing.T) {
 				usePod:  true,
 			},
 			want: &JfsSetting{
-				UsePod:             true,
-				Name:               "test",
-				Source:             "test",
-				Storage:            "s3",
-				ServiceAccountName: "test",
-				Configs:            map[string]string{},
-				Envs:               map[string]string{},
-				Options:            []string{},
-				CacheDirs:          []string{"/var/jfsCache"},
-				CachePVCs:          []CachePVC{},
-				Resources:          defaultResource,
-				Attr: PodAttr{
+				UsePod:    true,
+				Name:      "test",
+				Source:    "test",
+				Storage:   "s3",
+				Configs:   map[string]string{},
+				Envs:      map[string]string{},
+				Options:   []string{},
+				CacheDirs: []string{"/var/jfsCache"},
+				CachePVCs: []CachePVC{},
+				Attr: &PodAttr{
+					Resources:            defaultResource,
+					ServiceAccountName:   "test",
 					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
+					Image:                DefaultEEMountImage,
 					MountPointPath:       MountPointPath,
 					JFSMountPriorityName: JFSMountPriorityName,
 				},
@@ -421,10 +420,10 @@ func TestParseSecret(t *testing.T) {
 				Envs:      map[string]string{},
 				Options:   []string{},
 				CacheDirs: []string{"/var/jfsCache"},
-				Resources: defaultResource,
-				Attr: PodAttr{
+				Attr: &PodAttr{
+					Resources:            defaultResource,
 					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
+					Image:                DefaultEEMountImage,
 					MountPointPath:       MountPointPath,
 					JFSMountPriorityName: JFSMountPriorityName,
 				},
@@ -435,40 +434,6 @@ func TestParseSecret(t *testing.T) {
 		{
 			name:    "test-config-error",
 			args:    args{secrets: map[string]string{"configs": "-", "name": "test"}},
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name: "test-mountLabel",
-			args: args{
-				secrets:     map[string]string{"name": "test"},
-				MountLabels: "{a: b, c: d, e: f}",
-			},
-			want: &JfsSetting{
-				Name:           "test",
-				Source:         "test",
-				MountPodLabels: map[string]string{"a": "b", "c": "d", "e": "f"},
-				Configs:        map[string]string{},
-				Envs:           map[string]string{},
-				Options:        []string{},
-				CacheDirs:      []string{"/var/jfsCache"},
-				CachePVCs:      []CachePVC{},
-				Resources:      defaultResource,
-				Attr: PodAttr{
-					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
-					MountPointPath:       MountPointPath,
-					JFSMountPriorityName: JFSMountPriorityName,
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "test-mountLabel-error",
-			args: args{
-				secrets:     map[string]string{"name": "test"},
-				MountLabels: "-",
-			},
 			want:    nil,
 			wantErr: true,
 		},
@@ -500,11 +465,11 @@ func TestParseSecret(t *testing.T) {
 				Options:       []string{},
 				FormatOptions: "xxx",
 				CacheDirs:     []string{"/var/jfsCache"},
-				Resources:     defaultResource,
 				CachePVCs:     []CachePVC{},
-				Attr: PodAttr{
+				Attr: &PodAttr{
+					Resources:            defaultResource,
 					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
+					Image:                DefaultEEMountImage,
 					MountPointPath:       MountPointPath,
 					JFSMountPriorityName: JFSMountPriorityName,
 				},
@@ -535,10 +500,10 @@ func TestParseSecret(t *testing.T) {
 				Options:   []string{"cache-dir=/var/jfsCache-0:/var/jfsCache-1:/abc"},
 				Envs:      map[string]string{},
 				Configs:   map[string]string{},
-				Resources: defaultResource,
-				Attr: PodAttr{
+				Attr: &PodAttr{
+					Resources:            defaultResource,
 					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
+					Image:                DefaultEEMountImage,
 					MountPointPath:       MountPointPath,
 					JFSMountPriorityName: JFSMountPriorityName,
 				},
@@ -566,10 +531,10 @@ func TestParseSecret(t *testing.T) {
 				Options:   []string{"cache-dir=/var/jfsCache-0"},
 				Envs:      map[string]string{},
 				Configs:   map[string]string{},
-				Resources: defaultResource,
-				Attr: PodAttr{
+				Attr: &PodAttr{
+					Resources:            defaultResource,
 					JFSConfigPath:        JFSConfigPath,
-					Image:                EEMountImage,
+					Image:                DefaultEEMountImage,
 					MountPointPath:       MountPointPath,
 					JFSMountPriorityName: JFSMountPriorityName,
 				},
@@ -589,8 +554,8 @@ func TestParseSecret(t *testing.T) {
 				Envs:      map[string]string{},
 				Options:   []string{},
 				CacheDirs: []string{"/var/jfsCache"},
-				Resources: defaultResource,
-				Attr: PodAttr{
+				Attr: &PodAttr{
+					Resources:            defaultResource,
 					JFSConfigPath:        JFSConfigPath,
 					Image:                "abc",
 					MountPointPath:       MountPointPath,
@@ -613,8 +578,8 @@ func TestParseSecret(t *testing.T) {
 				Envs:      map[string]string{},
 				Options:   []string{},
 				CacheDirs: []string{"/var/jfsCache"},
-				Resources: defaultResource,
-				Attr: PodAttr{
+				Attr: &PodAttr{
+					Resources:            defaultResource,
 					JFSConfigPath:        JFSConfigPath,
 					Image:                "juicedata/mount:ee-nightly",
 					MountPointPath:       MountPointPath,
@@ -628,11 +593,8 @@ func TestParseSecret(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			MountLabels = ""
-			if tt.args.MountLabels != "" {
-				MountLabels = tt.args.MountLabels
-			}
-			got, err := ParseSetting(tt.args.secrets, tt.args.volCtx, tt.args.options, tt.args.usePod)
+			GlobalConfig.Reset()
+			got, err := ParseSetting(tt.args.secrets, tt.args.volCtx, tt.args.options, tt.args.usePod, nil, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseSecret() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -648,7 +610,7 @@ func TestParseSecret(t *testing.T) {
 				return
 			}
 			if string(gotStr) != string(wantStr) {
-				t.Errorf("ParseSecret() got = \n%v\n, want \n%v\n", got, tt.want)
+				t.Errorf("ParseSecret() got = \n%s\n, want \n%s\n", gotStr, wantStr)
 			}
 		})
 	}

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -281,7 +281,7 @@ func TestDeleteVolume(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
 				mockJuicefs := mocks.NewMockInterface(mockCtl)
-				mockJuicefs.EXPECT().JfsDeleteVol(context.TODO(), volumeId, volumeId, secret, nil, nil).Return(nil)
+				mockJuicefs.EXPECT().JfsDeleteVol(context.Background(), volumeId, volumeId, secret, nil, nil).Return(nil)
 
 				juicefsDriver := controllerService{
 					juicefs: mockJuicefs,
@@ -349,7 +349,7 @@ func TestDeleteVolume(t *testing.T) {
 				defer mockCtl.Finish()
 
 				mockJuicefs := mocks.NewMockInterface(mockCtl)
-				mockJuicefs.EXPECT().JfsDeleteVol(context.TODO(), volumeId, volumeId, secret, nil, nil).Return(errors.New("test"))
+				mockJuicefs.EXPECT().JfsDeleteVol(context.Background(), volumeId, volumeId, secret, nil, nil).Return(errors.New("test"))
 
 				juicefsDriver := controllerService{
 					juicefs:  mockJuicefs,

--- a/pkg/juicefs/juicefs_test.go
+++ b/pkg/juicefs/juicefs_test.go
@@ -574,7 +574,7 @@ func Test_juicefs_AuthFs(t *testing.T) {
 				},
 				K8sClient: nil,
 			}
-			setting, err := config.ParseSetting(nil, map[string]string{}, []string{}, true)
+			setting, err := config.ParseSetting(nil, map[string]string{}, []string{}, true, nil, nil)
 			So(err, ShouldBeNil)
 			_, err = jfs.AuthFs(context.TODO(), secrets, setting, false)
 			So(err, ShouldBeNil)
@@ -620,7 +620,7 @@ func Test_juicefs_AuthFs(t *testing.T) {
 				},
 				K8sClient: nil,
 			}
-			setting, err := config.ParseSetting(nil, map[string]string{}, []string{}, true)
+			setting, err := config.ParseSetting(nil, map[string]string{}, []string{}, true, nil, nil)
 			So(err, ShouldBeNil)
 			_, err = jfs.AuthFs(context.TODO(), secrets, setting, false)
 			So(err, ShouldNotBeNil)
@@ -670,7 +670,9 @@ func Test_juicefs_MountFs(t *testing.T) {
 			So(e, ShouldBeNil)
 		})
 		Convey("not MountPoint err", func() {
-			jfsSetting := &config.JfsSetting{}
+			jfsSetting := &config.JfsSetting{
+				Attr: &config.PodAttr{},
+			}
 			patch1 := ApplyFunc(mount.PathExists, func(path string) (bool, error) {
 				return true, errors.New("test")
 			})
@@ -937,7 +939,7 @@ func Test_juicefs_ceFormat(t *testing.T) {
 				},
 				K8sClient: nil,
 			}
-			setting, err := config.ParseSetting(secret, map[string]string{}, []string{}, true)
+			setting, err := config.ParseSetting(secret, map[string]string{}, []string{}, true, nil, nil)
 			So(err, ShouldBeNil)
 			_, err = jfs.ceFormat(context.TODO(), secret, true, setting)
 			So(err, ShouldBeNil)
@@ -981,7 +983,7 @@ func Test_juicefs_ceFormat(t *testing.T) {
 				},
 				K8sClient: nil,
 			}
-			setting, err := config.ParseSetting(secret, map[string]string{}, []string{}, true)
+			setting, err := config.ParseSetting(secret, map[string]string{}, []string{}, true, nil, nil)
 			So(err, ShouldBeNil)
 			_, err = jfs.ceFormat(context.TODO(), secret, true, setting)
 			So(err, ShouldNotBeNil)

--- a/pkg/juicefs/mocks/mock_jfs.go
+++ b/pkg/juicefs/mocks/mock_jfs.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	config "github.com/juicedata/juicefs-csi-driver/pkg/config"
 )
 
 // MockJfs is a mock of Jfs interface.
@@ -75,4 +76,18 @@ func (m *MockJfs) GetBasePath() string {
 func (mr *MockJfsMockRecorder) GetBasePath() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBasePath", reflect.TypeOf((*MockJfs)(nil).GetBasePath))
+}
+
+// GetSetting mocks base method.
+func (m *MockJfs) GetSetting() *config.JfsSetting {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSetting")
+	ret0, _ := ret[0].(*config.JfsSetting)
+	return ret0
+}
+
+// GetSetting indicates an expected call of GetSetting.
+func (mr *MockJfsMockRecorder) GetSetting() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSetting", reflect.TypeOf((*MockJfs)(nil).GetSetting))
 }

--- a/pkg/juicefs/mount/builder/common.go
+++ b/pkg/juicefs/mount/builder/common.go
@@ -76,7 +76,9 @@ func (r *BaseBuilder) genPodTemplate(baseCnGen func() corev1.Container) *corev1.
 // genCommonJuicePod generates a pod with common settings
 func (r *BaseBuilder) genCommonJuicePod(cnGen func() corev1.Container) *corev1.Pod {
 	// gen again to update the mount pod spec
-	r.jfsSetting.Attr, _ = config.GenPodAttrWithCfg(*r.jfsSetting, nil)
+	if err := config.GenPodAttrWithCfg(r.jfsSetting, nil); err != nil {
+		klog.Warningf("genCommonJuicePod gen pod attr failed, mount pod may not be the expected config  %+v", err)
+	}
 	pod := r.genPodTemplate(cnGen)
 	// labels & annotations
 	pod.ObjectMeta.Labels, pod.ObjectMeta.Annotations = r._genMetadata()

--- a/pkg/juicefs/mount/pod_mount_test.go
+++ b/pkg/juicefs/mount/pod_mount_test.go
@@ -812,7 +812,7 @@ func TestGenHashOfSetting(t *testing.T) {
 					Name: "test",
 				},
 			},
-			want:    "60fff489f3675b6761479ecbf61850b2489c73f9a540428e7ba16c19422fc07",
+			want:    "e11ef7a140d2e8bac9c75b1c44dcba22954402edc5015a8eae931d389b82db9",
 			wantErr: false,
 		},
 	}

--- a/pkg/juicefs/mount/pod_mount_test.go
+++ b/pkg/juicefs/mount/pod_mount_test.go
@@ -560,6 +560,7 @@ func TestWaitUntilMount(t *testing.T) {
 					VolumeId:   "h",
 					TargetPath: "/mnt/hhh",
 					MountPath:  "/mnt/hhh",
+					Attr:       &jfsConfig.PodAttr{},
 				},
 			},
 			pod:      testH,
@@ -573,6 +574,7 @@ func TestWaitUntilMount(t *testing.T) {
 					VolumeId:   "g",
 					TargetPath: "/mnt/ggg",
 					MountPath:  "/mnt/ggg",
+					Attr:       &jfsConfig.PodAttr{},
 				},
 			},
 			pod:     testG,
@@ -591,6 +593,7 @@ func TestWaitUntilMount(t *testing.T) {
 					VolumeId:   "i",
 					TargetPath: "/mnt/iii",
 					MountPath:  "/mnt/iii",
+					Attr:       &jfsConfig.PodAttr{},
 				},
 			},
 			pod:     nil,
@@ -664,7 +667,7 @@ func TestWaitUntilMountWithMock(t *testing.T) {
 			defer cancel()
 			podName, err := p.genMountPodName(context.TODO(), &jfsConfig.JfsSetting{Storage: "ttt"})
 			So(err, ShouldBeNil)
-			err = p.createOrAddRef(ctx, podName, &jfsConfig.JfsSetting{Storage: "ttt"}, nil)
+			err = p.createOrAddRef(ctx, podName, &jfsConfig.JfsSetting{Storage: "ttt", Attr: &jfsConfig.PodAttr{}}, nil)
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -694,7 +697,7 @@ func TestJMount(t *testing.T) {
 			})
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
-			err := p.JMount(ctx, nil, &jfsConfig.JfsSetting{Storage: "ttt"})
+			err := p.JMount(ctx, nil, &jfsConfig.JfsSetting{Storage: "ttt", Attr: &jfsConfig.PodAttr{}})
 			So(err, ShouldNotBeNil)
 		})
 	})

--- a/scripts/juicefs-csi-webhook-install.sh
+++ b/scripts/juicefs-csi-webhook-install.sh
@@ -542,6 +542,7 @@ spec:
         - --v=5
         - --webhook=true
         - --validating-webhook=true
+        - --config=/etc/config/config.yaml
         env:
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -599,6 +600,8 @@ spec:
         - mountPath: /etc/webhook/certs
           name: webhook-certs
           readOnly: true
+        - mountPath: /etc/config
+          name: juicefs-config
       - args:
         - --csi-address=$(ADDRESS)
         - --timeout=60s
@@ -656,6 +659,10 @@ spec:
       - name: webhook-certs
         secret:
           secretName: juicefs-webhook-certs
+      - configMap:
+          defaultMode: 420
+          name: juicefs-csi-driver-config
+        name: juicefs-config
   volumeClaimTemplates: []
 ---
 apiVersion: storage.k8s.io/v1
@@ -1252,6 +1259,7 @@ spec:
         - --v=5
         - --webhook=true
         - --validating-webhook=true
+        - --config=/etc/config/config.yaml
         env:
         - name: CSI_ENDPOINT
           value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -1309,6 +1317,8 @@ spec:
         - mountPath: /etc/webhook/certs
           name: webhook-certs
           readOnly: true
+        - mountPath: /etc/config
+          name: juicefs-config
       - args:
         - --csi-address=$(ADDRESS)
         - --timeout=60s
@@ -1366,6 +1376,10 @@ spec:
       - name: webhook-certs
         secret:
           secretName: juicefs-webhook-certs
+      - configMap:
+          defaultMode: 420
+          name: juicefs-csi-driver-config
+        name: juicefs-config
   volumeClaimTemplates: []
 ---
 apiVersion: cert-manager.io/v1

--- a/scripts/juicefs-csi-webhook-install.sh
+++ b/scripts/juicefs-csi-webhook-install.sh
@@ -378,6 +378,27 @@ subjects:
 ---
 apiVersion: v1
 data:
+  config.yaml: |-
+    mountPodPatch:
+      - lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - +e
+              - umount ${MOUNT_POINT} -l; rmdir ${MOUNT_POINT}; exit 0
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
+  name: juicefs-csi-driver-config
+  namespace: kube-system
+---
+apiVersion: v1
+data:
   ca.crt: CA_BUNDLE
   tls.crt: TLS_CRT
   tls.key: TLS_KEY
@@ -1079,6 +1100,27 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: juicefs-csi-controller-sa
+  namespace: kube-system
+---
+apiVersion: v1
+data:
+  config.yaml: |-
+    mountPodPatch:
+      - lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - +e
+              - umount ${MOUNT_POINT} -l; rmdir ${MOUNT_POINT}; exit 0
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: juicefs-csi-driver
+    app.kubernetes.io/name: juicefs-csi-driver
+    app.kubernetes.io/version: master
+  name: juicefs-csi-driver-config
   namespace: kube-system
 ---
 apiVersion: v1

--- a/tests/sanity/fake_juicefs_provider.go
+++ b/tests/sanity/fake_juicefs_provider.go
@@ -117,6 +117,10 @@ func (fs *fakeJfs) GetBasePath() string {
 	return fs.basePath
 }
 
+func (fs *fakeJfs) GetSetting() *config.JfsSetting {
+	return nil
+}
+
 func (fs *fakeJfs) BindTarget(ctx context.Context, bindSource, target string) error {
 	return nil
 }

--- a/tests/sanity/fake_juicefs_provider.go
+++ b/tests/sanity/fake_juicefs_provider.go
@@ -30,6 +30,7 @@ import (
 type fakeJfs struct {
 	basePath string
 	volumes  map[string]string
+	settings *config.JfsSetting
 }
 
 type fakeJfsProvider struct {
@@ -70,6 +71,7 @@ func (j *fakeJfsProvider) JfsMount(ctx context.Context, volumeID string, target 
 	fs = fakeJfs{
 		basePath: "/jfs/fake",
 		volumes:  map[string]string{},
+		settings: &config.JfsSetting{},
 	}
 
 	j.fs[jfsName] = fs
@@ -118,7 +120,7 @@ func (fs *fakeJfs) GetBasePath() string {
 }
 
 func (fs *fakeJfs) GetSetting() *config.JfsSetting {
-	return nil
+	return fs.settings
 }
 
 func (fs *fakeJfs) BindTarget(ctx context.Context, bindSource, target string) error {


### PR DESCRIPTION
Introduce a global configuration file for csi to bring better configuration changes.

users can follow the following configuration

```yaml
# arrange mount pod to node with node selector instead nodeName
enableNodeSelector: false

## supoort template parse
# ${MOUNT_POINT}
# ${VOLUME_ID}
# ${SUB_PATH}
mountPodPatch:
  # selector is nil, mean all pod will be patched
  - ceMountImage: juicedata/mount:ce-v1.1.2
    eeMountImage: juicedata/mount:ee-5.0.16-c62bb16
  # only matched selector PVC will patch livenessProbe
  - pvcSelector:
      matchLabels:
        app: need-liveness-pvc
    livenessProbe:
      exec:
        command:
        - stat
        - ${MOUNT_POINT}/${SUB_PATH}
      failureThreshold: 3
      initialDelaySeconds: 5
      periodSeconds: 5
      successThreshold: 1
      timeoutSeconds: 1
  # only matched selector PVC will use hostNetwork
  - pvcSelector:
      matchLabels:
        app: need-hostnetwrok-pvc
    hostNetwork: true # omit will extend csi node value
    hostPID: false # omit will extend csi node value
  - pvcSelector:
      matchLabels:
        app: need-readiness-pvc
    readinessProbe:
      exec:
        command:
        - stat
        - ${MOUNT_POINT}/${SUB_PATH}
      failureThreshold: 3
      initialDelaySeconds: 5
      periodSeconds: 5
      successThreshold: 1
      timeoutSeconds: 1
  - pvcSelector:
      matchLabels:
        app: need-startup-pvc
    startupProbe:
      exec:
        command:
        - stat
        - ${MOUNT_POINT}/${SUB_PATH}
      failureThreshold: 3
      initialDelaySeconds: 5
      periodSeconds: 5
      successThreshold: 1
      timeoutSeconds: 1
```


based on this config, a hot reload is introduced, which allows some configuration changes to be completed without restarting the daemonset.


ref： https://github.com/juicedata/juicefs-csi-driver/issues/903 https://github.com/juicedata/voc/issues/255