### PR TITLE
fix ci: upgrade go to 1.20

### DIFF
--- a/docker/csi.Dockerfile
+++ b/docker/csi.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19-buster AS builder
+FROM golang:1.20-buster AS builder
 
 ARG GOPROXY
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-go 1.19
+go 1.20
 
 replace k8s.io/api => k8s.io/api v0.22.0
 


### PR DESCRIPTION
to fix ci

```sh
 > [builder 13/13] RUN cd /workspace && git clone --branch=main https://github.com/juicedata/juicefs &&     cd juicefs && git checkout main &&     bash -c "if [[ amd64 == amd64 ]]; then make juicefs.all && mv juicefs.all juicefs; else make juicefs; fi":
13.36 go: downloading github.com/google/go-cmp v0.6.0
13.37 go: downloading github.com/hashicorp/golang-lru v0.5.4
13.38 go: downloading github.com/tidwall/gjson v1.9.3
13.39 go: downloading github.com/tidwall/sjson v1.0.4
13.40 go: downloading github.com/tidwall/match v1.1.1
13.40 go: downloading github.com/tidwall/pretty v1.2.0
101.2 # github.com/juicedata/juicefs/pkg/meta
101.2 pkg/meta/base.go:162:27: symCache.Swap undefined (type *symlinkCache has no field or method Swap)
101.2 note: module requires Go 1.20
106.2 make: *** [Makefile:44: juicefs.all] Error 2
```

/cc @zwwhdls 