### PR TITLE
feat: use subdir mount subpath when StorageClassShareMount is disabled

### DIFF
--- a/.github/scripts/test_case.py
+++ b/.github/scripts/test_case.py
@@ -1073,7 +1073,6 @@ def test_deployment_dynamic_patch_pv():
     pv_name = volume_id
     pv = client.CoreV1Api().read_persistent_volume(name=pv_name)
     pv.spec.mount_options = ["subdir={}".format(subdir), "verbose"]
-    pv.spec.mount_options.append("subdir={}".format(subdir))
     LOG.info(f"Patch PV {pv_name}: add subdir={subdir} and verbose in mountOptions")
     client.CoreV1Api().patch_persistent_volume(pv_name, pv)
 
@@ -1143,7 +1142,7 @@ def test_deployment_dynamic_patch_pv():
     LOG.info("Check subdir {}".format(subdir))
     result = check_mount_point(subdir + "/{}/out.txt".format(volume_id))
     if not result:
-        raise Exception("mount Point of /{}/out.txt are not ready within 5 min.".format(subdir))
+        raise Exception("mount Point of {}/{}/out.txt are not ready within 5 min.".format(subdir,volume_id))
 
     # check target
     LOG.info("Check target path is ok..")
@@ -1749,7 +1748,6 @@ def test_deployment_dynamic_patch_pv_with_webhook():
     pv_name = volume_id
     pv = client.CoreV1Api().read_persistent_volume(name=pv_name)
     pv.spec.mount_options = ["subdir={}".format(subdir), "verbose"]
-    pv.spec.mount_options.append("subdir={}".format(subdir))
     LOG.info(f"Patch PV {pv_name}: add subdir={subdir} and verbose in mountOptions")
     client.CoreV1Api().patch_persistent_volume(pv_name, pv)
 

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -107,6 +107,9 @@ func (fs *jfs) GetBasePath() string {
 // CreateVol creates the directory needed
 func (fs *jfs) CreateVol(ctx context.Context, volumeID, subPath string) (string, error) {
 	log := util.GenLog(ctx, jfsLog, "CreateVol")
+	if !config.StorageClassShareMount {
+		return fs.MountPath, nil
+	}
 	volPath := filepath.Join(fs.MountPath, subPath)
 	log.V(1).Info("checking volPath exists", "volPath", volPath, "fs", fs)
 	var exists bool

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -107,7 +107,7 @@ func (fs *jfs) GetBasePath() string {
 // CreateVol creates the directory needed
 func (fs *jfs) CreateVol(ctx context.Context, volumeID, subPath string) (string, error) {
 	log := util.GenLog(ctx, jfsLog, "CreateVol")
-	if !config.StorageClassShareMount {
+	if !config.StorageClassShareMount && !config.ByProcess {
 		return fs.MountPath, nil
 	}
 	volPath := filepath.Join(fs.MountPath, subPath)

--- a/pkg/juicefs/juicefs_test.go
+++ b/pkg/juicefs/juicefs_test.go
@@ -63,13 +63,15 @@ func Test_jfs_CreateVol(t *testing.T) {
 			}
 			got, err := j.CreateVol(context.TODO(), "", "subPath")
 			So(err, ShouldBeNil)
-			So(got, ShouldEqual, "/mountPath/subPath")
+			So(got, ShouldEqual, "/mountPath")
 		})
 		Convey("test exist err", func() {
 			patch1 := ApplyFunc(mount.PathExists, func(path string) (bool, error) {
 				return false, errors.New("test")
 			})
 			defer patch1.Reset()
+			patch2 := ApplyGlobalVar(&config.StorageClassShareMount, true)
+			defer patch2.Reset()
 
 			j := jfs{
 				MountPath: "/mountPath",
@@ -87,6 +89,8 @@ func Test_jfs_CreateVol(t *testing.T) {
 				return errors.New("test")
 			})
 			defer patch2.Reset()
+			patch3 := ApplyGlobalVar(&config.StorageClassShareMount, true)
+			defer patch3.Reset()
 
 			j := jfs{
 				MountPath: "/mountPath",
@@ -108,6 +112,8 @@ func Test_jfs_CreateVol(t *testing.T) {
 				return mocks.FakeFileInfoIno1{}, errors.New("test")
 			})
 			defer patch3.Reset()
+			patch4 := ApplyGlobalVar(&config.StorageClassShareMount, true)
+			defer patch4.Reset()
 
 			j := jfs{
 				MountPath: "/mountPath",

--- a/pkg/juicefs/mount/builder/cci-serverless.go
+++ b/pkg/juicefs/mount/builder/cci-serverless.go
@@ -107,9 +107,6 @@ func (r *CCIBuilder) NewMountSidecar() *corev1.Pod {
 	pod.Spec.Volumes = append(pod.Spec.Volumes, cacheVolumes...)
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, cacheVolumeMounts...)
 
-	// overwrite subdir
-	r.overwriteSubdirWithSubPath()
-
 	// command
 	mountCmd := r.genMountCommand()
 	initCmd := r.genInitCommand()

--- a/pkg/juicefs/mount/builder/common.go
+++ b/pkg/juicefs/mount/builder/common.go
@@ -148,24 +148,22 @@ func (r *BaseBuilder) genCommonJuicePod(cnGen func() corev1.Container) *corev1.P
 // genMountCommand generates mount command
 func (r *BaseBuilder) genMountCommand() string {
 	cmd := ""
-	options := r.jfsSetting.Options
-	subpath := r.jfsSetting.SubPath
+	options := []string{}
+	subdir := r.jfsSetting.SubPath
 	if !config.StorageClassShareMount {
-		hasSubdirOption := false
-		for i, option := range options {
+		for _, option := range r.jfsSetting.Options {
 			if strings.HasPrefix(option, "subdir=") {
 				s := strings.Split(option, "=")
 				if len(s) != 2 {
 					continue
 				}
-				subpath = path.Join(s[1], subpath)
-				hasSubdirOption = true
-				options[i] = fmt.Sprintf("subdir=%s", subpath)
-				break
+				subdir = path.Join(s[1], r.jfsSetting.SubPath)
+				continue
 			}
+			options = append(options, option)
 		}
-		if subpath != "" && !hasSubdirOption {
-			options = append(options, fmt.Sprintf("subdir=%s", subpath))
+		if subdir != "" {
+			options = append(options, fmt.Sprintf("subdir=%s", subdir))
 		}
 	}
 	if r.jfsSetting.IsCe {

--- a/pkg/juicefs/mount/builder/common.go
+++ b/pkg/juicefs/mount/builder/common.go
@@ -165,6 +165,8 @@ func (r *BaseBuilder) genMountCommand() string {
 		if subdir != "" {
 			options = append(options, fmt.Sprintf("subdir=%s", subdir))
 		}
+	} else {
+		options = r.jfsSetting.Options
 	}
 	if r.jfsSetting.IsCe {
 		mountArgs := []string{"exec", config.CeMountPath, "${metaurl}", security.EscapeBashStr(r.jfsSetting.MountPath)}

--- a/pkg/juicefs/mount/builder/common_test.go
+++ b/pkg/juicefs/mount/builder/common_test.go
@@ -18,92 +18,12 @@ package builder
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/common"
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 )
 
-func TestBaseBuilder_overwriteSubdirWithSubPath(t *testing.T) {
-	type fields struct {
-		jfsSetting *config.JfsSetting
-	}
-	tests := []struct {
-		name       string
-		fields     fields
-		wantSubdir string
-	}{
-		{
-			name: "test1",
-			fields: fields{
-				jfsSetting: &config.JfsSetting{
-					Options: []string{
-						"subdir=abc",
-					},
-					SubPath: "def",
-				},
-			},
-			wantSubdir: "abc/def",
-		},
-		{
-			name: "test2",
-			fields: fields{
-				jfsSetting: &config.JfsSetting{
-					Options: []string{},
-					SubPath: "def",
-				},
-			},
-			wantSubdir: "def",
-		},
-		{
-			name: "test3",
-			fields: fields{
-				jfsSetting: &config.JfsSetting{
-					Options: []string{},
-					SubPath: "",
-				},
-			},
-			wantSubdir: "",
-		},
-		{
-			name: "test4",
-			fields: fields{
-				jfsSetting: &config.JfsSetting{
-					Options: []string{
-						"subdir=abc",
-					},
-					SubPath: "",
-				},
-			},
-			wantSubdir: "abc",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r := &BaseBuilder{
-				jfsSetting: tt.fields.jfsSetting,
-			}
-			r.overwriteSubdirWithSubPath()
-			var subdir string
-			for _, option := range r.jfsSetting.Options {
-				if strings.HasPrefix(option, "subdir=") {
-					s := strings.Split(option, "=")
-					if len(s) != 2 {
-						t.Error("overwriteSubdirWithSubPath() error")
-					}
-					if s[0] == "subdir" {
-						subdir = s[1]
-					}
-				}
-			}
-
-			if subdir != tt.wantSubdir {
-				t.Errorf("overwriteSubdirWithSubPath() got=%s, want=%s", subdir, tt.wantSubdir)
-			}
-		})
-	}
-}
 func TestGenMetadata(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/pkg/juicefs/mount/builder/container.go
+++ b/pkg/juicefs/mount/builder/container.go
@@ -96,9 +96,6 @@ func (r *ContainerBuilder) NewMountSidecar() *corev1.Pod {
 			)}},
 	}
 
-	// overwrite subdir
-	r.overwriteSubdirWithSubPath()
-
 	mountCmd := r.genMountCommand()
 	cmd := mountCmd
 	initCmd := r.genInitCommand()

--- a/pkg/juicefs/mount/builder/pod_test.go
+++ b/pkg/juicefs/mount/builder/pod_test.go
@@ -426,6 +426,7 @@ func TestNewMountPod(t *testing.T) {
 func TestPodMount_getCommand(t *testing.T) {
 	type args struct {
 		mountPath string
+		subPath   string
 		options   []string
 	}
 	tests := []struct {
@@ -455,6 +456,17 @@ func TestPodMount_getCommand(t *testing.T) {
 			},
 			want: "exec /sbin/mount.juicefs test /jfs/test-volume -o foreground,no-update,debug",
 		},
+		{
+			name:   "test-subpath",
+			isCe:   false,
+			source: "test",
+			args: args{
+				mountPath: "/jfs/test-volume",
+				options:   []string{"subdir=test"},
+				subPath:   "/jfs/test-volume/subpath",
+			},
+			want: "exec /sbin/mount.juicefs test /jfs/test-volume -o foreground,no-update,subdir=test/jfs/test-volume/subpath",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -464,6 +476,7 @@ func TestPodMount_getCommand(t *testing.T) {
 				Source:    tt.source,
 				IsCe:      tt.isCe,
 				MountPath: tt.args.mountPath,
+				SubPath:   tt.args.subPath,
 				Options:   tt.args.options,
 				Attr:      &config.PodAttr{},
 			}

--- a/pkg/juicefs/mount/builder/serverless.go
+++ b/pkg/juicefs/mount/builder/serverless.go
@@ -93,9 +93,6 @@ func (r *ServerlessBuilder) NewMountSidecar() *corev1.Pod {
 	pod.Spec.Volumes = append(pod.Spec.Volumes, cacheVolumes...)
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, cacheVolumeMounts...)
 
-	// overwrite subdir
-	r.overwriteSubdirWithSubPath()
-
 	// command
 	mountCmd := r.genMountCommand()
 	initCmd := r.genInitCommand()

--- a/pkg/juicefs/mount/builder/vci-serverless.go
+++ b/pkg/juicefs/mount/builder/vci-serverless.go
@@ -131,9 +131,6 @@ func (r *VCIBuilder) NewMountSidecar() *corev1.Pod {
 	pod.Spec.Volumes = append(pod.Spec.Volumes, cacheVolumes...)
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, cacheVolumeMounts...)
 
-	// overwrite subdir
-	r.overwriteSubdirWithSubPath()
-
 	// command
 	mountCmd := r.genMountCommand()
 	initCmd := r.genInitCommand()


### PR DESCRIPTION
use subdir to mount the pv, to avoid mounting the entire root filesystem