### PR TITLE
feat(sidecar): attempts to use req.namespace

### DIFF
--- a/pkg/util/resource/namespace.go
+++ b/pkg/util/resource/namespace.go
@@ -34,9 +34,13 @@ var (
 )
 
 // GetNamespace get juicefs pv & pvc from pod when pod namespace is empty
-func GetNamespace(ctx context.Context, client *k8sclient.K8sClient, pod *corev1.Pod) (namespace string, err error) {
+func GetNamespace(ctx context.Context, client *k8sclient.K8sClient, pod *corev1.Pod, reqNs string) (namespace string, err error) {
 	namespace = pod.Namespace
 	if namespace != "" {
+		return
+	}
+	if reqNs != "" {
+		namespace = reqNs
 		return
 	}
 	if pod.OwnerReferences == nil && namespace == "" {

--- a/pkg/util/resource/volume.go
+++ b/pkg/util/resource/volume.go
@@ -35,11 +35,11 @@ type PVPair struct {
 }
 
 // GetVolumes get juicefs pv & pvc from pod
-func GetVolumes(ctx context.Context, client *k8sclient.K8sClient, pod *corev1.Pod) (used bool, pvPairGot []PVPair, err error) {
-	resourceLog.V(1).Info("Volumes of pod", "podName", pod.Name, "volumes", pod.Spec.Volumes)
+func GetVolumes(ctx context.Context, client *k8sclient.K8sClient, pod *corev1.Pod, reqNs string) (used bool, pvPairGot []PVPair, err error) {
+	resourceLog.V(1).Info("Volumes of pod", "podName", pod.Name, "reqNs", reqNs, "volumes", pod.Spec.Volumes)
 	var namespace string
 	pvPairGot = []PVPair{}
-	namespace, err = GetNamespace(ctx, client, pod)
+	namespace, err = GetNamespace(ctx, client, pod, reqNs)
 	if err != nil {
 		return
 	}

--- a/pkg/util/resource/volume_test.go
+++ b/pkg/util/resource/volume_test.go
@@ -236,7 +236,7 @@ func TestGetVolumes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotUsed, gotPair, err := GetVolumes(context.TODO(), k8sClient, tt.args.pod)
+			gotUsed, gotPair, err := GetVolumes(context.TODO(), k8sClient, tt.args.pod, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetVolume() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/webhook/handler/handler.go
+++ b/pkg/webhook/handler/handler.go
@@ -61,7 +61,8 @@ func NewSidecarHandler(client *k8sclient.K8sClient, serverless bool, scheme *run
 func (s *SidecarHandler) Handle(ctx context.Context, request admission.Request) admission.Response {
 	pod := &corev1.Pod{}
 	raw := request.Object.Raw
-	handlerLog.V(1).Info("get pod", "pod", string(raw))
+	reqNamespace := request.Namespace
+	handlerLog.V(1).Info("get pod", "reqNamespace", reqNamespace, "pod", string(raw))
 	err := s.decoder.Decode(request, pod)
 	if err != nil {
 		handlerLog.Error(err, "unable to decoder pod from req")
@@ -81,7 +82,7 @@ func (s *SidecarHandler) Handle(ctx context.Context, request admission.Request) 
 	}
 
 	// check if pod use JuiceFS Volume
-	used, pair, err := resource.GetVolumes(ctx, s.Client, pod)
+	used, pair, err := resource.GetVolumes(ctx, s.Client, pod, reqNamespace)
 	if err != nil {
 		handlerLog.Error(err, "get pv from pod", "name", pod.Name, "namespace", pod.Namespace)
 		return admission.Errored(http.StatusBadRequest, err)


### PR DESCRIPTION
In some scenarios, the pod's namespace may be empty; you can try using req.Namespace.
