### PR TITLE
feat: warmup cachegroup

### DIFF
--- a/dashboard-ui-v2/src/components/cg-workers-table.tsx
+++ b/dashboard-ui-v2/src/components/cg-workers-table.tsx
@@ -38,6 +38,7 @@ import { FormattedMessage } from 'react-intl'
 import { Link } from 'react-router-dom'
 
 import WorkerCacheBytes from './cache-bytes'
+import WarmupModal from './warmup-modal'
 import {
   useAddWorker,
   useCacheGroupWorkers,
@@ -102,7 +103,7 @@ const CgWorkersTable: React.FC<{
               trigger={
                 <Button type="primary">
                   <PlusOutlined />
-                  Add worker
+                  <FormattedMessage id="addWorker" />
                 </Button>
               }
               form={form}
@@ -139,6 +140,19 @@ const CgWorkersTable: React.FC<{
                 />
               </ProForm.Group>
             </ModalForm>,
+            data && data.items.length > 0 && (
+              <WarmupModal
+                name={data.items[0].metadata!.name!}
+                namespace={data.items[0].metadata!.namespace!}
+                container={data.items[0].status!.containerStatuses![0]}
+              >
+                {({ onClick }) => (
+                  <Button onClick={onClick}>
+                    <FormattedMessage id="warmup" />
+                  </Button>
+                )}
+              </WarmupModal>
+            ),
           ],
         }}
         columns={[

--- a/dashboard-ui-v2/src/components/warmup-modal.tsx
+++ b/dashboard-ui-v2/src/components/warmup-modal.tsx
@@ -117,7 +117,7 @@ const WarmupModal: React.FC<{
       {children({ onClick: showModal })}
       {isModalOpen ? (
         <Modal
-          title={`Warmup: ${namespace}/${name}/${container}`}
+          title={`Warmup: ${namespace}/${name}/${container.name}`}
           open={isModalOpen}
           footer={() => (
             <div style={{ textAlign: 'start' }}>

--- a/dashboard-ui-v2/src/locales/en-US.ts
+++ b/dashboard-ui-v2/src/locales/en-US.ts
@@ -132,6 +132,8 @@ export default {
   fileSystem: 'File System',
   dataMigration: 'Waiting for data migration',
   warmingUp: 'Warming up',
+  warmup: 'Warm up',
+  addWorker: 'Add Worker',
   updateConfigError: 'Fail to update Config',
   diff: 'Config Diff',
   view: 'View',

--- a/dashboard-ui-v2/src/locales/zh-CN.ts
+++ b/dashboard-ui-v2/src/locales/zh-CN.ts
@@ -125,6 +125,8 @@ export default {
   fileSystem: '文件系统',
   dataMigration: '等待数据迁移',
   warmingUp: '预热中',
+  warmup: '预热',
+  addWorker: '添加节点',
   podName: 'Pod 名称',
   upgradeStatus: '升级状态',
   updateConfigError: '更新配置错误',

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -391,7 +391,7 @@ func parseMntPath(cmd string) (string, string, error) {
 	if args[0] == "exec" {
 		args = args[1:]
 	}
-	if len(args) < 3 || !strings.HasPrefix(args[2], "/jfs") {
+	if len(args) < 3 || (!strings.HasPrefix(args[2], "/jfs") && !strings.HasPrefix(args[2], "/mnt/jfs")) {
 		return "", "", fmt.Errorf("err cmd:%s", cmd)
 	}
 	argSlice := strings.Split(args[2], "/")

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -833,6 +833,13 @@ func TestParseMntPath(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "without mnt jfs",
+			args:    args{cmd: "/bin/mount.juicefs redis://127.0.0.1/6379 /mnt/jfs"},
+			want:    "/mnt/jfs",
+			want1:   "jfs",
+			wantErr: false,
+		},
+		{
 			name: "with create subpath",
 			args: args{cmd: "/usr/local/bin/juicefs format --storage=s3 --bucket=http://juicefs-bucket.minio.default.svc.cluster.local:9000 --access-key=minioadmin --secret-key=${secretkey} ${metaurl} ce-secret\n" +
 				"/bin/mount.juicefs ${metaurl} /mnt/jfs -o buffer-size=300,cache-size=100,enable-xattr\n" +


### PR DESCRIPTION
<img width="433" alt="image" src="https://github.com/user-attachments/assets/338774f6-4068-45a3-8710-92cd3a15c377" />

复用之前 warmup mountpod 的逻辑 ，等 warmup 支持更多功能的时候，可以单独添加一个页面