### PR TITLE
fix set quota

### DIFF
--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -629,6 +629,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=$(ADDRESS)
+        - --timeout=20s
         - --leader-election
         - --v=2
         env:

--- a/deploy/k8s_before_v1_18.yaml
+++ b/deploy/k8s_before_v1_18.yaml
@@ -629,6 +629,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=$(ADDRESS)
+        - --timeout=20s
         - --leader-election
         - --v=2
         env:

--- a/deploy/kubernetes/base/resources.yaml
+++ b/deploy/kubernetes/base/resources.yaml
@@ -477,6 +477,7 @@ spec:
           image: registry.k8s.io/sig-storage/csi-resizer:v1.9.0
           args:
             - --csi-address=$(ADDRESS)
+            - --timeout=20s
             - --leader-election
             - --v=2
           env:

--- a/deploy/webhook-with-certmanager.yaml
+++ b/deploy/webhook-with-certmanager.yaml
@@ -538,6 +538,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=$(ADDRESS)
+        - --timeout=20s
         - --leader-election
         - --v=2
         env:

--- a/deploy/webhook.yaml
+++ b/deploy/webhook.yaml
@@ -566,6 +566,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=$(ADDRESS)
+        - --timeout=20s
         - --leader-election
         - --v=2
         env:

--- a/scripts/juicefs-csi-webhook-install.sh
+++ b/scripts/juicefs-csi-webhook-install.sh
@@ -637,6 +637,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=$(ADDRESS)
+        - --timeout=20s
         - --leader-election
         - --v=2
         env:
@@ -1374,6 +1375,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=$(ADDRESS)
+        - --timeout=20s
         - --leader-election
         - --v=2
         env:


### PR DESCRIPTION
fix #1260 

- Remove the logic that runs in the background upon `setQuota` timeout in the community version.

  after https://github.com/juicedata/juicefs-csi-driver/pull/1223, `NodePublish api` always running setQuota in background
  
  when expanding PVCs, timeouts must return errors to permit retries.

- Adjust csi-resizer timeout to 20s.
