### PR TITLE
avoid to umount -l if not delete mount pod

### DIFF
--- a/pkg/controller/pod_driver_test.go
+++ b/pkg/controller/pod_driver_test.go
@@ -651,7 +651,7 @@ func TestPodDriver_podReadyHandler(t *testing.T) {
 			}
 			patch1 := ApplyFuncSeq(os.Stat, outputs)
 			defer patch1.Reset()
-			patch2 := ApplyFunc(util.UmountPath, func(ctx context.Context, sourcePath string) {})
+			patch2 := ApplyFunc(util.UmountPath, func(ctx context.Context, sourcePath string, lazy bool) {})
 			defer patch2.Reset()
 			_, err := d.podReadyHandler(context.Background(), readyPod)
 			So(err, ShouldNotBeNil)

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -496,9 +496,11 @@ func TestNodeUnpublishVolume(t *testing.T) {
 
 			mockCtl := gomock.NewController(t)
 			defer mockCtl.Finish()
+			log := klog.NewKlogr().WithName("NodeUnpublishVolume")
+			ctxWithLog := util.WithLog(context.TODO(), log)
 
 			mockJuicefs := mocks.NewMockInterface(mockCtl)
-			mockJuicefs.EXPECT().JfsUnmount(context.TODO(), volumeId, targetPath).Return(nil)
+			mockJuicefs.EXPECT().JfsUnmount(ctxWithLog, volumeId, targetPath).Return(nil)
 
 			juicefsDriver := &nodeService{
 				juicefs:   mockJuicefs,
@@ -527,9 +529,11 @@ func TestNodeUnpublishVolume(t *testing.T) {
 			defer patch.Reset()
 			mockCtl := gomock.NewController(t)
 			defer mockCtl.Finish()
+			log := klog.NewKlogr().WithName("NodeUnpublishVolume")
+			ctxWithLog := util.WithLog(context.TODO(), log)
 
 			mockJuicefs := mocks.NewMockInterface(mockCtl)
-			mockJuicefs.EXPECT().JfsUnmount(context.TODO(), volumeId, targetPath).Return(errors.New("test"))
+			mockJuicefs.EXPECT().JfsUnmount(ctxWithLog, volumeId, targetPath).Return(errors.New("test"))
 
 			juicefsDriver := &nodeService{
 				juicefs:   mockJuicefs,

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -172,7 +172,7 @@ func (fs *jfs) BindTarget(ctx context.Context, bindSource, target string) error 
 		// target is bind by other path, umount it
 		log.Info("target bind mount to other path, umount it", "target", target)
 		_ = util.DoWithTimeout(ctx, defaultCheckTimeout, func() error {
-			util.UmountPath(ctx, target)
+			util.UmountPath(ctx, target, false)
 			return nil
 		})
 	}
@@ -592,7 +592,7 @@ func (j *juicefs) CreateTarget(ctx context.Context, target string) error {
 		} else if corruptedMnt = mount.IsCorruptedMnt(err); corruptedMnt {
 			// if target is a corrupted mount, umount it
 			_ = util.DoWithTimeout(ctx, defaultCheckTimeout, func() error {
-				util.UmountPath(ctx, target)
+				util.UmountPath(ctx, target, false)
 				return nil
 			})
 			continue

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -114,7 +114,7 @@ func (p *PodMount) JMount(ctx context.Context, appInfo *jfsConfig.AppInfo, jfsSe
 }
 
 func (p *PodMount) GetMountRef(ctx context.Context, target, podName string) (int, error) {
-	log := util.GenLog(ctx, p.log, "")
+	log := util.GenLog(ctx, p.log, "GetMountRef")
 	pod, err := p.K8sClient.GetPod(ctx, podName, jfsConfig.Namespace)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -267,7 +267,7 @@ func (p *PodMount) JCreateVolume(ctx context.Context, jfsSetting *jfsConfig.JfsS
 }
 
 func (p *PodMount) JDeleteVolume(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) error {
-	log := p.log.WithName("JDeleteVolume")
+	log := util.GenLog(ctx, p.log, "JDeleteVolume")
 	var exist *batchv1.Job
 	r := builder.NewJobBuilder(jfsSetting, 0)
 	job := r.NewJobForDeleteVolume()
@@ -336,7 +336,7 @@ func (p *PodMount) genMountPodName(ctx context.Context, jfsSetting *jfsConfig.Jf
 }
 
 func (p *PodMount) createOrAddRef(ctx context.Context, podName string, jfsSetting *jfsConfig.JfsSetting, appinfo *jfsConfig.AppInfo) (err error) {
-	log := p.log.WithName("createOrAddRef")
+	log := util.GenLog(ctx, p.log, "createOrAddRef")
 	log.V(1).Info("mount pod", "podName", podName)
 	jfsSetting.MountPath = jfsSetting.MountPath + podName[len(podName)-7:]
 	jfsSetting.SecretName = fmt.Sprintf("juicefs-%s-secret", jfsSetting.UniqueId)
@@ -438,7 +438,7 @@ func (p *PodMount) createOrAddRef(ctx context.Context, podName string, jfsSettin
 }
 
 func (p *PodMount) waitUtilMountReady(ctx context.Context, jfsSetting *jfsConfig.JfsSetting, podName string) error {
-	logger := util.GenLog(ctx, p.log, "")
+	logger := util.GenLog(ctx, p.log, "waitUtilMountReady")
 	err := resource.WaitUtilMountReady(ctx, podName, jfsSetting.MountPath, defaultCheckTimeout)
 	if err == nil {
 		return nil
@@ -453,7 +453,7 @@ func (p *PodMount) waitUtilMountReady(ctx context.Context, jfsSetting *jfsConfig
 }
 
 func (p *PodMount) waitUtilJobCompleted(ctx context.Context, jobName string) error {
-	log := p.log.WithName("waitUtilJobCompleted")
+	log := util.GenLog(ctx, p.log, "waitUtilJobCompleted")
 	// Wait until the job is completed
 	waitCtx, waitCancel := context.WithTimeout(ctx, 40*time.Second)
 	defer waitCancel()
@@ -500,7 +500,7 @@ func (p *PodMount) waitUtilJobCompleted(ctx context.Context, jobName string) err
 }
 
 func (p *PodMount) AddRefOfMount(ctx context.Context, target string, podName string) error {
-	log := p.log.WithName("AddRefOfMount")
+	log := util.GenLog(ctx, p.log, "AddRefOfMount")
 	log.Info("Add target ref in mount pod.", "podName", podName, "target", target)
 	// add volumeId ref in pod annotation
 	key := util.GetReferenceKey(target)
@@ -551,7 +551,7 @@ func (p *PodMount) setMountLabel(ctx context.Context, uniqueId, mountPodName str
 
 // GetJfsVolUUID get UUID from result of `juicefs status <volumeName>`
 func (p *PodMount) GetJfsVolUUID(ctx context.Context, jfsSetting *jfsConfig.JfsSetting) (string, error) {
-	log := util.GenLog(ctx, p.log, "")
+	log := util.GenLog(ctx, p.log, "GetJfsVolUUID")
 	cmdCtx, cmdCancel := context.WithTimeout(ctx, 8*defaultCheckTimeout)
 	defer cmdCancel()
 	statusCmd := p.Exec.CommandContext(cmdCtx, jfsConfig.CeCliPath, "status", jfsSetting.Source)
@@ -582,7 +582,7 @@ func (p *PodMount) GetJfsVolUUID(ctx context.Context, jfsSetting *jfsConfig.JfsS
 }
 
 func (p *PodMount) CleanCache(ctx context.Context, image string, id string, volumeId string, cacheDirs []string) error {
-	log := p.log.WithName("CleanCache")
+	log := util.GenLog(ctx, p.log, "CleanCache")
 	jfsSetting, err := jfsConfig.ParseSetting(map[string]string{"name": id}, nil, []string{}, true, nil, nil)
 	if err != nil {
 		log.Error(err, "parse jfs setting err")

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -443,21 +443,6 @@ func (p *PodMount) waitUtilMountReady(ctx context.Context, jfsSetting *jfsConfig
 	if err == nil {
 		return nil
 	}
-	pod, err := p.K8sClient.GetPod(ctx, podName, jfsConfig.Namespace)
-	if err != nil {
-		return err
-	}
-	if util.SupportFusePass(jfsSetting.Attr.Image) {
-		logger.Error(err, "pod is not ready within 60s")
-		// mount pod hang probably, close fd
-		logger.Info("close fuse fd")
-		passfd.GlobalFds.CloseFd(pod)
-		// umount it
-		_ = util.DoWithTimeout(ctx, defaultCheckTimeout, func() error {
-			util.UmountPath(ctx, jfsSetting.MountPath)
-			return nil
-		})
-	}
 	// mountpoint not ready, get mount pod log for detail
 	log, err := p.getErrContainerLog(ctx, podName)
 	if err != nil {

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -33,6 +33,7 @@ func WithLog(parentCtx context.Context, log klog.Logger) context.Context {
 func GenLog(ctx context.Context, log klog.Logger, name string) klog.Logger {
 	if ctx.Value(LoggerType(LogKey)) != nil {
 		log = ctx.Value(LoggerType(LogKey)).(klog.Logger)
+		return log
 	}
 	if name != "" {
 		log = log.WithName(name)

--- a/pkg/util/resource/secret.go
+++ b/pkg/util/resource/secret.go
@@ -26,10 +26,11 @@ import (
 
 	jfsConfig "github.com/juicedata/juicefs-csi-driver/pkg/config"
 	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+	"github.com/juicedata/juicefs-csi-driver/pkg/util"
 )
 
 func CreateOrUpdateSecret(ctx context.Context, client *k8sclient.K8sClient, secret *corev1.Secret) error {
-	log := log.WithName("createOrUpdateSecret")
+	log := util.GenLog(ctx, log, "createOrUpdateSecret")
 	log.Info("secret", "name", secret.Name, "namespace", secret.Namespace)
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		oldSecret, err := client.GetSecret(ctx, secret.Name, jfsConfig.Namespace)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -357,9 +357,17 @@ func CheckDynamicPV(name string) (bool, error) {
 	return regexp.Match("pvc-\\w{8}(-\\w{4}){3}-\\w{12}", []byte(name))
 }
 
-func UmountPath(ctx context.Context, sourcePath string) {
+func UmountPath(ctx context.Context, sourcePath string, lazy bool) {
 	log := GenLog(ctx, utilLog, "Umount")
-	out, err := exec.CommandContext(ctx, "umount", "-l", sourcePath).CombinedOutput()
+	var (
+		out []byte
+		err error
+	)
+	if lazy {
+		out, err = exec.CommandContext(ctx, "umount", "-l", sourcePath).CombinedOutput()
+	} else {
+		out, err = exec.CommandContext(ctx, "umount", sourcePath).CombinedOutput()
+	}
 	if err != nil &&
 		!strings.Contains(string(out), "not mounted") &&
 		!strings.Contains(string(out), "mountpoint not found") &&


### PR DESCRIPTION
fix https://github.com/juicedata/juicefs-csi-driver/issues/1229

When mount pod is not ready within 60s, csi-node will execute `umount -l` and retry. And next time kubelet rePublish it, mount pod may be ready and csi-node bind target in it. But `umount -l` will umount it and app pod write data in disk, not in juicefs. That's why app pod can not be deleted.
