### PR TITLE
feat: specify cachedirs in configmap

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -130,13 +130,31 @@ type PVCSelector struct {
 	MatchName             string `json:"matchName,omitempty"`
 }
 
+type MountPatchCacheDirType string
+
+var (
+	MountPatchCacheDirTypeHostPath MountPatchCacheDirType = "HostPath"
+	MountPatchCacheDirTypePVC      MountPatchCacheDirType = "PVC"
+)
+
+type MountPatchCacheDir struct {
+	Type MountPatchCacheDirType `json:"type,omitempty"`
+
+	// required for HostPath type
+	Path string `json:"path,omitempty"`
+
+	// required for PVC type
+	Name string `json:"name,omitempty"`
+}
+
 type MountPodPatch struct {
 	// used to specify the selector for the PVC that will be patched
 	// omit will patch for all PVC
 	PVCSelector *PVCSelector `json:"pvcSelector,omitempty"`
 
-	CEMountImage string `json:"ceMountImage,omitempty"`
-	EEMountImage string `json:"eeMountImage,omitempty"`
+	CEMountImage string               `json:"ceMountImage,omitempty"`
+	EEMountImage string               `json:"eeMountImage,omitempty"`
+	CacheDirs    []MountPatchCacheDir `json:"cacheDirs,omitempty"`
 
 	Image                         string                       `json:"-"`
 	Labels                        map[string]string            `json:"labels,omitempty"`
@@ -274,6 +292,9 @@ func (mpp *MountPodPatch) merge(mp MountPodPatch) {
 	}
 	if mp.MountOptions != nil {
 		mpp.MountOptions = mp.MountOptions
+	}
+	if mp.CacheDirs != nil {
+		mpp.CacheDirs = mp.CacheDirs
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -87,6 +87,11 @@ MountPodPatch:
     - name: block-devices
       persistentVolumeClaim:
         claimName: block-pvc
+  - cacheDirs:
+    - type: PVC
+      name: cache-pvc
+    - type: HostPath
+      Path: /tmp
 `)
 	err := os.WriteFile(configPath, testData, 0644)
 	if err != nil {
@@ -100,7 +105,7 @@ MountPodPatch:
 	}
 	defer GlobalConfig.Reset()
 	// Check the loaded config
-	assert.Equal(t, len(GlobalConfig.MountPodPatch), 9)
+	assert.Equal(t, len(GlobalConfig.MountPodPatch), 10)
 	assert.Equal(t, GlobalConfig.MountPodPatch[0], MountPodPatch{
 		CEMountImage: "juicedata/mount:ce-test",
 		EEMountImage: "juicedata/mount:ee-test",
@@ -197,6 +202,18 @@ MountPodPatch:
 			{
 				Name:       "block-devices",
 				DevicePath: "/dev/sda",
+			},
+		},
+	})
+	assert.Equal(t, GlobalConfig.MountPodPatch[9], MountPodPatch{
+		CacheDirs: []MountPatchCacheDir{
+			{
+				Type: "PVC",
+				Name: "cache-pvc",
+			},
+			{
+				Type: "HostPath",
+				Path: "/tmp",
 			},
 		},
 	})

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -261,25 +261,23 @@ func genCacheDirs(jfsSetting *JfsSetting, volCtx map[string]string) error {
 	if volCtx != nil && volCtx[common.CachePVC] != "" {
 		cachePVCs = strings.Split(strings.TrimSpace(volCtx[common.CachePVC]), ",")
 	}
-	if len(jfsSetting.Attr.CacheDirs) > 0 {
+	if jfsSetting.Attr != nil {
 		for _, cacheDir := range jfsSetting.Attr.CacheDirs {
 			if cacheDir.Type == MountPatchCacheDirTypePVC {
 				cachePVCs = append(cachePVCs, cacheDir.Name)
 			}
 		}
 	}
-	if len(cachePVCs) > 0 {
-		for i, pvc := range cachePVCs {
-			if pvc == "" {
-				continue
-			}
-			volPath := fmt.Sprintf("/var/jfsCache-%d", i)
-			jfsSetting.CachePVCs = append(jfsSetting.CachePVCs, CachePVC{
-				PVCName: pvc,
-				Path:    volPath,
-			})
-			cacheDirsInContainer = append(cacheDirsInContainer, volPath)
+	for i, pvc := range cachePVCs {
+		if pvc == "" {
+			continue
 		}
+		volPath := fmt.Sprintf("/var/jfsCache-%d", i)
+		jfsSetting.CachePVCs = append(jfsSetting.CachePVCs, CachePVC{
+			PVCName: pvc,
+			Path:    volPath,
+		})
+		cacheDirsInContainer = append(cacheDirsInContainer, volPath)
 	}
 
 	// parse emptydir of cache
@@ -348,10 +346,12 @@ func genCacheDirs(jfsSetting *JfsSetting, volCtx map[string]string) error {
 		}
 	}
 	// parse hostPath dirs in setting attr
-	for _, cacheDir := range jfsSetting.Attr.CacheDirs {
-		if cacheDir.Type == MountPatchCacheDirTypeHostPath {
-			cacheDirsInContainer = append(cacheDirsInContainer, cacheDir.Path)
-			jfsSetting.CacheDirs = append(jfsSetting.CacheDirs, cacheDir.Path)
+	if jfsSetting.Attr != nil {
+		for _, cacheDir := range jfsSetting.Attr.CacheDirs {
+			if cacheDir.Type == MountPatchCacheDirTypeHostPath {
+				cacheDirsInContainer = append(cacheDirsInContainer, cacheDir.Path)
+				jfsSetting.CacheDirs = append(jfsSetting.CacheDirs, cacheDir.Path)
+			}
 		}
 	}
 	if len(cacheDirsInContainer) == 0 {

--- a/pkg/config/setting_test.go
+++ b/pkg/config/setting_test.go
@@ -646,12 +646,29 @@ func Test_genCacheDirs(t *testing.T) {
 		{
 			name: "test-cache-pvcs",
 			args: args{
-				JfsSetting: JfsSetting{},
-				volCtx:     map[string]string{"juicefs/mount-cache-pvc": "abc,def"},
+				JfsSetting: JfsSetting{
+					Attr: &PodAttr{
+						CacheDirs: []MountPatchCacheDir{
+							{
+								Type: "PVC",
+								Name: "sss",
+							},
+						},
+					},
+				},
+				volCtx: map[string]string{"juicefs/mount-cache-pvc": "abc,def"},
 			},
 			want: JfsSetting{
-				CachePVCs: []CachePVC{{PVCName: "abc", Path: "/var/jfsCache-0"}, {PVCName: "def", Path: "/var/jfsCache-1"}},
-				Options:   []string{"cache-dir=/var/jfsCache-0:/var/jfsCache-1"},
+				CachePVCs: []CachePVC{{PVCName: "abc", Path: "/var/jfsCache-0"}, {PVCName: "def", Path: "/var/jfsCache-1"}, {PVCName: "sss", Path: "/var/jfsCache-2"}},
+				Options:   []string{"cache-dir=/var/jfsCache-0:/var/jfsCache-1:/var/jfsCache-2"},
+				Attr: &PodAttr{
+					CacheDirs: []MountPatchCacheDir{
+						{
+							Type: "PVC",
+							Name: "sss",
+						},
+					},
+				},
 			},
 			wantErr: false,
 		},
@@ -683,6 +700,36 @@ func Test_genCacheDirs(t *testing.T) {
 					"/tmp/abc",
 				},
 				Options: []string{"cache-dir=/tmp/abc"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test-hostPath-with-pod-attr",
+			args: args{
+				JfsSetting: JfsSetting{
+					Attr: &PodAttr{
+						CacheDirs: []MountPatchCacheDir{
+							{
+								Type: "HostPath",
+								Path: "/abc",
+							},
+						},
+					},
+				},
+			},
+			want: JfsSetting{
+				Attr: &PodAttr{
+					CacheDirs: []MountPatchCacheDir{
+						{
+							Type: "HostPath",
+							Path: "/abc",
+						},
+					},
+				},
+				CacheDirs: []string{
+					"/abc",
+				},
+				Options: []string{"cache-dir=/abc"},
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
Now we can specify cachedirs in configmap

```yaml

mountPodPatch:
  cacheDirs:
    - type: PVC
      name: jfs-cache-pvc
    - type: HostPath
      path: /var/jfsCache
```

fix: #1131 