### PR TITLE
fix quota error when metaurl has special symbols in it

### DIFF
--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -743,7 +743,7 @@ func (j *juicefs) SetQuota(ctx context.Context, secrets map[string]string, jfsSe
 
 	var args, cmdArgs []string
 	if jfsSetting.IsCe {
-		args = []string{"quota", "set", secrets["metaurl"], "--path", quotaPath, "--capacity", strconv.FormatInt(cap, 10)}
+		args = []string{"quota", "set", fmt.Sprintf("'%s'", secrets["metaurl"]), "--path", quotaPath, "--capacity", strconv.FormatInt(cap, 10)}
 		cmdArgs = []string{config.CeCliPath, "quota", "set", "${metaurl}", "--path", quotaPath, "--capacity", strconv.FormatInt(cap, 10)}
 		if util.SupportQuotaPathCreate(true, config.BuiltinCeVersion) {
 			args = append(args, "--create")


### PR DESCRIPTION
fix  https://github.com/juicedata/juicefs-csi-driver/issues/1413