### PR TITLE
make hostname configurable

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -207,6 +207,7 @@ type MountPodPatch struct {
 	Annotations                   map[string]string            `json:"annotations,omitempty"`
 	HostNetwork                   *bool                        `json:"hostNetwork,omitempty" `
 	HostPID                       *bool                        `json:"hostPID,omitempty" `
+	HostnameKey                   string                       `json:"hostnameKey,omitempty"`
 	LivenessProbe                 *corev1.Probe                `json:"livenessProbe,omitempty"`
 	ReadinessProbe                *corev1.Probe                `json:"readinessProbe,omitempty"`
 	StartupProbe                  *corev1.Probe                `json:"startupProbe,omitempty"`
@@ -344,6 +345,9 @@ func (mpp *MountPodPatch) merge(mp MountPodPatch) {
 	}
 	if mp.CacheDirs != nil {
 		mpp.CacheDirs = mp.CacheDirs
+	}
+	if mp.HostnameKey != "" {
+		mpp.HostnameKey = mp.HostnameKey
 	}
 }
 

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -157,6 +157,7 @@ type PodAttr struct {
 	VolumeMounts                  []corev1.VolumeMount  `json:"volumeMounts,omitempty"`
 	Env                           []corev1.EnvVar       `json:"env,omitempty"`
 	CacheDirs                     []MountPatchCacheDir  `json:"cacheDirs,omitempty"`
+	HostnameKey                   string                `json:"-"`
 
 	// inherit from csi
 	Image            string
@@ -1082,6 +1083,9 @@ func applyConfigPatch(setting *JfsSetting) {
 	}
 	if patch.Resources != nil {
 		attr.Resources = *patch.Resources
+	}
+	if patch.HostnameKey != "" {
+		attr.HostnameKey = patch.HostnameKey
 	}
 	attr.Lifecycle = util.CpNotNil(patch.Lifecycle, attr.Lifecycle)
 	attr.LivenessProbe = util.CpNotNil(patch.LivenessProbe, attr.LivenessProbe)

--- a/pkg/juicefs/mount/builder/common.go
+++ b/pkg/juicefs/mount/builder/common.go
@@ -85,7 +85,9 @@ func (r *BaseBuilder) genCommonJuicePod(cnGen func() corev1.Container) *corev1.P
 	pod.Spec.ServiceAccountName = r.jfsSetting.Attr.ServiceAccountName
 	pod.Spec.PriorityClassName = config.JFSMountPriorityName
 	pod.Spec.RestartPolicy = corev1.RestartPolicyAlways
-	pod.Spec.Hostname = r.jfsSetting.VolumeId
+	if hostname := r.genHostname(); hostname != "" {
+		pod.Spec.Hostname = hostname
+	}
 	gracePeriod := int64(10)
 	if r.jfsSetting.Attr.TerminationGracePeriodSeconds != nil {
 		gracePeriod = *r.jfsSetting.Attr.TerminationGracePeriodSeconds
@@ -143,6 +145,21 @@ func (r *BaseBuilder) genCommonJuicePod(cnGen func() corev1.Container) *corev1.P
 		}
 	}
 	return pod
+}
+
+func (r *BaseBuilder) genHostname() string {
+	// set hostname according to jfsSetting.Attr.HostnameKey
+	// default is volumeid
+	hostnameKey := strings.ToLower(r.jfsSetting.Attr.HostnameKey)
+	switch hostnameKey {
+	case "podname":
+		// if hostname is none, use pod name by default
+		return ""
+	case "volumeid":
+		fallthrough
+	default:
+		return r.jfsSetting.VolumeId
+	}
 }
 
 // genMountCommand generates mount command


### PR DESCRIPTION
fix https://github.com/juicedata/juicefs-csi-driver/issues/1381

usage:

```
    mountPodPatch:
    - hostnameKey: podname/volumeid
```

`volumeid` is default