### PR TITLE
improve mount operation

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -177,9 +177,6 @@ func (d *nodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "invalid capacity %s: %v", cap, err)
 		}
-		if capacity/1024/1024/1024 <= 0 {
-			return nil, status.Errorf(codes.InvalidArgument, "capacity %d is too small, at least 1GiB for quota", capacity)
-		}
 		settings := jfs.GetSetting()
 		if settings.PV != nil {
 			capacity = settings.PV.Spec.Capacity.Storage().Value()

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -27,6 +27,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	k8sexec "k8s.io/utils/exec"
 	"k8s.io/utils/mount"
@@ -176,6 +177,9 @@ func (d *nodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "invalid capacity %s: %v", cap, err)
 		}
+		if capacity/1024/1024/1024 <= 0 {
+			return nil, status.Errorf(codes.InvalidArgument, "capacity %d is too small, at least 1GiB for quota", capacity)
+		}
 		settings := jfs.GetSetting()
 		if settings.PV != nil {
 			capacity = settings.PV.Spec.Capacity.Storage().Value()
@@ -192,10 +196,14 @@ func (d *nodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			}
 		}
 
-		err = d.juicefs.SetQuota(ctx, secrets, settings, path.Join(subdir, quotaPath), capacity)
-		if err != nil {
-			log.Error(err, "set quota error")
-		}
+		go func() {
+			err := retry.OnError(retry.DefaultRetry, func(err error) bool { return true }, func() error {
+				return d.juicefs.SetQuota(context.Background(), secrets, settings, path.Join(subdir, quotaPath), capacity)
+			})
+			if err != nil {
+				log.Error(err, "set quota failed")
+			}
+		}()
 	}
 
 	log.Info("juicefs volume mounted", "volumeId", volumeID, "target", target)

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -736,7 +736,7 @@ func (j *juicefs) SetQuota(ctx context.Context, secrets map[string]string, jfsSe
 		cmdArgs = []string{config.CliPath, "quota", "set", secrets["name"], "--path", quotaPath, "--capacity", strconv.FormatInt(cap, 10)}
 	}
 	log.Info("quota cmd", "command", strings.Join(cmdArgs, " "))
-	cmdCtx, cmdCancel := context.WithTimeout(ctx, 2*defaultCheckTimeout)
+	cmdCtx, cmdCancel := context.WithTimeout(ctx, 5*defaultCheckTimeout)
 	defer cmdCancel()
 	envs := syscall.Environ()
 	for key, val := range jfsSetting.Envs {

--- a/pkg/juicefs/mount/builder/common.go
+++ b/pkg/juicefs/mount/builder/common.go
@@ -182,8 +182,7 @@ func (r *BaseBuilder) genInitCommand() string {
 	if r.jfsSetting.InitConfig != "" {
 		confPath := filepath.Join(config.ROConfPath, r.jfsSetting.Name+".conf")
 		args := []string{"cp", confPath, r.jfsSetting.ClientConfPath}
-		confCmd := strings.Join(args, " ")
-		formatCmd = strings.Join([]string{confCmd, formatCmd}, "\n")
+		formatCmd = strings.Join(args, " ")
 	}
 	return formatCmd
 }


### PR DESCRIPTION
- make setQuota async
- if initConfig not nil, do not auth in mountpod
- Increase the timeout for setQuota(async) and add retry logic

before 0.24.6 (mount pod image is already present on node)
**6-9s**
```
# start
I0830 02:50:57.784318       6 node.go:103] NodePublishVolume: called with args volume_id:"pvc-a7389353-2037-40e8-b90d-2b91cdd24a8d" ...
...

# mount success
I0830 02:51:06.602511       6 node.go:193] NodePublishVolume: mounted pvc-a7389353-2037-40e8-b90d-2b91cdd24a8d at /var/lib/kubelet/pods/4ea9d9cf-5f1b-45d1-b111-ba00607b27d4/volumes/kubernetes.io~csi/pvc-a7389353-2037-40e8-b90d-2b91cdd24a8d/mount with options [subdir=/zxh-test-dev verbose]
```


after this PR (mount pod image is already present on node)
**3-5s**
```
# start
I0830 03:00:30.124331       7 node.go:115] "NodePublishVolume: called with args" appName="busybox-default-6df968b7f8-9prps" volumeId="pvc-91f69ac3-16ce-4cb7-85d7-7387642c261f" ...
...
# mount success
I0830 03:00:33.828076       7 node.go:206] "NodePublishVolume: juicefs volume mounted" appName="busybox-default-6df968b7f8-9prps" volumeId="pvc-91f69ac3-16ce-4cb7-85d7-7387642c261f" target="/var/lib/kubelet/pods/4fefb00a-21dc-46e5-a672-289fedd5bb65/volumes/kubernetes.io~csi/pvc-91f69ac3-16ce-4cb7-85d7-7387642c261f/mount"

# start
I0830 03:22:01.039929       6 node.go:116] "NodePublishVolume: called with args" appName="busybox-default-6df968b7f8-8cj7f" volumeId="pvc-23a1ab9e-178f-46c1-b59c-0bf7e2426e8c"...
...
# mount success
I0830 03:22:04.751753       6 node.go:209] "NodePublishVolume: juicefs volume mounted" appName="busybox-default-6df968b7f8-8cj7f" volumeId="pvc-23a1ab9e-178f-46c1-b59c-0bf7e2426e8c" ..
```

Expected to improve by 4-6 seconds for mount operation