### PR TITLE
Support injecting volume name in global config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -274,6 +274,7 @@ func (c *Config) GenMountPodPatch(setting JfsSetting) MountPodPatch {
 	strData := string(data)
 	strData = strings.ReplaceAll(strData, "${MOUNT_POINT}", setting.MountPath)
 	strData = strings.ReplaceAll(strData, "${VOLUME_ID}", setting.VolumeId)
+	strData = strings.ReplaceAll(strData, "${VOLUME_NAME}", setting.Name)
 	strData = strings.ReplaceAll(strData, "${SUB_PATH}", setting.SubPath)
 	json.Unmarshal([]byte(strData), patch)
 	klog.V(6).Infof("volume %s using patch: %+v", setting.VolumeId, patch)


### PR DESCRIPTION
So we can inject jfs volume name into labels, and filter logs by volume name in loki.