### PR TITLE
chore: add PV subpath label to provisioned PV

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -136,6 +136,9 @@ const (
 	DefaultMountPodMemLimit   = "5Gi"
 	DefaultMountPodCpuRequest = "1000m"
 	DefaultMountPodMemRequest = "1Gi"
+
+	// pv labels
+	PVSubpathKey = "juicefs/sub-path"
 )
 
 var PodLocks [1024]sync.Mutex

--- a/pkg/driver/provisioner.go
+++ b/pkg/driver/provisioner.go
@@ -149,6 +149,9 @@ func (j *provisionerService) Provision(ctx context.Context, options provisioncon
 	pv := &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: options.PVName,
+			Labels: map[string]string{
+				config.PVSubpathKey: subPath,
+			},
 		},
 		Spec: corev1.PersistentVolumeSpec{
 			Capacity: corev1.ResourceList{

--- a/pkg/util/resource/pvc.go
+++ b/pkg/util/resource/pvc.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
@@ -106,8 +107,24 @@ func CheckForSubPath(ctx context.Context, client *k8s.K8sClient, volume *v1.Pers
 		return false, nil
 	}
 
+	// list by labels
+	labelsSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			config.PVSubpathKey: nowSubPath,
+		},
+	}
+	pvs, err := client.ListPersistentVolumes(ctx, &labelsSelector, nil)
+	if err != nil {
+		return false, err
+	}
+	if len(pvs) > 1 {
+		klog.V(5).Infof("Found more than one PV with the same subPath %s, skip delete volume %s data", nowSubPath, volume.Name)
+		return false, nil
+	}
+
+	// FIXME: we still need to list all PVs to check because the labels were not set in the old version.
 	// get all pvs
-	pvs, err := client.ListPersistentVolumes(ctx, nil, nil)
+	pvs, err = client.ListPersistentVolumes(ctx, nil, nil)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
- add a label `subPath` to the PV object. this change allows for better tracking of pv with specific subPath, maybe useful in the future, but currently useless


ref: https://github.com/juicedata/juicefs-csi-driver/issues/1022