### PR TITLE
feat: support custom mountpod volumes

### DIFF
--- a/juicefs-csi-driver-config.example.yaml
+++ b/juicefs-csi-driver-config.example.yaml
@@ -75,3 +75,15 @@ data:
       #     initialDelaySeconds: 10
       #     periodSeconds: 5
       #     successThreshold: 1
+
+      # mount some volumes to the mount pod
+      # - pvcSelector:
+      #     matchLabels:
+      #       need-block-device: "true"
+      #   volumeDevices:
+      #     - name: block-devices
+      #       devicePath: /dev/sda1
+      #   volumes:
+      #     - name: block-devices
+      #       persistentVolumeClaim:
+      #         claimName: block-pv

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -98,13 +98,17 @@ type PodAttr struct {
 
 	Resources corev1.ResourceRequirements
 
-	Labels                        map[string]string `json:"labels,omitempty"`
-	Annotations                   map[string]string `json:"annotations,omitempty"`
-	LivenessProbe                 *corev1.Probe     `json:"livenessProbe,omitempty"`
-	ReadinessProbe                *corev1.Probe     `json:"readinessProbe,omitempty"`
-	StartupProbe                  *corev1.Probe     `json:"startupProbe,omitempty"`
-	Lifecycle                     *corev1.Lifecycle `json:"lifecycle,omitempty"`
-	TerminationGracePeriodSeconds *int64            `json:"terminationGracePeriodSeconds,omitempty"`
+	Labels                        map[string]string     `json:"labels,omitempty"`
+	Annotations                   map[string]string     `json:"annotations,omitempty"`
+	LivenessProbe                 *corev1.Probe         `json:"livenessProbe,omitempty"`
+	ReadinessProbe                *corev1.Probe         `json:"readinessProbe,omitempty"`
+	StartupProbe                  *corev1.Probe         `json:"startupProbe,omitempty"`
+	Lifecycle                     *corev1.Lifecycle     `json:"lifecycle,omitempty"`
+	TerminationGracePeriodSeconds *int64                `json:"terminationGracePeriodSeconds,omitempty"`
+	Volumes                       []corev1.Volume       `json:"volumes,omitempty"`
+	VolumeDevices                 []corev1.VolumeDevice `json:"volumeDevices,omitempty"`
+	VolumeMounts                  []corev1.VolumeMount  `json:"volumeMounts,omitempty"`
+	Env                           []corev1.EnvVar       `json:"env,omitempty"`
 
 	// inherit from csi
 	Image            string
@@ -684,6 +688,10 @@ func applyAttrPatch(attr *PodAttr, setting *JfsSetting) {
 	attr.ReadinessProbe = patch.ReadinessProbe
 	attr.StartupProbe = patch.StartupProbe
 	attr.TerminationGracePeriodSeconds = patch.TerminationGracePeriodSeconds
+	attr.VolumeDevices = patch.VolumeDevices
+	attr.VolumeMounts = patch.VolumeMounts
+	attr.Volumes = patch.Volumes
+	attr.Env = patch.Env
 }
 
 // IsCEMountPod check if the pod is a mount pod of CE

--- a/pkg/juicefs/mount/builder/common.go
+++ b/pkg/juicefs/mount/builder/common.go
@@ -103,6 +103,7 @@ func (r *BaseBuilder) genCommonJuicePod(cnGen func() corev1.Container) *corev1.P
 			},
 		},
 	}}
+	pod.Spec.Containers[0].Env = r.jfsSetting.Attr.Env
 	pod.Spec.Containers[0].Resources = r.jfsSetting.Attr.Resources
 	if r.jfsSetting.Attr.Lifecycle == nil {
 		pod.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{

--- a/pkg/juicefs/mount/builder/pod.go
+++ b/pkg/juicefs/mount/builder/pod.go
@@ -52,10 +52,10 @@ func (r *PodBuilder) NewMountPod(podName string) *corev1.Pod {
 		cmd = strings.Join([]string{initCmd, mountCmd}, "\n")
 	}
 	pod.Spec.Containers[0].Command = []string{"sh", "-c", cmd}
-	pod.Spec.Containers[0].Env = []corev1.EnvVar{{
+	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
 		Name:  "JFS_FOREGROUND",
 		Value: "1",
-	}}
+	})
 
 	// generate volumes and volumeMounts only used in mount pod
 	volumes, volumeMounts := r.genPodVolumes()
@@ -71,6 +71,17 @@ func (r *PodBuilder) NewMountPod(podName string) *corev1.Pod {
 	mountVolumes, mountVolumeMounts := r.genHostPathVolumes()
 	pod.Spec.Volumes = append(pod.Spec.Volumes, mountVolumes...)
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, mountVolumeMounts...)
+
+	// add users custom volumes, volumeMounts, volumeDevices
+	if r.jfsSetting.Attr.Volumes != nil {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, r.jfsSetting.Attr.Volumes...)
+	}
+	if r.jfsSetting.Attr.VolumeMounts != nil {
+		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, r.jfsSetting.Attr.VolumeMounts...)
+	}
+	if r.jfsSetting.Attr.VolumeDevices != nil {
+		pod.Spec.Containers[0].VolumeDevices = append(pod.Spec.Containers[0].VolumeDevices, r.jfsSetting.Attr.VolumeDevices...)
+	}
 
 	return pod
 }


### PR DESCRIPTION
user can add some volumes to mountpod

like this
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: juicefs-csi-driver-config
  namespace: kube-system
data:
  config.yaml: |-
    mountPodPatch:    
    - pvcSelector:
        matchLabels:
          need-block-device: "true"
      volumeDevices:
        - name: block-devices
          devicePath: /dev/sda1
      volumes:
        - name: block-devices
          persistentVolumeClaim:
            claimName: block-pvc
```

ref: https://github.com/juicedata/voc/issues/270#issuecomment-2268088105