### PR TITLE
fix: update JUICEFS_CSI_REPO_REF in Makefile

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -38,8 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build docker image nightly
-#        env:
-#          JFSCHAN: beta
+        env:
+          JUICEFS_CSI_REPO_REF: ${{ github.ref }}
         run: |
           make -C docker image-nightly
       - name: Prepare microk8s environment
@@ -81,8 +81,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build docker image nightly
-#        env:
-#          JFSCHAN: beta
+        env:
+          JUICEFS_CSI_REPO_REF: ${{ github.ref }}
         run: |
           make -C docker image-nightly
       - name: Prepare microk8s environment
@@ -126,8 +126,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build docker image nightly
-#        env:
-#          JFSCHAN: beta
+        env:
+          JUICEFS_CSI_REPO_REF: ${{ github.ref }}
         run: |
           make -C docker image-nightly
       - name: Prepare microk8s environment
@@ -169,8 +169,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build docker image nightly
-#        env:
-#          JFSCHAN: beta
+        env:
+          JUICEFS_CSI_REPO_REF: ${{ github.ref }}
         run: |
           make -C docker image-nightly
       - name: Prepare microk8s environment

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -72,6 +72,7 @@ jobs:
         EEVERSION: ee-${{ env.JUICEFS_EE_LATEST_VERSION }}
         CSIVERSION: ${{ env.CSI_LATEST_VERSION }}
         DASHBOARD_TAG: ${{ env.CSI_LATEST_VERSION }}
+        JUICEFS_CSI_REPO_REF: ${{ github.ref }}
       run: |
         export DOCKER_CLI_EXPERIMENTAL=enabled
         docker run --privileged --rm tonistiigi/binfmt:qemu-v6.2.0 --uninstall qemu-*

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -19,16 +19,8 @@ JUICEFS_IMAGE?=juicedata/mount
 VERSION=$(shell git describe --tags --match 'v*' --always --dirty)
 DASHBOARD_IMAGE?=juicedata/csi-dashboard
 DASHBOARD_TAG?=$(VERSION)
-GIT_BRANCH?=$(shell git rev-parse --abbrev-ref HEAD)
-GIT_COMMIT?=$(shell git rev-parse HEAD)
 DEV_TAG=dev-$(shell git describe --always --dirty)
-BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-PKG=github.com/juicedata/juicefs-csi-driver
-LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} -s -w"
-GO111MODULE=on
-JUICEFS_CSI_LATEST_VERSION=$(shell git describe --tags --match 'v*' | grep -oE 'v[0-9]+\.[0-9][0-9]*(\.[0-9]+)?')
 IMAGE_VERSION_ANNOTATED=$(IMAGE):$(VERSION)-juicefs$(shell docker run --entrypoint=/usr/bin/juicefs $(IMAGE):$(VERSION) version | cut -d' ' -f3)
-
 JUICEFS_CE_LATEST_VERSION=$(shell curl -fsSL https://api.github.com/repos/juicedata/juicefs/releases/latest | grep tag_name | grep -oE 'v[0-9]+\.[0-9][0-9]*(\.[0-9]+(-[0-9a-z]+)?)?')
 JUICEFS_EE_LATEST_VERSION=$(shell curl -sSL https://juicefs.com/static/juicefs -o juicefs-ee && chmod +x juicefs-ee && ./juicefs-ee version | cut -d' ' -f3)
 JFS_CHAN=${JFSCHAN}
@@ -39,6 +31,8 @@ CE_VERSION=${CEVERSION}
 CE_JUICEFS_VERSION=${CEJUICEFS_VERSION}
 EE_VERSION=${EEVERSION}
 CSI_VERSION=${CSIVERSION}
+JUICEFS_CSI_REPO_URL?=https://github.com/juicedata/juicefs-csi-driver
+JUICEFS_CSI_REPO_REF?=master
 
 ################# CSI image #######################
 
@@ -50,6 +44,8 @@ image-nightly:
 		--build-arg JUICEFS_CE_MOUNT_IMAGE=$(JUICEFS_IMAGE):ce-nightly \
 		--build-arg JUICEFS_EE_MOUNT_IMAGE=$(JUICEFS_IMAGE):ee-nightly \
 		--build-arg JFSCHAN=$(JFS_CHAN) \
+		--build-arg JUICEFS_CSI_REPO_URL=$(JUICEFS_CSI_REPO_URL) \
+		--build-arg JUICEFS_CSI_REPO_REF=$(JUICEFS_CSI_REPO_REF) \
         -t $(IMAGE):nightly -f csi.Dockerfile .
 
 # push nightly image
@@ -64,6 +60,8 @@ image-version:
         --build-arg JUICEFS_REPO_REF=$(CE_JUICEFS_VERSION) \
 		--build-arg JUICEFS_CE_MOUNT_IMAGE=$(JUICEFS_IMAGE):$(CE_VERSION) \
 		--build-arg JUICEFS_EE_MOUNT_IMAGE=$(JUICEFS_IMAGE):$(EE_VERSION) \
+		--build-arg JUICEFS_CSI_REPO_URL=$(JUICEFS_CSI_REPO_URL) \
+		--build-arg JUICEFS_CSI_REPO_REF=$(JUICEFS_CSI_REPO_REF) \
 		--platform linux/amd64,linux/arm64 -f csi.Dockerfile . --push
 
 .PHONY: push-version
@@ -83,6 +81,8 @@ image-release-check:
 		--build-arg JFSCHAN=$(JFS_CHAN) \
 		--build-arg JUICEFS_CE_MOUNT_IMAGE=$(JUICEFS_IMAGE):$(CE_VERSION) \
 		--build-arg JUICEFS_EE_MOUNT_IMAGE=$(JUICEFS_IMAGE):$(EE_VERSION) \
+		--build-arg JUICEFS_CSI_REPO_URL=$(JUICEFS_CSI_REPO_URL) \
+		--build-arg JUICEFS_CSI_REPO_REF=$(JUICEFS_CSI_REPO_REF) \
 		-t $(IMAGE):$(DEV_TAG) -f csi.Dockerfile .
 	docker build --build-context project=.. --build-context ui=../dashboard-ui/ -f dashboard.Dockerfile \
 		-t $(REGISTRY)/$(DASHBOARD_IMAGE):$(DEV_TAG) .


### PR DESCRIPTION
Update the `JUICEFS_CSI_REPO_REF` variable in the Makefile to include the value of the `github.ref` environment variable. 

this ensures that the correct repository reference is used when building the CSI image.