### PR TITLE
fix: delete volumePath metrics when unpublish

### DIFF
--- a/pkg/driver/fakes.go
+++ b/pkg/driver/fakes.go
@@ -17,6 +17,8 @@ limitations under the License.
 package driver
 
 import (
+	"sync"
+
 	"k8s.io/client-go/kubernetes/fake"
 	testingexec "k8s.io/utils/exec/testing"
 	"k8s.io/utils/mount"
@@ -54,6 +56,7 @@ func NewFakeDriver(endpoint string, fakeProvider juicefs.Interface) *Driver {
 			k8sClient:          &k8sclient.K8sClient{Interface: fake.NewSimpleClientset()},
 			metrics:            metrics,
 			SafeFormatAndMount: fakeMounter,
+			unmountedPaths:     &sync.Map{},
 		},
 	}
 }

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -345,8 +345,8 @@ func (d *nodeService) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 	}
 
 	if d.isPathUnmounted(volumePath) {
-		log.Info("Volume path was unmounted, ignoring stats request", "volumePath", volumePath)
-		return nil, status.Error(codes.NotFound, "Volume path was unmounted")
+		log.Info("Volume path was unmounted due to app pod unpublish or exit, ignoring stats request", "volumePath", volumePath)
+		return nil, status.Error(codes.NotFound, "Volume path was unmounted due to app pod unpublish or exit")
 	}
 
 	podUID := extractPodUIDFromVolumePath(volumePath)

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -131,6 +131,10 @@ func (d *nodeService) cleanupUnmountedPaths() {
 }
 
 func (d *nodeService) isPathUnmounted(path string) bool {
+	// for sanity test, ignore temp mount paths
+	if strings.HasPrefix(path, "/tmp/csi-mount") {
+		return false
+	}
 	_, exists := d.unmountedPaths.Load(path)
 	return exists
 }
@@ -346,7 +350,7 @@ func (d *nodeService) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 
 	if d.isPathUnmounted(volumePath) {
 		log.Info("Volume path was unmounted due to app pod unpublish or exit, ignoring stats request", "volumePath", volumePath)
-		return nil, status.Error(codes.NotFound, "Volume path was unmounted due to app pod unpublish or exit")
+		return nil, status.Errorf(codes.NotFound, "Volume path %s was unmounted due to app pod unpublish or exit", volumePath)
 	}
 
 	podUID := extractPodUIDFromVolumePath(volumePath)

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"sync"
 	"testing"
 
 	. "github.com/agiledragon/gomonkey/v2"
@@ -63,6 +64,7 @@ var _ = Describe("nodeService", func() {
 			k8sClient:          &k8s.K8sClient{Interface: fake.NewSimpleClientset()},
 			metrics:            metrics,
 			SafeFormatAndMount: *mounter,
+			unmountedPaths:     &sync.Map{},
 		}
 	})
 

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -444,7 +444,7 @@ func (p *PodMount) waitUtilMountReady(ctx context.Context, jfsSetting *jfsConfig
 	log, err := p.getErrContainerLog(ctx, podName)
 	if err != nil {
 		logger.Error(err, "Get pod log error", "podName", podName)
-		return fmt.Errorf("mount %v at %v failed: mount isn't ready in 30 seconds", util.StripPasswd(jfsSetting.Source), jfsSetting.MountPath)
+		return fmt.Errorf("mount %v at %v failed: mount isn't ready in 60 seconds", util.StripPasswd(jfsSetting.Source), jfsSetting.MountPath)
 	}
 	return fmt.Errorf("mount %v at %v failed, mountpod: %s, failed log: %v", util.StripPasswd(jfsSetting.Source), jfsSetting.MountPath, podName, log)
 }


### PR DESCRIPTION
1. `NodeUnpublishVolume` successfully unmounts the mount path
2. The app Pod exits
3. Kubelet calls `NodeGetVolumeStats` to check the volume status
4. The mount point has already been unmounted, the `volumePathHealth` metric is set to 0 (not mounted)
5. Since the Pod has already exited, Kubelet won't call again, and the metric remains at 0 forever