### PR TITLE
fix: pod lock may cause reconciler deadlock

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -147,6 +147,15 @@ func GetPodLock(podName string) *sync.Mutex {
 	return &PodLocks[index%1024]
 }
 
+var BindLocks [1024]sync.Mutex
+
+func GetBindLock(target string) *sync.Mutex {
+	h := fnv.New32a()
+	h.Write([]byte(target))
+	index := int(h.Sum32())
+	return &BindLocks[index%1024]
+}
+
 func MustGetWebPort() int {
 	value, exists := os.LookupEnv("JUICEFS_CSI_WEB_PORT")
 	if exists {

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -216,6 +216,10 @@ func (fs *jfs) CreateVol(ctx context.Context, volumeID, subPath string) (string,
 }
 
 func (fs *jfs) BindTarget(ctx context.Context, bindSource, target string) error {
+	lock := config.GetBindLock(target)
+	lock.Lock()
+	defer lock.Unlock()
+
 	mountInfos, err := mount.ParseMountInfo(procMountInfoPath)
 	if err != nil {
 		return err

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -329,7 +329,9 @@ func (p *PodMount) createOrAddRef(ctx context.Context, podName string, jfsSettin
 		oldPod, err := p.K8sClient.GetPod(waitCtx, podName, jfsConfig.Namespace)
 		if err == nil && oldPod.DeletionTimestamp != nil {
 			klog.V(6).Infof("createOrAddRef: wait for old mount pod deleted.")
+			lock.Unlock()
 			time.Sleep(time.Millisecond * 500)
+			lock.Lock()
 			continue
 		} else if err != nil {
 			if k8serrors.IsNotFound(err) {


### PR DESCRIPTION
ISSUE: https://github.com/juicedata/juicefs-csi-driver/issues/957

1. if a mount pod is creating when it is in terminating status, createOrAddRef will hold the pod lock and wait old mount pod to be deleted. if the reconciler checkAnnotations run after createOrAddRef, it also need hold pod lock, because createOrAddRef won't release pod lock until pod deleted or waitCtx, it will hang 60 seconds, and may cause kubelet grpc timeout 

2. BindTarget checked mount info to prevent repeat mounts, but it may running concurrency can alse cause repeat mounts, so i think there should add a lock. 

