### PR TITLE
Info on fixing problem with SELinux systems referencing pull request in chart repo

### DIFF
--- a/docs/en/getting_started.md
+++ b/docs/en/getting_started.md
@@ -45,6 +45,7 @@ Installation requires Helm 3.1.0 and above, refer to the [Helm Installation Guid
 
     * Search for `repository` and optionally change to your private image repository. If this is in need, you'll also need to [copy the Docker images](./administration/offline.md)
     * Search for `resources` and optionally adjust resource definitions for components
+    * Search for `sidecarPrivileged` and optionally set this to `true` if using SELinux based nodes to prevent socket access issues
 
   After the above adjustments, your values file may look like:
 


### PR DESCRIPTION
Related to this pull request in helm chart repo: https://github.com/juicedata/charts/pull/174

Without this flag all SELinux systems are unable to install the driver due to SELinux restrictions on the socket, which cannot be accessed.