### PR TITLE
update batch upgrade

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -46,6 +46,8 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	juicefsiov1 "github.com/juicedata/juicefs-cache-group-operator/api/v1"
+
+	jfsConfig "github.com/juicedata/juicefs-csi-driver/pkg/config"
 	"github.com/juicedata/juicefs-csi-driver/pkg/dashboard"
 )
 
@@ -120,6 +122,7 @@ func run() {
 	if v := os.Getenv(SysNamespaceKey); v != "" {
 		sysNamespace = v
 	}
+	jfsConfig.Namespace = sysNamespace
 	if devMode {
 		config, err = getLocalConfig()
 	} else {

--- a/cmd/dashboard/upgrade.go
+++ b/cmd/dashboard/upgrade.go
@@ -276,6 +276,9 @@ func (u *BatchUpgrade) flushStatus(ctx context.Context) {
 			if u.status == config.Stop && mp.Status == config.Running {
 				mp.Status = config.Stop
 			}
+			if u.status == config.Fail && mp.Status == config.Running {
+				mp.Status = config.Fail
+			}
 			conf.Batches[i][j] = mp
 		}
 	}

--- a/cmd/dashboard/upgrade.go
+++ b/cmd/dashboard/upgrade.go
@@ -29,15 +29,19 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/remotecommand"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/common"
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+	"github.com/juicedata/juicefs-csi-driver/pkg/util/resource"
 )
 
 var batchConfigName string
@@ -102,6 +106,10 @@ var upgradeCmd = &cobra.Command{
 		defer cancel()
 
 		go bu.handleSignal()
+		if err := bu.fetchPods(ctx); err != nil {
+			logger("BATCH-FAIL failed to fetch pods")
+			os.Exit(1)
+		}
 		bu.Run(ctx)
 	},
 }
@@ -143,12 +151,19 @@ type BatchUpgrade struct {
 	k8sClient    *k8sclient.K8sClient
 	clientset    *kubernetes.Clientset
 
+	batches         [][]*PodUpgrade
 	lock            sync.Mutex
 	podsStatus      map[string]config.UpgradeStatus
 	status          config.UpgradeStatus
 	crtBatchStatus  config.UpgradeStatus
 	nextBatchStatus config.UpgradeStatus
 	crtBatch        int
+}
+
+type PodUpgrade struct {
+	pod         *corev1.Pod
+	hashVal     string
+	upgradeUUID string
 }
 
 func (u *BatchUpgrade) Run(ctx context.Context) {
@@ -210,6 +225,42 @@ func (u *BatchUpgrade) Run(ctx context.Context) {
 	}
 }
 
+func (u *BatchUpgrade) fetchPods(ctx context.Context) error {
+	labelSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			common.PodTypeKey: common.PodTypeValue,
+		},
+	}
+	podLists, err := u.k8sClient.ListPod(ctx, config.Namespace, labelSelector, nil)
+	if err != nil {
+		log.Error(err, "reconcile ListPod error")
+		return err
+	}
+	podMap := make(map[string]*corev1.Pod)
+	for _, pod := range podLists {
+		po := pod
+		podMap[pod.Name] = &po
+	}
+
+	u.batches = make([][]*PodUpgrade, len(u.conf.Batches))
+	for i, batch := range u.conf.Batches {
+		pods := make([]*PodUpgrade, 0)
+		for _, pu := range batch {
+			po := podMap[pu.Name]
+			if po == nil {
+				continue
+			}
+			pods = append(pods, &PodUpgrade{
+				pod:         po,
+				hashVal:     po.Labels[common.PodJuiceHashLabelKey],
+				upgradeUUID: resource.GetUpgradeUUID(po),
+			})
+		}
+		u.batches[i] = pods
+	}
+	return nil
+}
+
 func (u *BatchUpgrade) processBatch(ctx context.Context) {
 	if u.crtBatch > len(u.conf.Batches) {
 		return
@@ -219,11 +270,11 @@ func (u *BatchUpgrade) processBatch(ctx context.Context) {
 		wg                  sync.WaitGroup
 		batch               = u.conf.Batches[u.crtBatch-1]
 		crtBatchFinalStatus = config.Success
-		csiNodeNames        = make(map[string]bool)
+		csiNodeNames        = make(map[string]string)
 	)
 	// trigger upgrade in each csi node only one time
 	for _, mp := range batch {
-		csiNodeNames[mp.CSINodePod] = true
+		csiNodeNames[mp.CSINodePod] = mp.Node
 	}
 	resultCh := make(chan error, len(csiNodeNames))
 	go func() {
@@ -231,10 +282,21 @@ func (u *BatchUpgrade) processBatch(ctx context.Context) {
 			wg.Wait()
 			close(resultCh)
 		}()
-		for csiNode := range csiNodeNames {
+		for csiNode, node := range csiNodeNames {
 			wg.Add(1)
 			go func() {
 				resultCh <- u.triggerUpgrade(ctx, csiNode, batchConfigName, u.crtBatch)
+				needWait := false
+				for _, p := range u.batches[u.crtBatch-1] {
+					if u.podsStatus[p.pod.Name] != config.Success && u.podsStatus[p.pod.Name] != config.Fail {
+						needWait = true
+						break
+					}
+				}
+				if needWait {
+					u.waitForUpgrade(ctx, u.crtBatch, node)
+				}
+
 				wg.Done()
 			}()
 		}
@@ -326,6 +388,131 @@ func (u *BatchUpgrade) triggerUpgrade(ctx context.Context, csiNode string, confi
 		return err
 	}
 	return nil
+}
+
+func (u *BatchUpgrade) waitForUpgrade(ctx context.Context, index int, nodeName string) {
+	ctx, cancel := context.WithTimeout(ctx, 1200*time.Second)
+	defer cancel()
+
+	var (
+		successSum = make(map[string]bool)
+		failSum    = make(map[string]bool)
+		crtBatch   = u.batches[index-1]
+	)
+
+	for _, p := range crtBatch {
+		if u.podsStatus[p.pod.Name] == config.Fail {
+			failSum[p.pod.Name] = true
+		}
+		if u.podsStatus[p.pod.Name] == config.Success {
+			successSum[p.pod.Name] = true
+		}
+	}
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	labelSelector, _ := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			common.PodTypeKey: common.PodTypeValue,
+		},
+	})
+	watchlist := cache.NewFilteredListWatchFromClient(
+		u.clientset.CoreV1().RESTClient(),
+		"pods",
+		config.Namespace,
+		func(options *metav1.ListOptions) {
+			options.ResourceVersion = "0"
+			options.FieldSelector = fields.Set{"spec.nodeName": nodeName}.String()
+			options.LabelSelector = labelSelector.String()
+		},
+	)
+	handle := func(obj interface{}) {
+		if obj == nil {
+			return
+		}
+		po, ok := obj.(*corev1.Pod)
+		if !ok {
+			return
+		}
+		var pu *PodUpgrade
+		for _, p := range crtBatch {
+			if p.pod.Labels[common.PodUpgradeUUIDLabelKey] == po.Labels[common.PodUpgradeUUIDLabelKey] {
+				pu = p
+				break
+			}
+		}
+		if pu == nil {
+			return
+		}
+		if po.Name != pu.pod.Name {
+			if po.DeletionTimestamp == nil && !resource.IsPodComplete(po) {
+				if resource.IsPodReady(po) && !successSum[pu.pod.Name] {
+					u.lock.Lock()
+					u.podsStatus[pu.pod.Name] = config.Success
+					u.lock.Unlock()
+					successSum[pu.pod.Name] = true
+					logger(fmt.Sprintf("POD-SUCCESS [%s] Upgrade mount pod and recreate one: %s !", pu.pod.Name, po.Name))
+					return
+				}
+			}
+		}
+		if po.Name == pu.pod.Name {
+			if resource.IsPodComplete(po) {
+				logger(fmt.Sprintf("Mount pod %s received signal and completed", pu.pod.Name))
+				return
+			}
+			if po.DeletionTimestamp != nil {
+				logger(fmt.Sprintf("Mount pod %s is deleted", pu.pod.Name))
+				return
+			}
+		}
+	}
+	_, controller := cache.NewInformerWithOptions(cache.InformerOptions{
+		ListerWatcher: watchlist,
+		ObjectType:    &corev1.Pod{},
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				handle(obj)
+			},
+			DeleteFunc: func(obj interface{}) {
+				handle(obj)
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				handle(newObj)
+			},
+		},
+	})
+	go controller.Run(stop)
+
+	for {
+		select {
+		case <-ctx.Done():
+			if len(successSum) == len(crtBatch) {
+				logger(fmt.Sprintf("CRT-BATCH-SUCCESS all pods of current batch upgrade success in node %s", nodeName))
+				return
+			}
+			for _, p := range crtBatch {
+				if u.podsStatus[p.pod.Name] != config.Success {
+					u.lock.Lock()
+					u.podsStatus[p.pod.Name] = config.Fail
+					u.lock.Unlock()
+					logger(fmt.Sprintf("POD-FAIL [%s] node may be busy, upgrade mount pod timeout, please check it later manually.", p.pod.Name))
+				}
+			}
+			logger(fmt.Sprintf("CRT-BATCH-FAIL pods of current batch upgrade timeout in node %s", nodeName))
+			return
+		default:
+			if len(successSum) == len(crtBatch) {
+				logger(fmt.Sprintf("CRT-BATCH-SUCCESS all pods of current batch upgrade success in node %s", nodeName))
+				return
+			}
+			if len(failSum) > 0 && len(failSum)+len(successSum) == len(crtBatch) {
+				logger(fmt.Sprintf("CRT-BATCH-FAIL some pods of current batch upgrade failed in node %s", nodeName))
+				return
+			}
+		}
+	}
 }
 
 func (u *BatchUpgrade) Write(p []byte) (n int, err error) {

--- a/cmd/dashboard/upgrade.go
+++ b/cmd/dashboard/upgrade.go
@@ -52,6 +52,7 @@ var upgradeCmd = &cobra.Command{
 		if sysNamespace == "" {
 			sysNamespace = "kube-system"
 		}
+		config.Namespace = sysNamespace
 		if devMode {
 			k8sconfig, _ = getLocalConfig()
 		} else {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -45,8 +45,7 @@ var upgradeCmd = &cobra.Command{
 				log.Error(err, "failed to upgrade mount pod")
 				os.Exit(1)
 			}
-		}
-		if err := grace.TriggerShutdown(config.ShutdownSockPath, name, recreate); err != nil {
+		} else if err := grace.TriggerShutdown(config.ShutdownSockPath, name, recreate); err != nil {
 			log.Error(err, "failed to upgrade mount pod")
 			os.Exit(1)
 		}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -26,7 +26,9 @@ import (
 )
 
 var (
-	recreate = false
+	recreate        = false
+	batchConfigName = ""
+	crtBatchIndex   = 1
 )
 
 var upgradeCmd = &cobra.Command{
@@ -38,6 +40,12 @@ var upgradeCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		name := args[0]
+		if name == "BATCH" {
+			if err := grace.TriggerBatchUpgrade(config.ShutdownSockPath, batchConfigName, crtBatchIndex); err != nil {
+				log.Error(err, "failed to upgrade mount pod")
+				os.Exit(1)
+			}
+		}
 		if err := grace.TriggerShutdown(config.ShutdownSockPath, name, recreate); err != nil {
 			log.Error(err, "failed to upgrade mount pod")
 			os.Exit(1)
@@ -47,4 +55,6 @@ var upgradeCmd = &cobra.Command{
 
 func init() {
 	upgradeCmd.Flags().BoolVar(&recreate, "recreate", false, "smoothly upgrade the mount pod with recreate")
+	upgradeCmd.Flags().StringVar(&batchConfigName, "batchConfig", "", "batch config name")
+	upgradeCmd.Flags().IntVar(&crtBatchIndex, "batchIndex", 1, "current batch index")
 }

--- a/dashboard-ui-v2/src/components/batch-upgrade-modal.tsx
+++ b/dashboard-ui-v2/src/components/batch-upgrade-modal.tsx
@@ -48,7 +48,7 @@ const BatchUpgradeModal: React.FC<{
   const [selectedPVCName, setSelectedPVCName] = useState('')
   const { data: selectedPVC } = usePVCsWithUniqueId(selectedPVCName)
   const [uniqueId, setUniqueId] = useState('')
-  const { data: pvcs } = usePVCs({ name: '' , pageSize: 100})
+  const { data: pvcs } = usePVCs({ name: '', pageSize: 100 })
 
   const [selectedNode, setSelectedNode] = useState('All Nodes')
   const { data: nodes } = useNodes()

--- a/dashboard-ui-v2/src/components/batch-upgrade-modal.tsx
+++ b/dashboard-ui-v2/src/components/batch-upgrade-modal.tsx
@@ -48,7 +48,7 @@ const BatchUpgradeModal: React.FC<{
   const [selectedPVCName, setSelectedPVCName] = useState('')
   const { data: selectedPVC } = usePVCsWithUniqueId(selectedPVCName)
   const [uniqueId, setUniqueId] = useState('')
-  const { data: pvcs } = usePVCs({ name: '' })
+  const { data: pvcs } = usePVCs({ name: '' , pageSize: 100})
 
   const [selectedNode, setSelectedNode] = useState('All Nodes')
   const { data: nodes } = useNodes()

--- a/dashboard-ui-v2/src/components/pod-to-upgrade-table.tsx
+++ b/dashboard-ui-v2/src/components/pod-to-upgrade-table.tsx
@@ -133,7 +133,6 @@ const PodToUpgradeTable: React.FC<{
     <>
       <Table<UpgradeType>
         className="diff-pods-table"
-        pagination={false}
         columns={upgradeColumn}
         dataSource={mountPods(batchConfig?.batches || []) || []}
       />

--- a/dashboard-ui-v2/src/components/pod-upgrade-table.tsx
+++ b/dashboard-ui-v2/src/components/pod-upgrade-table.tsx
@@ -128,19 +128,19 @@ const PodUpgradeTable: React.FC<{
         )
         return (
           <>
-            {podStatus !== 'fail' ?
+            {podStatus !== 'fail' ? (
               <Badge
                 status={getUpgradeStatusBadge(podStatus)}
                 text={podStatus}
               />
-              :
+            ) : (
               <Tooltip title={failReasons.get(podUpgrade.name) || ''}>
                 <Badge
                   status={getUpgradeStatusBadge(podStatus)}
                   text={podStatus}
                 />
               </Tooltip>
-            }
+            )}
           </>
         )
       },
@@ -155,12 +155,13 @@ const PodUpgradeTable: React.FC<{
             title={<FormattedMessage id="diff" />}
             trigger="click"
           >
-            {diffStatus.get(podDiff.name) !== 'success' ?
+            {diffStatus.get(podDiff.name) !== 'success' ? (
               <Tooltip title={<FormattedMessage id="clickToViewDetail" />}>
                 <Button icon={<DiffIcon />} />
-              </Tooltip> :
+              </Tooltip>
+            ) : (
               <Button disabled={true} icon={<DiffIcon />} />
-            }
+            )}
           </Popover>
         )
       },
@@ -184,7 +185,7 @@ const getPodUpgradeStatus = (
   statusFromLog: string,
   config?: BatchConfig,
 ): string => {
-  if (statusFromLog !== 'running') {
+  if (statusFromLog !== 'pending') {
     return statusFromLog
   }
   let status = statusFromLog

--- a/dashboard-ui-v2/src/components/upgrade-basic.tsx
+++ b/dashboard-ui-v2/src/components/upgrade-basic.tsx
@@ -199,5 +199,10 @@ const canResume = (status: string): boolean => {
 }
 
 const canDelete = (status: string): boolean => {
-  return status === 'fail' || status === 'success' || status === 'stop' || status === 'pause'
+  return (
+    status === 'fail' ||
+    status === 'success' ||
+    status === 'stop' ||
+    status === 'pause'
+  )
 }

--- a/dashboard-ui-v2/src/components/upgrade-basic.tsx
+++ b/dashboard-ui-v2/src/components/upgrade-basic.tsx
@@ -86,15 +86,17 @@ const UpgradeBasic: React.FC<{
               />
             </Tooltip>
           ) : null}
-          <Tooltip title="Delete">
-            <Button
-              onClick={() => {
-                action.execute(upgradeJob.job.metadata?.name || '')
-                window.location.href = `/jobs`
-              }}
-              icon={<DeleteIcon />}
-            />
-          </Tooltip>
+          {canDelete(status) ? (
+            <Tooltip title="Delete">
+              <Button
+                onClick={() => {
+                  action.execute(upgradeJob.job.metadata?.name || '')
+                  window.location.href = `/jobs`
+                }}
+                icon={<DeleteIcon />}
+              />
+            </Tooltip>
+          ) : null}
         </Space>
       }
     >
@@ -188,4 +190,8 @@ const canStop = (status: string): boolean => {
 
 const canResume = (status: string): boolean => {
   return status === 'pause'
+}
+
+const canDelete = (status: string): boolean => {
+  return status === 'fail' || status === 'success' || status === 'stop' || status === 'pause'
 }

--- a/dashboard-ui-v2/src/components/upgrade-basic.tsx
+++ b/dashboard-ui-v2/src/components/upgrade-basic.tsx
@@ -16,7 +16,7 @@
 
 import React, { useEffect, useState } from 'react'
 import { ProCard, ProDescriptions } from '@ant-design/pro-components'
-import { Button, Space, Tooltip } from 'antd'
+import { Button, Popconfirm, Space, Tooltip } from 'antd'
 import { Badge } from 'antd/lib'
 import { FormattedMessage } from 'react-intl'
 import { Link } from 'react-router-dom'
@@ -88,13 +88,19 @@ const UpgradeBasic: React.FC<{
           ) : null}
           {canDelete(status) ? (
             <Tooltip title="Delete">
-              <Button
-                onClick={() => {
+              <Popconfirm
+                placement="topRight"
+                title={<FormattedMessage id="deleteJob" />}
+                description={<FormattedMessage id="deleteJobDesc" />}
+                okText={<FormattedMessage id="yes" />}
+                cancelText={<FormattedMessage id="no" />}
+                onConfirm={() => {
                   action.execute(upgradeJob.job.metadata?.name || '')
                   window.location.href = `/jobs`
                 }}
-                icon={<DeleteIcon />}
-              />
+              >
+                <Button icon={<DeleteIcon />} />
+              </Popconfirm>
             </Tooltip>
           ) : null}
         </Space>

--- a/dashboard-ui-v2/src/components/upgrade-modal.tsx
+++ b/dashboard-ui-v2/src/components/upgrade-modal.tsx
@@ -57,7 +57,8 @@ const UpgradeModal: React.FC<{
       onMessage: async (msg) => {
         setData((prev) => prev + msg.data)
         if (msg.data.includes('POD-SUCCESS')) {
-          const regex = /Upgrade mount pod and recreate one: ([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*) !/
+          const regex =
+            /Upgrade mount pod and recreate one: ([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*) !/
           const match = msg.data.match(regex)
 
           if (match && match[1]) {

--- a/dashboard-ui-v2/src/locales/en-US.ts
+++ b/dashboard-ui-v2/src/locales/en-US.ts
@@ -70,7 +70,7 @@ export default {
   mountContainUidMsg:
     'Mount Pod still contain its uid，please check logs of CSI Node',
   podFinalizerMsg:
-    "There are still finalizers in the Pod. Please check the finalizer's status.",
+    'There are still finalizers in the Pod. Please check the finalizer\'s status.',
   csiNodeNullMsg:
     'CSI Node in the node did not start, please check: 1. If it is in sidecar mode, please check whether the namespace has set the required label or check the CSI Controller log to confirm why the sidecar is not injected; 2. If it is in Mount Pod mode, please check Whether CSI Node DaemonSet has been scheduled to this node.',
   csiNodeErrMsg:
@@ -148,4 +148,8 @@ export default {
   upgradeLog: 'Upgrade Log',
   jobNotFound: 'Task not found',
   inputJobName: 'Job Name',
+  deleteJob: 'Delete Task',
+  deleteJobDesc: 'Are you sure to delete this task?',
+  yes: 'Yes',
+  no: 'No',
 }

--- a/dashboard-ui-v2/src/locales/en-US.ts
+++ b/dashboard-ui-v2/src/locales/en-US.ts
@@ -70,7 +70,7 @@ export default {
   mountContainUidMsg:
     'Mount Pod still contain its uid，please check logs of CSI Node',
   podFinalizerMsg:
-    'There are still finalizers in the Pod. Please check the finalizer\'s status.',
+    "There are still finalizers in the Pod. Please check the finalizer's status.",
   csiNodeNullMsg:
     'CSI Node in the node did not start, please check: 1. If it is in sidecar mode, please check whether the namespace has set the required label or check the CSI Controller log to confirm why the sidecar is not injected; 2. If it is in Mount Pod mode, please check Whether CSI Node DaemonSet has been scheduled to this node.',
   csiNodeErrMsg:

--- a/dashboard-ui-v2/src/locales/zh-CN.ts
+++ b/dashboard-ui-v2/src/locales/zh-CN.ts
@@ -143,4 +143,8 @@ export default {
   upgradeLog: '升级日志',
   jobNotFound: '任务找不到',
   jobName: '任务名',
+  deleteJob: '删除任务',
+  deleteJobDesc: '你确定删除该任务吗？',
+  yes: '是',
+  no: '否',
 }

--- a/dashboard-ui-v2/src/pages/batch-upgrade-job-detail.tsx
+++ b/dashboard-ui-v2/src/pages/batch-upgrade-job-detail.tsx
@@ -50,6 +50,18 @@ const BatchUpgradeJobDetail: React.FC<{
     let totalPods = 0
     upgradeJob?.config?.batches?.forEach((podUpgrades) => {
       totalPods += podUpgrades?.length || 0
+      podUpgrades.forEach((mu) => {
+        setDiffStatus((prev) => new Map(prev).set(mu.name, mu.status))
+        setPercent((prev) => {
+          if (totalPods != 0) {
+            return Math.min(
+              Math.ceil(prev + (1 / totalPods) * 100),
+              100,
+            )
+          }
+          return 0
+        })
+      })
     })
     setTotal(totalPods)
     setJobStatus(upgradeJob?.config?.status || 'running')
@@ -91,17 +103,6 @@ const BatchUpgradeJobDetail: React.FC<{
       /POD-FAIL \[([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)\]/g,
       'fail',
     )
-
-    const successMatches = message.match(/POD-SUCCESS/g) || []
-    setPercent((prev) => {
-      if (total != 0) {
-        return Math.min(
-          Math.ceil(prev + (successMatches.length / total) * 100),
-          100,
-        )
-      }
-      return 0
-    })
   }
 
   const failReason = (message: string, regex: RegExp) => {

--- a/dashboard-ui-v2/src/pages/batch-upgrade-job-detail.tsx
+++ b/dashboard-ui-v2/src/pages/batch-upgrade-job-detail.tsx
@@ -51,16 +51,9 @@ const BatchUpgradeJobDetail: React.FC<{
     upgradeJob?.config?.batches?.forEach((podUpgrades) => {
       totalPods += podUpgrades?.length || 0
       podUpgrades.forEach((mu) => {
-        setDiffStatus((prev) => new Map(prev).set(mu.name, mu.status))
-        setPercent((prev) => {
-          if (totalPods != 0) {
-            return Math.min(
-              Math.ceil(prev + (1 / totalPods) * 100),
-              100,
-            )
-          }
-          return 0
-        })
+        if (mu.status !== 'pending') {
+          setDiffStatus((prev) => new Map(prev).set(mu.name, mu.status))
+        }
       })
     })
     setTotal(totalPods)
@@ -74,7 +67,8 @@ const BatchUpgradeJobDetail: React.FC<{
       updatePodStatus(msg.data)
     }
     if (msg.data.includes('POD-FAIL')) {
-      failReason(msg.data,
+      failReason(
+        msg.data,
         /POD-FAIL \[([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)\]/g,
       )
     }
@@ -103,6 +97,16 @@ const BatchUpgradeJobDetail: React.FC<{
       /POD-FAIL \[([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)\]/g,
       'fail',
     )
+    const successMatches = message.match(/POD-SUCCESS/g) || []
+    setPercent((prev) => {
+      if (total != 0) {
+        return Math.min(
+          Math.ceil(prev + (successMatches.length / total) * 100),
+          100,
+        )
+      }
+      return 0
+    })
   }
 
   const failReason = (message: string, regex: RegExp) => {

--- a/deploy/kubernetes/base/resources.yaml
+++ b/deploy/kubernetes/base/resources.yaml
@@ -205,6 +205,13 @@ rules:
     verbs:
       - get
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -33,7 +33,6 @@ const (
 	JobTypeValue           = "juicefs-job"
 	ConfigTypeValue        = "juicefs-conf"
 	JfsInsideContainer     = "JFS_INSIDE_CONTAINER"
-	MaxParallelUpgradeNum  = 50
 
 	// CSI Secret
 	ProvisionerSecretName           = "csi.storage.k8s.io/provisioner-secret-name"
@@ -85,6 +84,7 @@ const (
 	PodInfoNamespace = "csi.storage.k8s.io/pod.namespace"
 
 	// smooth upgrade
+	JfsUpgradeProcess   = "juicefs-upgrade-process"
 	JfsFuseFsPathInPod  = "/tmp"
 	JfsFuseFsPathInHost = "/var/run/juicefs-csi"
 	JfsCommEnv          = "JFS_SUPER_COMM"

--- a/pkg/config/batch_config.go
+++ b/pkg/config/batch_config.go
@@ -201,16 +201,14 @@ func UpdateUpgradeConfig(ctx context.Context, client *k8s.K8sClient, configName 
 	return cfg, client.UpdateConfigMap(ctx, cfg)
 }
 
-func GetDiff(mountPod *corev1.Pod, pvc *corev1.PersistentVolumeClaim, pv *corev1.PersistentVolume, secret, custSecret *corev1.Secret) (old *MountPodPatch, new *MountPodPatch, err error) {
-	var (
-		oldSetting *JfsSetting
-		newSetting *JfsSetting
-	)
+func GetDiff(mountPod *corev1.Pod, pvc *corev1.PersistentVolumeClaim, pv *corev1.PersistentVolume, secret, custSecret *corev1.Secret) (old *MountPodPatch, oldSetting *JfsSetting, new *MountPodPatch, newSetting *JfsSetting, err error) {
 	oldSetting, err = GenSetting(mountPod, pvc, pv, secret)
 	if err != nil {
 		return
 	}
 	old = genPatchFromSetting(*oldSetting)
+	oldSetting = oldSetting.Safe()
+
 	newSetting, err = GenSetting(mountPod, pvc, pv, secret)
 	if err != nil {
 		return
@@ -219,6 +217,7 @@ func GetDiff(mountPod *corev1.Pod, pvc *corev1.PersistentVolumeClaim, pv *corev1
 		return
 	}
 	new = genPatchFromSetting(*newSetting)
+	newSetting = newSetting.Safe()
 	return
 }
 

--- a/pkg/config/batch_config.go
+++ b/pkg/config/batch_config.go
@@ -82,6 +82,7 @@ func NewBatchConfig(pods []corev1.Pod, parallel int, ignoreError bool, recreate 
 			Name:       pod.Name,
 			Node:       pod.Spec.NodeName,
 			CSINodePod: csiNodesMap[pod.Spec.NodeName].Name,
+			Status:     Pending,
 		}
 		batches[j] = append(batches[j], mountPod)
 		index += 1

--- a/pkg/config/batch_config.go
+++ b/pkg/config/batch_config.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
@@ -117,14 +116,10 @@ func (p podList) Swap(i, j int) {
 }
 
 func LoadUpgradeConfig(ctx context.Context, client *k8s.K8sClient, configName string) (*BatchConfig, error) {
-	sysNamespace := os.Getenv("SYS_NAMESPACE")
-	if sysNamespace == "" {
-		sysNamespace = "kube-system"
-	}
 	if configName == "" {
 		return nil, fmt.Errorf("config name is empty")
 	}
-	cm, err := client.GetConfigMap(ctx, configName, sysNamespace)
+	cm, err := client.GetConfigMap(ctx, configName, Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -144,16 +139,12 @@ func LoadBatchConfig(cm *corev1.ConfigMap) (*BatchConfig, error) {
 }
 
 func CreateUpgradeConfig(ctx context.Context, client *k8s.K8sClient, configName string, config *BatchConfig) (*corev1.ConfigMap, error) {
-	sysNamespace := os.Getenv("SYS_NAMESPACE")
-	if sysNamespace == "" {
-		sysNamespace = "kube-system"
-	}
 	if configName == "" {
 		return nil, fmt.Errorf("config name is empty")
 	}
 	var cfg *corev1.ConfigMap
 	var err error
-	if cfg, err = client.GetConfigMap(ctx, configName, sysNamespace); err != nil {
+	if cfg, err = client.GetConfigMap(ctx, configName, Namespace); err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return nil, err
 		}
@@ -167,7 +158,7 @@ func CreateUpgradeConfig(ctx context.Context, client *k8s.K8sClient, configName 
 		cfg = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      configName,
-				Namespace: sysNamespace,
+				Namespace: Namespace,
 				Labels: map[string]string{
 					common.PodTypeKey: common.ConfigTypeValue,
 				},
@@ -181,16 +172,12 @@ func CreateUpgradeConfig(ctx context.Context, client *k8s.K8sClient, configName 
 }
 
 func UpdateUpgradeConfig(ctx context.Context, client *k8s.K8sClient, configName string, config *BatchConfig) (*corev1.ConfigMap, error) {
-	sysNamespace := os.Getenv("SYS_NAMESPACE")
-	if sysNamespace == "" {
-		sysNamespace = "kube-system"
-	}
 	if configName == "" {
 		return nil, fmt.Errorf("config name is empty")
 	}
 	var cfg *corev1.ConfigMap
 	var err error
-	if cfg, err = client.GetConfigMap(ctx, configName, sysNamespace); err != nil {
+	if cfg, err = client.GetConfigMap(ctx, configName, Namespace); err != nil {
 		return nil, err
 	}
 	data, err := json.Marshal(config)

--- a/pkg/config/batch_config_test.go
+++ b/pkg/config/batch_config_test.go
@@ -72,12 +72,14 @@ func TestNewBatchConfig(t *testing.T) {
 				Batches: [][]MountPodUpgrade{
 					{
 						{
-							Name: "test1",
-							Node: "node1",
+							Name:   "test1",
+							Node:   "node1",
+							Status: Pending,
 						},
 						{
-							Name: "test2",
-							Node: "node2",
+							Name:   "test2",
+							Node:   "node2",
+							Status: Pending,
 						},
 					},
 				},
@@ -132,22 +134,26 @@ func TestNewBatchConfig(t *testing.T) {
 				Batches: [][]MountPodUpgrade{
 					{
 						{
-							Name: "test11",
-							Node: "node1",
+							Name:   "test11",
+							Node:   "node1",
+							Status: Pending,
 						},
 						{
-							Name: "test12",
-							Node: "node1",
+							Name:   "test12",
+							Node:   "node1",
+							Status: Pending,
 						},
 					},
 					{
 						{
-							Name: "test13",
-							Node: "node1",
+							Name:   "test13",
+							Node:   "node1",
+							Status: Pending,
 						},
 						{
-							Name: "test21",
-							Node: "node2",
+							Name:   "test21",
+							Node:   "node2",
+							Status: Pending,
 						},
 					},
 				},
@@ -202,22 +208,26 @@ func TestNewBatchConfig(t *testing.T) {
 				Batches: [][]MountPodUpgrade{
 					{
 						{
-							Name: "test11",
-							Node: "node1",
+							Name:   "test11",
+							Node:   "node1",
+							Status: Pending,
 						},
 						{
-							Name: "test12",
-							Node: "node1",
+							Name:   "test12",
+							Node:   "node1",
+							Status: Pending,
 						},
 					},
 					{
 						{
-							Name: "test13",
-							Node: "node1",
+							Name:   "test13",
+							Node:   "node1",
+							Status: Pending,
 						},
 						{
-							Name: "test21",
-							Node: "node1",
+							Name:   "test21",
+							Node:   "node1",
+							Status: Pending,
 						},
 					},
 				},

--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -123,7 +123,6 @@ func GenAuthCmd(secrets map[string]string, setting *JfsSetting) (args []string, 
 		args = append(args, fmt.Sprintf("--conf-dir=%s", setting.ClientConfPath))
 	}
 
-	log.Info("AuthFs cmd", "args", cmdArgs)
 	return
 }
 
@@ -184,6 +183,5 @@ func GenFormatCmd(secrets map[string]string, noUpdate bool, setting *JfsSetting)
 		cmdArgs = append(cmdArgs, stripped...)
 	}
 
-	log.Info("ce format cmd", "args", cmdArgs)
 	return
 }

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -96,6 +96,38 @@ func (s *JfsSetting) String() string {
 	return string(data)
 }
 
+func (s *JfsSetting) Safe() *JfsSetting {
+	if s == nil {
+		return nil
+	}
+	sCopy := s
+	if sCopy.Token != "" {
+		sCopy.Token = "***"
+	}
+	if sCopy.SecretKey != "" {
+		sCopy.SecretKey = "***"
+	}
+	if sCopy.SecretKey2 != "" {
+		sCopy.SecretKey2 = "***"
+	}
+	if sCopy.Passphrase != "" {
+		sCopy.Passphrase = "***"
+	}
+	if sCopy.EncryptRsaKey != "" {
+		sCopy.EncryptRsaKey = "***"
+	}
+	return sCopy
+}
+
+func (s *JfsSetting) SafeString() string {
+	if s == nil {
+		return ""
+	}
+	sCopy := s.Safe()
+	data, _ := json.Marshal(sCopy)
+	return string(data)
+}
+
 func (s *JfsSetting) Load(str string) error {
 	return json.Unmarshal([]byte(str), s)
 }
@@ -1074,6 +1106,6 @@ func GenHashOfSetting(log klog.Logger, setting JfsSetting) string {
 	h := sha256.New()
 	h.Write(settingStr)
 	val := hex.EncodeToString(h.Sum(nil))[:63]
-	log.V(1).Info("get jfsSetting hash", "hashVal", val, "setting", setting)
+	log.V(1).Info("get jfsSetting hash", "hashVal", val, "setting", setting.SafeString())
 	return val
 }

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -727,6 +727,7 @@ func ApplySettingWithMountPod(mountPod *corev1.Pod, pvc *corev1.PersistentVolume
 				setting.Envs = custSetting.Envs
 			}
 			setting.CustomerSecret = custSecret
+			setting.ClientConfPath = DefaultClientConfPath
 			if !setting.IsCe {
 				if setting.Token == "" {
 					log.Info("token is empty, skip authfs.")

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -565,7 +565,7 @@ func GenSettingAttrWithMountPod(ctx context.Context, client *k8sclient.K8sClient
 	if err != nil {
 		log.Error(err, "Get pv error", "pv", pvName)
 	}
-	if pv != nil {
+	if pv != nil && pv.Spec.ClaimRef != nil {
 		pvc, err = client.GetPersistentVolumeClaim(ctx, pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace)
 		if err != nil {
 			log.Error(err, "Get pvc error", "namespace", pv.Spec.ClaimRef.Namespace, "name", pv.Spec.ClaimRef.Name)
@@ -1106,6 +1106,5 @@ func GenHashOfSetting(log klog.Logger, setting JfsSetting) string {
 	h := sha256.New()
 	h.Write(settingStr)
 	val := hex.EncodeToString(h.Sum(nil))[:63]
-	log.V(1).Info("get jfsSetting hash", "hashVal", val, "setting", setting.SafeString())
 	return val
 }

--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -858,10 +858,12 @@ func (p *PodDriver) applyConfigPatch(ctx context.Context, pod *corev1.Pod) error
 		newPod.Spec.NodeSelector = pod.Spec.NodeSelector
 		pod.Spec = newPod.Spec
 		pod.ObjectMeta = newPod.ObjectMeta
-		// update secret
-		secret := podBuilder.NewSecret()
-		if err := resource.CreateOrUpdateSecret(ctx, p.Client, &secret); err != nil {
-			return err
+		if setting.HashVal != pod.Labels[common.PodJuiceHashLabelKey] {
+			// update secret
+			secret := podBuilder.NewSecret()
+			if err := resource.CreateOrUpdateSecret(ctx, p.Client, &secret); err != nil {
+				return err
+			}
 		}
 		return nil
 	}

--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -1019,7 +1019,9 @@ func (p *PodDriver) getAvailableMountPod(ctx context.Context, uniqueId, upgradeU
 	// check pods in which get from kubelet
 	for _, u := range p.uniqueIdIndex[uniqueId] {
 		if u.upgradeUUID == upgradeUUID {
-			return u.status != podDeleted && u.status != podComplete
+			if u.status != podDeleted && u.status != podComplete {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -143,7 +143,7 @@ func doReconcile(ks *k8sclient.K8sClient, kc *k8sclient.KubeletClient) {
 					lastStatus.syncAt = time.Now()
 					if err != nil {
 						reconcilerLog.Error(err, "Driver check pod error, will retry", "name", pod.Name)
-						if strings.Contains(err.Error(), "client rate limiter Wait returned an error: context canceled") {
+						if strings.Contains(err.Error(), "client rate limiter Wait returned an error") {
 							reconcilerLog.V(1).Info("client rate limit")
 							backOff.Next(backOffID, time.Now())
 						} else {

--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	retryPeriod    = 5 * time.Second
-	maxRetryPeriod = 300 * time.Second
+	maxRetryPeriod = 60 * time.Second
 )
 
 var (

--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -119,6 +119,7 @@ func doReconcile(ks *k8sclient.K8sClient, kc *k8sclient.KubeletClient) {
 
 			backOffID := fmt.Sprintf("mountpod/%s", pod.Name)
 			if backOff.IsInBackOffSinceUpdate(backOffID, backOff.Clock.Now()) {
+				reconcilerLog.V(1).Info("in backoff, retry later", "name", pod.Name)
 				continue
 			}
 			g.Go(func() error {

--- a/pkg/dashboard/batch.go
+++ b/pkg/dashboard/batch.go
@@ -438,7 +438,7 @@ func newUpgradeJob(jobName string) *batchv1.Job {
 			Parallelism:             util.ToPtr(int32(1)),
 			Completions:             util.ToPtr(int32(1)),
 			BackoffLimit:            util.ToPtr(int32(0)),
-			TTLSecondsAfterFinished: util.ToPtr(int32(3600 * 24)), // automatically deleted after 1 day
+			TTLSecondsAfterFinished: util.ToPtr(int32(3600 * 24 * 7)), // automatically deleted after 7 day
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -582,7 +582,7 @@ func (api *API) genPodDiffs(ctx context.Context, mountPods []corev1.Pod, shouldD
 }
 
 func GenUpgradeJobName() string {
-	return fmt.Sprintf("juicefs-upgrade-job-%s", util.RandStringRunes(6))
+	return fmt.Sprintf("jfs-upgrade-job-%s", util.RandStringRunes(6))
 }
 
 func GenUpgradeConfig(jobName string) string {

--- a/pkg/dashboard/cm.go
+++ b/pkg/dashboard/cm.go
@@ -104,7 +104,8 @@ func (api *API) getCSIConfigDiff() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		nodeName := c.Query("nodeName")
 		uniqueId := c.Query("uniqueId")
-		_, podDiffs, err := api.getUpgradePods(c, uniqueId, nodeName, true)
+		debug := c.Query("debug")
+		_, podDiffs, err := api.getUpgradePods(c, uniqueId, nodeName, true, debug == "true")
 		if err != nil {
 			c.String(500, "get upgrade pods error %v", err)
 			return

--- a/pkg/dashboard/utils.go
+++ b/pkg/dashboard/utils.go
@@ -18,7 +18,6 @@ package dashboard
 
 import (
 	"context"
-	"os"
 	"regexp"
 	"sort"
 
@@ -141,14 +140,6 @@ func LabelSelectorOfMount(pv corev1.PersistentVolume) labels.Selector {
 	}
 	labelMap, _ := metav1.LabelSelectorAsSelector(&sl)
 	return labelMap
-}
-
-func getSysNamespace() string {
-	namespace := "kube-system"
-	if os.Getenv("SYS_NAMESPACE") != "" {
-		namespace = os.Getenv("SYS_NAMESPACE")
-	}
-	return namespace
 }
 
 func isShareMount(pod *corev1.Pod) bool {

--- a/pkg/fuse/grace/batch.go
+++ b/pkg/fuse/grace/batch.go
@@ -149,7 +149,7 @@ func (u *BatchUpgrade) BatchUpgrade(ctx context.Context, conn net.Conn) {
 				u.failSum[p.pod.Name] = true
 				u.lock.Unlock()
 				sendMessage(conn, fmt.Sprintf("pod [%s] upgrade pod error", p.pod.Name))
-				if e := resource.DelPodAnnotation(ctx, u.client, p.pod, []string{common.JfsUpgradeProcess}); e != nil {
+				if e := resource.DelPodAnnotation(ctx, u.client, p.pod.Name, p.pod.Namespace, []string{common.JfsUpgradeProcess}); e != nil {
 					sendMessage(conn, fmt.Sprintf("WARNING delete annotation uprgadeProcess in [%s] error: %s.", p.pod.Name, e.Error()))
 				}
 				return

--- a/pkg/fuse/grace/batch.go
+++ b/pkg/fuse/grace/batch.go
@@ -229,8 +229,12 @@ func (u *BatchUpgrade) waitForUpgrade(ctx context.Context, conn net.Conn) {
 			sendMessage(conn, fmt.Sprintf("CRT-BATCH-FAIL pods of current batch upgrade timeout in node %s", config.NodeName))
 			return
 		default:
-			if u.successSum+u.failSum == len(u.podsToUpgrade) {
+			if u.successSum == len(u.podsToUpgrade) {
 				sendMessage(conn, fmt.Sprintf("CRT-BATCH-SUCCESS all pods of current batch upgrade success in node %s", config.NodeName))
+				return
+			}
+			if u.failSum > 0 && u.failSum+u.successSum == len(u.podsToUpgrade) {
+				sendMessage(conn, fmt.Sprintf("CRT-BATCH-FAIL some pods of current batch upgrade failed in node %s", config.NodeName))
 				return
 			}
 		}

--- a/pkg/fuse/grace/batch.go
+++ b/pkg/fuse/grace/batch.go
@@ -127,7 +127,7 @@ func (u *BatchUpgrade) fetchPods(ctx context.Context, conn net.Conn) error {
 func (u *BatchUpgrade) BatchUpgrade(ctx context.Context, conn net.Conn) {
 	if err := u.fetchPods(ctx, conn); err != nil {
 		log.Error(err, "fetch pods error", "config", u.batchConfigName)
-		sendMessage(conn, fmt.Sprintf("CRT-BATCH-FAIL fetch pods error: %s", err.Error()))
+		sendMessage(conn, fmt.Sprintf("CRT-BATCH-FAIL fetch pods in node %s error: %s", config.NodeName, err.Error()))
 		return
 	}
 	var (

--- a/pkg/fuse/grace/batch.go
+++ b/pkg/fuse/grace/batch.go
@@ -195,7 +195,7 @@ func (u *BatchUpgrade) waitForUpgrade(ctx context.Context, conn net.Conn) {
 		}
 		var pu *PodUpgrade
 		for _, p := range u.podsToUpgrade {
-			if p.pod.Name == po.Name {
+			if p.pod.Labels[common.PodUpgradeUUIDLabelKey] == po.Labels[common.PodUpgradeUUIDLabelKey] {
 				pu = p
 				break
 			}

--- a/pkg/fuse/grace/batch.go
+++ b/pkg/fuse/grace/batch.go
@@ -1,0 +1,265 @@
+/*
+ Copyright 2024 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package grace
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/common"
+	"github.com/juicedata/juicefs-csi-driver/pkg/config"
+	k8s "github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+	"github.com/juicedata/juicefs-csi-driver/pkg/util"
+	"github.com/juicedata/juicefs-csi-driver/pkg/util/resource"
+)
+
+type BatchUpgrade struct {
+	batchConfigName string
+	batchConfig     *config.BatchConfig
+	crtBatchIndex   int
+	client          *k8s.K8sClient
+	recreate        bool
+
+	// batch
+	podsToUpgrade map[string]*PodUpgrade
+	successSum    int
+	failSum       int
+}
+
+func NewBatchUpgrade(client *k8s.K8sClient, req upgradeRequest) *BatchUpgrade {
+	return &BatchUpgrade{
+		client:          client,
+		recreate:        true,
+		batchConfigName: req.configName,
+		crtBatchIndex:   req.batchIndex,
+		podsToUpgrade:   map[string]*PodUpgrade{},
+	}
+}
+
+func (u *BatchUpgrade) fetchPods(ctx context.Context) error {
+	batchConfig, err := config.LoadUpgradeConfig(ctx, u.client, u.batchConfigName)
+	if err != nil {
+		return err
+	}
+	u.batchConfig = batchConfig
+	labelSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			common.PodTypeKey: common.PodTypeValue,
+		},
+	}
+	fieldSelector := &fields.Set{"spec.nodeName": config.NodeName}
+	podLists, err := u.client.ListPod(ctx, config.Namespace, labelSelector, fieldSelector)
+	if err != nil {
+		log.Error(err, "reconcile ListPod error")
+		return err
+	}
+	u.podsToUpgrade = make(map[string]*PodUpgrade)
+	podNames := make(map[string]bool)
+	for _, batch := range batchConfig.Batches[u.crtBatchIndex-1] {
+		if batch.Node == config.NodeName {
+			podNames[batch.Name] = true
+		}
+	}
+	for _, pod := range podLists {
+		po := pod
+		if _, ok := podNames[po.Name]; !ok {
+			continue
+		}
+		canUpgrade, reason, err := resource.CanUpgradeWithHash(ctx, u.client, po, u.recreate)
+		if err != nil || !canUpgrade {
+			log.Info("pod can not upgrade, ignore", "pod", pod.Name, "err", err, "reason", reason)
+			continue
+		}
+		ce := util.ContainSubString(pod.Spec.Containers[0].Command, "metaurl")
+		pu := &PodUpgrade{
+			client:      u.client,
+			pod:         &po,
+			recreate:    true,
+			ce:          ce,
+			hashVal:     pod.Labels[common.PodJuiceHashLabelKey],
+			upgradeUUID: resource.GetUpgradeUUID(&po),
+			status:      config.Running,
+		}
+		u.podsToUpgrade[po.Labels[common.PodUpgradeUUIDLabelKey]] = pu
+	}
+
+	podNameStrs := []string{}
+	for _, pu := range u.podsToUpgrade {
+		name := pu.pod.Name
+		podNameStrs = append(podNameStrs, name)
+	}
+	log.Info("pods to upgrade", "pods", strings.Join(podNameStrs, ", "))
+	return nil
+}
+
+func (u *BatchUpgrade) BatchUpgrade(ctx context.Context, conn net.Conn) {
+	if err := u.fetchPods(ctx); err != nil {
+		return
+	}
+	var (
+		wg sync.WaitGroup
+	)
+
+	ctx, canF := context.WithCancel(ctx)
+	defer canF()
+
+	for _, p := range u.podsToUpgrade {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sendMessage(conn, fmt.Sprintf("POD-START [%s] start to upgrade", p.pod.Name))
+			if err := p.gracefulShutdown(ctx, conn); err != nil {
+				log.Error(err, "upgrade pod error", "pod", p.pod.Name)
+				p.status = config.Fail
+				u.failSum++
+				return
+			}
+		}()
+	}
+	wg.Wait()
+
+	u.waitForUpgrade(ctx, conn)
+}
+
+func (u *BatchUpgrade) waitForUpgrade(ctx context.Context, conn net.Conn) {
+	ctx, cancel := context.WithTimeout(ctx, 3600*time.Second)
+	defer cancel()
+
+	labelSelector, _ := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			common.PodTypeKey: common.PodTypeValue,
+		},
+	})
+	fieldSelector := fields.Set{
+		"spec.nodeName": config.NodeName,
+	}
+
+	stop := make(chan struct{})
+	defer func() {
+		close(stop)
+	}()
+	watchlist := cache.NewFilteredListWatchFromClient(
+		u.client.CoreV1().RESTClient(),
+		"pods",
+		config.Namespace,
+		func(options *metav1.ListOptions) {
+			options.FieldSelector = fieldSelector.String()
+			options.LabelSelector = labelSelector.String()
+		},
+	)
+	handle := func(obj interface{}) {
+		po, ok := obj.(*corev1.Pod)
+		if !ok {
+			return
+		}
+		pu := u.podsToUpgrade[po.Labels[common.PodUpgradeUUIDLabelKey]]
+		if pu == nil {
+			return
+		}
+		if po.Name != pu.pod.Name {
+			if po.DeletionTimestamp == nil && !resource.IsPodComplete(po) {
+				if resource.IsPodReady(po) {
+					sendMessage(conn, fmt.Sprintf("POD-SUCCESS [%s] Upgrade mount pod and recreate one: %s !", pu.pod.Name, po.Name))
+					pu.status = config.Success
+					u.successSum++
+					return
+				}
+			}
+		}
+		if po.Name == pu.pod.Name {
+			if resource.IsPodComplete(po) {
+				sendMessage(conn, fmt.Sprintf("Mount pod %s received signal and completed", pu.pod.Name))
+				return
+			}
+			if po.DeletionTimestamp != nil {
+				sendMessage(conn, fmt.Sprintf("Mount pod %s is deleted", pu.pod.Name))
+				return
+			}
+		}
+	}
+	_, controller := cache.NewInformerWithOptions(cache.InformerOptions{
+		ListerWatcher: watchlist,
+		ObjectType:    &corev1.Pod{},
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				handle(obj)
+			},
+			DeleteFunc: func(obj interface{}) {
+				handle(obj)
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				handle(newObj)
+			},
+		},
+	})
+	go controller.Run(stop)
+
+	for {
+		select {
+		case <-ctx.Done():
+			for _, p := range u.podsToUpgrade {
+				if p.status != config.Success {
+					sendMessage(conn, fmt.Sprintf("POD-FAIL [%s] node may be busy, upgrade mount pod timeout, please check it later manually.", p.pod.Name))
+				}
+			}
+			sendMessage(conn, fmt.Sprintf("CRT-BATCH-FAIL pods of current batch upgrade timeout in node %s", config.NodeName))
+			return
+		default:
+			if u.successSum+u.failSum == len(u.podsToUpgrade) {
+				sendMessage(conn, fmt.Sprintf("CRT-BATCH-SUCCESS all pods of current batch upgrade success in node %s", config.NodeName))
+				return
+			}
+		}
+	}
+}
+
+func TriggerBatchUpgrade(socketPath string, batchConfigName string, batchIndex int) error {
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		log.Error(err, "error connecting to socket")
+		return err
+	}
+	var message string
+	message = fmt.Sprintf("BATCH %s batchConfig=%s,batchIndex=%d", recreate, batchConfigName, batchIndex)
+
+	_, err = conn.Write([]byte(message))
+	if err != nil {
+		log.Error(err, "error sending message")
+		return err
+	}
+
+	scanner := bufio.NewScanner(conn)
+	for scanner.Scan() {
+		message = scanner.Text()
+		fmt.Printf("%s %s\n", time.Now().Format("2006-01-02 15:04:05"), message)
+		if strings.HasPrefix(message, "CRT-BATCH") {
+			break
+		}
+	}
+
+	return scanner.Err()
+}

--- a/pkg/fuse/grace/batch.go
+++ b/pkg/fuse/grace/batch.go
@@ -140,7 +140,7 @@ func (u *BatchUpgrade) BatchUpgrade(ctx context.Context, conn net.Conn) {
 		go func() {
 			defer wg.Done()
 			sendMessage(conn, fmt.Sprintf("POD-START [%s] start to upgrade", p.pod.Name))
-			if err := p.gracefulShutdown(ctx, conn); err != nil && u.failSum[p.pod.Name] != true {
+			if err := p.gracefulShutdown(ctx, conn); err != nil && !u.failSum[p.pod.Name] {
 				log.Error(err, "upgrade pod error", "pod", p.pod.Name)
 				p.status = config.Fail
 				u.lock.Lock()
@@ -197,7 +197,7 @@ func (u *BatchUpgrade) waitForUpgrade(ctx context.Context, conn net.Conn) {
 		}
 		if po.Name != pu.pod.Name {
 			if po.DeletionTimestamp == nil && !resource.IsPodComplete(po) {
-				if resource.IsPodReady(po) && u.successSum[pu.pod.Name] != true {
+				if resource.IsPodReady(po) && !u.successSum[pu.pod.Name] {
 					pu.status = config.Success
 					u.lock.Lock()
 					u.successSum[pu.pod.Name] = true

--- a/pkg/fuse/grace/batch.go
+++ b/pkg/fuse/grace/batch.go
@@ -174,6 +174,7 @@ func (u *BatchUpgrade) waitForUpgrade(ctx context.Context, conn net.Conn) {
 		"pods",
 		config.Namespace,
 		func(options *metav1.ListOptions) {
+			options.ResourceVersion = "0"
 			options.FieldSelector = fieldSelector.String()
 			options.LabelSelector = labelSelector.String()
 		},

--- a/pkg/fuse/grace/batch.go
+++ b/pkg/fuse/grace/batch.go
@@ -126,6 +126,8 @@ func (u *BatchUpgrade) fetchPods(ctx context.Context, conn net.Conn) error {
 
 func (u *BatchUpgrade) BatchUpgrade(ctx context.Context, conn net.Conn) {
 	if err := u.fetchPods(ctx, conn); err != nil {
+		log.Error(err, "fetch pods error", "config", u.batchConfigName)
+		sendMessage(conn, fmt.Sprintf("CRT-BATCH-FAIL fetch pods error: %s", err.Error()))
 		return
 	}
 	var (

--- a/pkg/fuse/grace/grace.go
+++ b/pkg/fuse/grace/grace.go
@@ -411,6 +411,7 @@ func (p *PodUpgrade) waitForUpgrade(ctx context.Context, conn net.Conn) {
 		"pods",
 		p.pod.Namespace,
 		func(options *metav1.ListOptions) {
+			options.ResourceVersion = "0"
 			options.FieldSelector = fieldSelector.String()
 			options.LabelSelector = labelSelector.String()
 		},

--- a/pkg/fuse/grace/grace.go
+++ b/pkg/fuse/grace/grace.go
@@ -284,7 +284,7 @@ func (p *PodUpgrade) sighup(ctx context.Context, conn net.Conn, jfsConf *util.Ju
 }
 
 func (p *PodUpgrade) isInUpgradeProcess() bool {
-	if p.pod.Annotations == nil {
+	if p.pod.Annotations == nil || p.pod.Annotations[common.JfsUpgradeProcess] == "" {
 		return false
 	}
 	t, err := time.Parse(time.DateTime, p.pod.Annotations[common.JfsUpgradeProcess])

--- a/pkg/fuse/grace/grace.go
+++ b/pkg/fuse/grace/grace.go
@@ -177,7 +177,7 @@ func SinglePodUpgrade(ctx context.Context, client *k8s.K8sClient, name string, r
 	if err := pu.gracefulShutdown(ctx, conn); err != nil {
 		log.Error(err, "graceful shutdown error")
 		if pu.recreate {
-			if e := resource.DelPodAnnotation(ctx, client, pu.pod, []string{common.JfsUpgradeProcess}); e != nil {
+			if e := resource.DelPodAnnotation(ctx, client, pu.pod.Name, pu.pod.Namespace, []string{common.JfsUpgradeProcess}); e != nil {
 				sendMessage(conn, fmt.Sprintf("WARNING delete annotation uprgadeProcess in [%s] error: %s.", pu.pod.Name, e.Error()))
 				return
 			}
@@ -341,7 +341,7 @@ func (p *PodUpgrade) prepareShutdown(ctx context.Context, conn net.Conn) (*util.
 	sendMessage(conn, fmt.Sprintf("canary job of mount pod %s completed", p.pod.Name))
 
 	if p.recreate {
-		if err := resource.AddPodAnnotation(ctx, p.client, p.pod, map[string]string{common.JfsUpgradeProcess: time.Now().Format(time.DateTime)}); err != nil {
+		if err := resource.AddPodAnnotation(ctx, p.client, p.pod.Name, p.pod.Namespace, map[string]string{common.JfsUpgradeProcess: time.Now().Format(time.DateTime)}); err != nil {
 			sendMessage(conn, fmt.Sprintf("POD-FAIL [%s] %s.", p.pod.Name, err.Error()))
 			return nil, err
 		}

--- a/pkg/fuse/grace/grace_test.go
+++ b/pkg/fuse/grace/grace_test.go
@@ -17,6 +17,7 @@
 package grace
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -48,6 +49,18 @@ func Test_parseRequest(t *testing.T) {
 			want: upgradeRequest{
 				action: noRecreate,
 				name:   "juicefs-xxxx",
+			},
+		},
+		{
+			name: "batch",
+			args: args{
+				message: fmt.Sprintf("BATCH %s batchConfig=test,batchIndex=1", recreate),
+			},
+			want: upgradeRequest{
+				action:     recreate,
+				name:       "BATCH",
+				configName: "test",
+				batchIndex: 1,
 			},
 		},
 	}

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -618,6 +618,7 @@ func (j *juicefs) AuthFs(ctx context.Context, secrets map[string]string, setting
 		return "", err
 	}
 
+	log.Info("AuthFs cmd", "args", cmdArgs)
 	// only run command when in process mode
 	if !force && !config.ByProcess {
 		cmd := strings.Join(cmdArgs, " ")
@@ -799,6 +800,7 @@ func (j *juicefs) ceFormat(ctx context.Context, secrets map[string]string, noUpd
 		return "", err
 	}
 
+	log.Info("ce format cmd", "args", cmdArgs)
 	// only run command when in process mode
 	if !config.ByProcess {
 		cmd := strings.Join(cmdArgs, " ")

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -316,7 +316,7 @@ func (p *PodMount) genMountPodName(ctx context.Context, jfsSetting *jfsConfig.Jf
 		if pod.Spec.NodeName != jfsConfig.NodeName && pod.Spec.NodeSelector["kubernetes.io/hostname"] != jfsConfig.NodeName {
 			continue
 		}
-		if po.Labels[common.PodJuiceHashLabelKey] != jfsSetting.HashVal {
+		if po.Labels[common.PodJuiceHashLabelKey] != jfsSetting.HashVal || po.DeletionTimestamp != nil || resource.IsPodComplete(&po) {
 			for k, v := range po.Annotations {
 				if v == jfsSetting.TargetPath {
 					log.Info("Found pod with same target path, delete the reference", "podName", pod.Name, "targetPath", jfsSetting.TargetPath)
@@ -325,9 +325,6 @@ func (p *PodMount) genMountPodName(ctx context.Context, jfsSetting *jfsConfig.Jf
 					}
 				}
 			}
-			continue
-		}
-		if po.DeletionTimestamp != nil || resource.IsPodComplete(&po) {
 			continue
 		}
 		podName = pod.Name

--- a/pkg/util/resource/pod.go
+++ b/pkg/util/resource/pod.go
@@ -521,7 +521,7 @@ func CanUpgrade(pod corev1.Pod, recreate bool) (bool, string, error) {
 	}
 
 	// check prestop hook
-	if pod.Spec.Containers[0].Lifecycle.PreStop.Exec != nil {
+	if pod.Spec.Containers[0].Lifecycle != nil && pod.Spec.Containers[0].Lifecycle.PreStop != nil && pod.Spec.Containers[0].Lifecycle.PreStop.Exec != nil {
 		prestopCmd := pod.Spec.Containers[0].Lifecycle.PreStop.Exec.Command
 		for _, cmd := range prestopCmd {
 			if strings.Contains(cmd, "umount") {


### PR DESCRIPTION
1. trigger batch upgrade in one csi node once at one time
2. dashboard: add pagination of pods in upgrade job
3. dashboard: show fail reason of each pod if it upgrade failed
4. users can delete job only when the status is pause/stop/fail/success
5. use the same backoff when meeting apiserver rate limit
6. check if mount pod has `umount` in prestop before upgrade

close https://github.com/juicedata/juicefs-csi-driver/issues/1214
close https://github.com/juicedata/juicefs-csi-driver/issues/1152