### PR TITLE
fix: do not return err when cannot get secret in deleting mount pod

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 	"github.com/juicedata/juicefs-csi-driver/pkg/driver"
+
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
@@ -56,6 +58,13 @@ var (
 
 	log = klog.NewKlogr().WithName("main")
 )
+
+func init() {
+	// Initialize a logger for the controller runtime
+	ctrllog.SetLogger(klog.NewKlogr())
+	// To disable controller runtime logging, instead set the null logger:
+	//log.SetLogger(logr.New(log.NullLogSink{}))
+}
 
 func main() {
 	var cmd = &cobra.Command{

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -541,7 +541,7 @@ func GenSettingAttrWithMountPod(ctx context.Context, client *k8sclient.K8sClient
 	secretName := fmt.Sprintf("juicefs-%s-secret", mountPod.Labels[common.PodUniqueIdLabelKey])
 	secret, err := client.GetSecret(ctx, secretName, mountPod.Namespace)
 	if err != nil {
-		return nil, err
+		log.Error(err, "Get secret error", "secret", secretName)
 	}
 	setting, err := GenSetting(mountPod, pvc, pv, secret)
 	if err != nil {


### PR DESCRIPTION
1. do not return err when cannot get secret in deleting mount pod
2. enable logging for the controller runtime  

fix https://github.com/juicedata/juicefs-csi-driver/issues/1208