### PR TITLE
fix: use HostPathDirectoryOrCreate for clean cache pod volumes

### DIFF
--- a/pkg/juicefs/mount/builder/pod.go
+++ b/pkg/juicefs/mount/builder/pod.go
@@ -302,7 +302,7 @@ func (r *PodBuilder) genCleanCachePod() *corev1.Pod {
 	cacheVolumes := []corev1.Volume{}
 	cacheVolumeMounts := []corev1.VolumeMount{}
 
-	hostPathType := corev1.HostPathDirectory
+	hostPathType := corev1.HostPathDirectoryOrCreate
 
 	for idx, cacheDir := range r.jfsSetting.CacheDirs {
 		name := fmt.Sprintf("cachedir-%d", idx)


### PR DESCRIPTION
Change `HostPathDirectory` to `HostPathDirectoryOrCreate` in `genCleanCachePod()` to allow automatic directory creation if it doesn't exist.

Resolves https://github.com/juicedata/juicefs-csi-driver/issues/1429