### PR TITLE
fix(dashboard): init csi-node pod annotations if nil before updating

### DIFF
--- a/pkg/dashboard/cm.go
+++ b/pkg/dashboard/cm.go
@@ -86,6 +86,9 @@ func (api *API) putCSIConfig() gin.HandlerFunc {
 			return
 		}
 		for _, pod := range csiNodeList.Items {
+			if pod.Annotations == nil {
+				pod.Annotations = make(map[string]string)
+			}
 			pod.Annotations["juicefs/update-time"] = metav1.Now().Format("2006-01-02T15:04:05Z")
 			_, err = api.client.CoreV1().Pods(api.sysNamespace).Update(c, &pod, metav1.UpdateOptions{})
 			if err != nil {


### PR DESCRIPTION
/cc @zwwhdls 

```
2024/12/11 07:44:08 [Recovery] 2024/12/11 - 07:44:08 panic recovered:
assignment to entry in nil map
/usr/local/go/src/runtime/map_faststr.go:205 (0x417d7a)
/workspace/pkg/dashboard/cm.go:89 (0x1ad5f9e)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x9ffa19)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/recovery.go:102 (0x9ffa07)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x9feb5c)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/logger.go:240 (0x9feb43)
[GIN] 2024/12/11 - 07:44:08 | 500 |   11.810563ms |       10.0.0.10 | PUT      "/api/v1/config"
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x9fe04d)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:620 (0x9fdcdc)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:576 (0x9fd811)
/usr/local/go/src/net/http/server.go:3142 (0x718c2d)
/usr/local/go/src/net/http/server.go:2044 (0x713f07)
/usr/local/go/src/runtime/asm_amd64.s:1695 (0x478b00)
```