### PR TITLE
Support for init containers for mount pods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	golang.org/x/net v0.38.0
 	golang.org/x/sync v0.12.0
 	google.golang.org/grpc v1.65.0
+	google.golang.org/protobuf v1.34.2
 	k8s.io/api v0.31.1
 	k8s.io/apimachinery v0.31.1
 	k8s.io/client-go v0.31.1
@@ -96,7 +97,6 @@ require (
 	golang.org/x/tools v0.24.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240701130421-f6361c86f094 // indirect
-	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/juicefs-csi-driver-config.example.yaml
+++ b/juicefs-csi-driver-config.example.yaml
@@ -95,3 +95,23 @@ data:
       #   mountOptions:
       #     - writeback
       #     - xxx
+
+      # add init containers to the mount pod for setup tasks
+      # - pvcSelector:
+      #     matchLabels:
+      #       init-required: "true"
+      #   initContainers:
+      #     - name: volume-setup
+      #       image: alpine:latest
+      #       command: ["sh", "-c"]
+      #       args: ["mkdir -p /data/logs && chmod 755 /data/logs"]
+      #       volumeMounts:
+      #         - name: jfs-dir
+      #           mountPath: /data
+
+      # global init container (applies to all mount pods without pvcSelector)
+      # - initContainers:
+      #     - name: global-setup
+      #       image: busybox:latest
+      #       command: ["sh", "-c"]
+      #       args: ["echo 'Initializing volume ${VOLUME_ID} at ${MOUNT_POINT}' > /tmp/init.log"]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -339,6 +339,9 @@ func (mpp *MountPodPatch) merge(mp MountPodPatch) {
 			mpp.VolumeDevices = append(mpp.VolumeDevices, vm)
 		}
 	}
+	if mp.InitContainers != nil {
+		mpp.InitContainers = mp.InitContainers
+	}
 	if mp.Env != nil {
 		mpp.Env = mp.Env
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -219,6 +219,7 @@ type MountPodPatch struct {
 	VolumeDevices                 []corev1.VolumeDevice        `json:"volumeDevices,omitempty"`
 	VolumeMounts                  []corev1.VolumeMount         `json:"volumeMounts,omitempty"`
 	Env                           []corev1.EnvVar              `json:"env,omitempty"`
+	InitContainers                []corev1.Container           `json:"initContainers,omitempty"`
 	MountOptions                  []string                     `json:"mountOptions,omitempty"`
 }
 

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -1107,9 +1107,7 @@ func applyConfigPatch(setting *JfsSetting, replaceTemplate bool) {
 	attr.VolumeMounts = patch.VolumeMounts
 	attr.Volumes = patch.Volumes
 	attr.Env = patch.Env
-	if patch.InitContainers != nil {
-		attr.InitContainers = append(attr.InitContainers, patch.InitContainers...)
-	}
+	attr.InitContainers = patch.InitContainers
 	attr.CacheDirs = patch.CacheDirs
 
 	newOptions := make([]string, 0)

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -159,6 +159,7 @@ type PodAttr struct {
 	VolumeMounts                  []corev1.VolumeMount  `json:"volumeMounts,omitempty"`
 	Env                           []corev1.EnvVar       `json:"env,omitempty"`
 	CacheDirs                     []MountPatchCacheDir  `json:"cacheDirs,omitempty"`
+	InitContainers                []corev1.Container    `json:"initContainers,omitempty"`
 	HostnameKey                   string                `json:"-"`
 
 	// inherit from csi
@@ -1106,6 +1107,9 @@ func applyConfigPatch(setting *JfsSetting, replaceTemplate bool) {
 	attr.VolumeMounts = patch.VolumeMounts
 	attr.Volumes = patch.Volumes
 	attr.Env = patch.Env
+	if patch.InitContainers != nil {
+		attr.InitContainers = append(attr.InitContainers, patch.InitContainers...)
+	}
 	attr.CacheDirs = patch.CacheDirs
 
 	newOptions := make([]string, 0)
@@ -1212,6 +1216,9 @@ func GenHashOfSetting(log klog.Logger, setting JfsSetting) string {
 		})
 		util.SortBy(s.Attr.HostAliases, func(i, j int) bool {
 			return strings.Compare(s.Attr.HostAliases[i].IP, s.Attr.HostAliases[j].IP) < 0
+		})
+		util.SortBy(s.Attr.InitContainers, func(i, j int) bool {
+			return strings.Compare(s.Attr.InitContainers[i].Name, s.Attr.InitContainers[j].Name) < 0
 		})
 	}
 

--- a/pkg/config/setting_test.go
+++ b/pkg/config/setting_test.go
@@ -1387,6 +1387,37 @@ func Test_applyConfigPatch(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "test-init-containers",
+			args: args{
+				setting: &JfsSetting{
+					Attr: &PodAttr{},
+				},
+				patch: MountPodPatch{
+					InitContainers: []corev1.Container{
+						{
+							Name:    "init-setup",
+							Image:   "busybox:latest",
+							Command: []string{"sh", "-c"},
+							Args:    []string{"echo 'Initializing...'"},
+						},
+					},
+				},
+			},
+			want: &JfsSetting{
+				Attr: &PodAttr{
+					InitContainers: []corev1.Container{
+						{
+							Name:    "init-setup",
+							Image:   "busybox:latest",
+							Command: []string{"sh", "-c"},
+							Args:    []string{"echo 'Initializing...'"},
+						},
+					},
+				},
+				Options: []string{},
+			},
+		},
 	}
 
 	defer GlobalConfig.Reset()

--- a/pkg/juicefs/mount/builder/pod.go
+++ b/pkg/juicefs/mount/builder/pod.go
@@ -102,7 +102,7 @@ func (r *PodBuilder) NewMountPod(podName string) (*corev1.Pod, error) {
 	}
 
 	// add init containers from configuration
-	if r.jfsSetting.Attr.InitContainers != nil && len(r.jfsSetting.Attr.InitContainers) > 0 {
+	if len(r.jfsSetting.Attr.InitContainers) > 0 {
 		pod.Spec.InitContainers = append(pod.Spec.InitContainers, r.jfsSetting.Attr.InitContainers...)
 	}
 

--- a/pkg/juicefs/mount/builder/pod.go
+++ b/pkg/juicefs/mount/builder/pod.go
@@ -102,7 +102,7 @@ func (r *PodBuilder) NewMountPod(podName string) (*corev1.Pod, error) {
 	}
 
 	// add init containers from configuration
-	if len(r.jfsSetting.Attr.InitContainers) > 0 {
+	if r.jfsSetting.Attr.InitContainers != nil && len(r.jfsSetting.Attr.InitContainers) > 0 {
 		pod.Spec.InitContainers = append(pod.Spec.InitContainers, r.jfsSetting.Attr.InitContainers...)
 	}
 

--- a/pkg/juicefs/mount/builder/pod.go
+++ b/pkg/juicefs/mount/builder/pod.go
@@ -101,6 +101,11 @@ func (r *PodBuilder) NewMountPod(podName string) (*corev1.Pod, error) {
 		pod.Spec.Containers[0].VolumeDevices = append(pod.Spec.Containers[0].VolumeDevices, r.jfsSetting.Attr.VolumeDevices...)
 	}
 
+	// add init containers from configuration
+	if len(r.jfsSetting.Attr.InitContainers) > 0 {
+		pod.Spec.InitContainers = append(pod.Spec.InitContainers, r.jfsSetting.Attr.InitContainers...)
+	}
+
 	return pod, nil
 }
 

--- a/pkg/juicefs/mount/builder/pod_test.go
+++ b/pkg/juicefs/mount/builder/pod_test.go
@@ -312,16 +312,6 @@ func TestNewMountPod(t *testing.T) {
 	podfusePassTest.Spec.Containers[0].Lifecycle = nil
 	podfusePassTest.Spec.Containers[0].Image = config.DefaultCEMountImage
 
-	podInitContainerTest := corev1.Pod{}
-	deepcopyPodFromDefault(&podInitContainerTest)
-	podInitContainerTest.Spec.InitContainers = []corev1.Container{
-		{
-			Name:    "init-setup",
-			Image:   "busybox:latest",
-			Command: []string{"sh", "-c"},
-			Args:    []string{"echo 'Initializing...'"},
-		},
-	}
 
 	type args struct {
 		name           string
@@ -333,9 +323,8 @@ func TestNewMountPod(t *testing.T) {
 		annotations    map[string]string
 		serviceAccount string
 		options        []string
-		cacheDirs      []string
-		image          string
-		initContainers []corev1.Container
+		cacheDirs []string
+		image     string
 	}
 	tests := []struct {
 		name string
@@ -423,23 +412,6 @@ func TestNewMountPod(t *testing.T) {
 			},
 			want: podfusePassTest,
 		},
-		{
-			name: "test-init-containers",
-			args: args{
-				name:      "test",
-				cmd:       defaultCmd,
-				mountPath: defaultMountPath,
-				initContainers: []corev1.Container{
-					{
-						Name:    "init-setup",
-						Image:   "busybox:latest",
-						Command: []string{"sh", "-c"},
-						Args:    []string{"echo 'Initializing...'"},
-					},
-				},
-			},
-			want: podInitContainerTest,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -466,7 +438,6 @@ func TestNewMountPod(t *testing.T) {
 					MountPointPath:     config.MountPointPath,
 					JFSConfigPath:      config.JFSConfigPath,
 					Image:              unsupoortFusePassImage,
-					InitContainers:     tt.args.initContainers,
 				},
 			}
 			if tt.args.image != "" {

--- a/pkg/juicefs/mount/builder/pod_test.go
+++ b/pkg/juicefs/mount/builder/pod_test.go
@@ -312,6 +312,17 @@ func TestNewMountPod(t *testing.T) {
 	podfusePassTest.Spec.Containers[0].Lifecycle = nil
 	podfusePassTest.Spec.Containers[0].Image = config.DefaultCEMountImage
 
+	podInitContainerTest := corev1.Pod{}
+	deepcopyPodFromDefault(&podInitContainerTest)
+	podInitContainerTest.Spec.InitContainers = []corev1.Container{
+		{
+			Name:    "init-setup",
+			Image:   "busybox:latest",
+			Command: []string{"sh", "-c"},
+			Args:    []string{"echo 'Initializing...'"},
+		},
+	}
+
 	type args struct {
 		name           string
 		cmd            string
@@ -324,6 +335,7 @@ func TestNewMountPod(t *testing.T) {
 		options        []string
 		cacheDirs      []string
 		image          string
+		initContainers []corev1.Container
 	}
 	tests := []struct {
 		name string
@@ -411,6 +423,23 @@ func TestNewMountPod(t *testing.T) {
 			},
 			want: podfusePassTest,
 		},
+		{
+			name: "test-init-containers",
+			args: args{
+				name:      "test",
+				cmd:       defaultCmd,
+				mountPath: defaultMountPath,
+				initContainers: []corev1.Container{
+					{
+						Name:    "init-setup",
+						Image:   "busybox:latest",
+						Command: []string{"sh", "-c"},
+						Args:    []string{"echo 'Initializing...'"},
+					},
+				},
+			},
+			want: podInitContainerTest,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -437,6 +466,7 @@ func TestNewMountPod(t *testing.T) {
 					MountPointPath:     config.MountPointPath,
 					JFSConfigPath:      config.JFSConfigPath,
 					Image:              unsupoortFusePassImage,
+					InitContainers:     tt.args.initContainers,
 				},
 			}
 			if tt.args.image != "" {

--- a/pkg/juicefs/mount/builder/pod_test.go
+++ b/pkg/juicefs/mount/builder/pod_test.go
@@ -312,7 +312,6 @@ func TestNewMountPod(t *testing.T) {
 	podfusePassTest.Spec.Containers[0].Lifecycle = nil
 	podfusePassTest.Spec.Containers[0].Image = config.DefaultCEMountImage
 
-
 	type args struct {
 		name           string
 		cmd            string
@@ -323,8 +322,8 @@ func TestNewMountPod(t *testing.T) {
 		annotations    map[string]string
 		serviceAccount string
 		options        []string
-		cacheDirs []string
-		image     string
+		cacheDirs      []string
+		image          string
 	}
 	tests := []struct {
 		name string


### PR DESCRIPTION
# Overview

Add support for adding init containers to mount pods.

There are cases where users might have custom initialization logic they may want or need to run in init containers in their mount pods.

For example, some organizations use tools like [consul-template](https://github.com/hashicorp/consul-template) or similar configuration management tools to inject sensitive data into their pod containers as files. 

## Scope

Init containers should follow the same configuration pattern as existing pod attributes like volumes e.g.:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: juicefs-csi-driver-config
data:
  config.yaml: |-
    mountPodPatch:
      - initContainers:
        - name: custom-init
          image: busybox
          command: ["sh", "-c", "echo 'Initializing'"]
```

# Testing

I tested using `kind`

## `juicefs-csi-driver-config`

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: juicefs-csi-driver-config
  namespace: kube-system
data:
  config.yaml: |-
    mountPodPatch:
      # Test init container for PVCs with specific label
      - pvcSelector:
          matchLabels:
            init-test: "true"
        initContainers:
          - name: init-test
            image: alpine:latest
            command: ["sh", "-c"]
            args: ["echo 'Init container test successful! Volume: ${VOLUME_ID}' > /shared/init-test.txt && echo 'Init completed at:' && date >> /shared/init-test.txt"]
            volumeMounts:
              - name: shared-data
                mountPath: /shared
        volumeMounts:
          - name: shared-data
            mountPath: /shared
        volumes:
          - name: shared-data
            emptyDir: {}
```

## Test pod

```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: test-pvc2002
  namespace: default
  labels:
    init-test: "true"  # This label triggers our init container
spec:
  accessModes:
    - ReadWriteOnce
  storageClassName: juicefs-sc
  resources:
    requests:
      storage: 1Gi
---
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
  namespace: default
spec:
  containers:
  - name: test-container
    image: alpine:latest
    command: ["sleep", "3600"]
    volumeMounts:
    - name: juicefs-volume
      mountPath: /data
  volumes:
  - name: juicefs-volume
    persistentVolumeClaim:
      claimName: test-pvc2002
  restartPolicy: Never
```

## Create test pod

```
➜  juicefs-csi-driver git:(support-init-containers) ✗ k apply -f ./scratch/support-init-containers/e2e/k8s/test-pod.yaml
persistentvolumeclaim/test-pvc2002 created
pod/test-pod created
```

## Watch mount pod initialize
```
➜  juicefs-csi-driver git:(support-init-containers) ✗ k get pods -n kube-system -w                                       
NAME                                                 READY   STATUS    RESTARTS   AGE
coredns-66bc5c9577-kjtl6                             1/1     Running   0          22h
coredns-66bc5c9577-vh6ht                             1/1     Running   0          22h
etcd-juicefs-test-control-plane                      1/1     Running   0          22h
juicefs-csi-controller-0                             4/4     Running   0          56s
juicefs-csi-controller-1                             4/4     Running   0          58s
juicefs-csi-node-zljpw                               3/3     Running   0          59s
kindnet-nt28w                                        1/1     Running   0          22h
kube-apiserver-juicefs-test-control-plane            1/1     Running   0          22h
kube-controller-manager-juicefs-test-control-plane   1/1     Running   0          22h
kube-proxy-xrrsk                                     1/1     Running   0          22h
kube-scheduler-juicefs-test-control-plane            1/1     Running   0          22h
juicefs-198121e2-createvol-t99dk                     0/1     Pending   0          0s
juicefs-198121e2-createvol-t99dk                     0/1     Pending   0          0s
juicefs-198121e2-createvol-t99dk                     0/1     ContainerCreating   0          0s
juicefs-198121e2-createvol-t99dk                     1/1     Running             0          1s
juicefs-198121e2-createvol-t99dk                     0/1     Completed           0          2s
juicefs-198121e2-createvol-t99dk                     0/1     Completed           0          3s
juicefs-198121e2-createvol-t99dk                     0/1     Completed           0          3s
juicefs-juicefs-test-control-plane-pvc-2550de8a-82ae-4839-b99c-f14dffbe82f4-nnalfd   0/1     Pending             0          0s
juicefs-juicefs-test-control-plane-pvc-2550de8a-82ae-4839-b99c-f14dffbe82f4-nnalfd   0/1     Init:0/1            0          0s
juicefs-juicefs-test-control-plane-pvc-2550de8a-82ae-4839-b99c-f14dffbe82f4-nnalfd   0/1     PodInitializing     0          1s
juicefs-juicefs-test-control-plane-pvc-2550de8a-82ae-4839-b99c-f14dffbe82f4-nnalfd   1/1     Running             0          2s
juicefs-198121e2-createvol-t99dk                                                     0/1     Completed           0          8s
juicefs-198121e2-createvol-t99dk                                                     0/1     Completed           0          8s
^C%                                                                                                                                                               
➜  juicefs-csi-driver git:(support-init-containers) ✗ k exec -ti juicefs-juicefs-test-control-plane-pvc-2550de8a-82ae-4839-b99c-f14dffbe82f4-nnalfd -n kube-system -- cat /shared/init-test.txt
Defaulted container "jfs-mount" out of: jfs-mount, init-test (init)
Init container test successful! Volume: pvc-2550de8a-82ae-4839-b99c-f14dffbe82f4
Fri Oct 31 17:54:53 UTC 2025
```
