### PR TITLE
fix upgrade when upgrade annotation is empty & update fs name when update pvc's secret

### DIFF
--- a/cmd/dashboard/upgrade.go
+++ b/cmd/dashboard/upgrade.go
@@ -441,7 +441,7 @@ func (u *BatchUpgrade) waitForUpgrade(ctx context.Context, index int, nodeName s
 		}
 		var pu *PodUpgrade
 		for _, p := range crtBatch {
-			if p.pod.Labels[common.PodUpgradeUUIDLabelKey] == po.Labels[common.PodUpgradeUUIDLabelKey] {
+			if resource.GetUpgradeUUID(p.pod) == resource.GetUpgradeUUID(po) {
 				pu = p
 				break
 			}

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -753,6 +753,18 @@ func ApplySettingWithMountPod(mountPod *corev1.Pod, pvc *corev1.PersistentVolume
 			}
 		}
 		if err == nil {
+			setting.Name = util.CpNotEmpty(custSetting.Name, setting.Name)
+			setting.Source = custSetting.Name
+			if custSetting.MetaUrl != "" {
+				setting.MetaUrl = custSetting.MetaUrl
+				source := custSetting.MetaUrl
+				setting.IsCe = true
+				// Default use redis:// scheme
+				if !strings.Contains(custSetting.MetaUrl, "://") {
+					source = "redis://" + source
+				}
+				setting.Source = source
+			}
 			setting.SecretKey = util.CpNotEmpty(custSetting.SecretKey, setting.SecretKey)
 			setting.SecretKey2 = util.CpNotEmpty(custSetting.SecretKey2, setting.SecretKey2)
 			setting.Token = util.CpNotEmpty(custSetting.Token, setting.Token)

--- a/pkg/juicefs/mount/builder/common.go
+++ b/pkg/juicefs/mount/builder/common.go
@@ -283,7 +283,10 @@ func GenMetadata(jfsSetting *config.JfsSetting) (labels map[string]string, annot
 		labels[k] = v
 	}
 	for k, v := range jfsSetting.Attr.Annotations {
-		annotations[k] = v
+		if k != common.JfsUpgradeProcess {
+			// new pod do not need upgradeProcess annotation
+			annotations[k] = v
+		}
 	}
 	// inter labels & annotations
 	annotations[common.JuiceFSUUID] = jfsSetting.UUID


### PR DESCRIPTION
1. update fs name when update pvc's secret
2. fix upgrade when upgrade annotation is empty
3. do not cp upgrade process annotation when generate new pod