### PR TITLE
fix: start mountManager when enable webhook & set resource to zero instead of delete

### DIFF
--- a/.github/scripts/test_case.py
+++ b/.github/scripts/test_case.py
@@ -845,8 +845,8 @@ def test_pod_resource_err():
     mount_pod = Pod(name=get_only_mount_pod_name(volume_id), deployment_name="", replicas=1, namespace=KUBE_SYSTEM)
     spec = mount_pod.get_spec()
     resource_requests = spec.containers[0].resources.requests
-    if resource_requests is not None and resource_requests["cpu"] != "" and resource_requests["memory"] != "":
-        raise Exception("Mount pod {} resources request is not none.".format(mount_pod.name))
+    if resource_requests["cpu"] != "0" and resource_requests["memory"] != "0":
+        raise Exception("Mount pod {} resources request is not zero.".format(mount_pod.name))
 
     # delete test resources
     LOG.info("Remove pod {}".format(pod.name))

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -65,7 +65,6 @@ func parseControllerConfig() {
 	if webhook {
 		// if enable webhook, does not need mount manager & must format in pod
 		config.FormatInPod = true
-		config.MountManager = false
 		config.ByProcess = false
 	}
 	if jfsImmutable := os.Getenv("JUICEFS_IMMUTABLE"); jfsImmutable != "" {

--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -378,7 +378,7 @@ func (p *PodDriver) podErrorHandler(ctx context.Context, pod *corev1.Pod) (Resul
 				Spec: pod.Spec,
 			}
 			controllerutil.AddFinalizer(newPod, common.Finalizer)
-			resource.DeleteResourceOfPod(newPod)
+			resource.SetRequestToZeroOfPod(newPod)
 			err := mkrMp(ctx, *newPod)
 			if err != nil {
 				log.Error(err, "mkdir mount point of pod")
@@ -585,7 +585,7 @@ func (p *PodDriver) podPendingHandler(ctx context.Context, pod *corev1.Pod) (Res
 				Spec: pod.Spec,
 			}
 			controllerutil.AddFinalizer(newPod, common.Finalizer)
-			resource.DeleteResourceOfPod(newPod)
+			resource.SetRequestToZeroOfPod(newPod)
 			err := mkrMp(ctx, *newPod)
 			if err != nil {
 				log.Error(err, "mkdir mount point of pod error")

--- a/pkg/util/resource/pod.go
+++ b/pkg/util/resource/pod.go
@@ -28,6 +28,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/juicedata/juicefs-csi-driver/pkg/common"
@@ -107,6 +108,15 @@ func DeleteResourceOfPod(pod *corev1.Pod) {
 	for i := range pod.Spec.Containers {
 		pod.Spec.Containers[i].Resources.Requests = nil
 		pod.Spec.Containers[i].Resources.Limits = nil
+	}
+}
+
+func SetRequestToZeroOfPod(pod *corev1.Pod) {
+	for i := range pod.Spec.Containers {
+		pod.Spec.Containers[i].Resources.Requests = corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("0"),
+			corev1.ResourceMemory: resource.MustParse("0"),
+		}
 	}
 }
 


### PR DESCRIPTION
- start mountManager when enable webhook

webhook may used by validate webhook

- set resource to zero instead of delete

avoid severe overcommit