### PR TITLE
feat: allow to disable auto remove request resources when pod has resource error

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -364,8 +364,10 @@ type Config struct {
 	// enable set quota in controller (CreateVolume/Provisioner)
 	// if enabled, SetQuota will be called in controller
 	// if disabled, SetQuota will be called in node (NodePublishVolume)
-	EnableControllerSetQuota *bool           `json:"enableControllerSetQuota,omitempty"`
-	MountPodPatch            []MountPodPatch `json:"mountPodPatch"`
+	EnableControllerSetQuota *bool `json:"enableControllerSetQuota,omitempty"`
+	// enable auto remove request resources when pod has resources error, the default is true
+	EnableAutoRemoveRequestResources *bool           `json:"enableAutoRemoveRequestResources,omitempty"`
+	MountPodPatch                    []MountPodPatch `json:"mountPodPatch"`
 }
 
 func (c *Config) Unmarshal(data []byte) error {

--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -540,8 +540,9 @@ func (p *PodDriver) podPendingHandler(ctx context.Context, pod *corev1.Pod) (Res
 	lock.Lock()
 	defer lock.Unlock()
 
+	enableAutoRemove := config.GlobalConfig.EnableAutoRemoveRequestResources == nil || *config.GlobalConfig.EnableAutoRemoveRequestResources
 	// check resource err
-	if resource.IsPodResourceError(pod) {
+	if resource.IsPodResourceError(pod) && enableAutoRemove {
 		log.Info("Pod failed because of resource.")
 		if resource.IsPodHasResource(*pod) {
 			// if pod is failed because of resource, delete resource and deploy pod again.


### PR DESCRIPTION
The auto removal of requested resources may cause pods to accumulate on nodes. We should provide an option to disable this behavior, allowing users to handle errors themselves.