### PR TITLE
distinct pod err and mountpoint err when mount not ready

### DIFF
--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -626,7 +626,7 @@ func (p *PodDriver) podReadyHandler(ctx context.Context, pod *corev1.Pod) (Resul
 	lock.Lock()
 	defer lock.Unlock()
 
-	err = resource.WaitUtilMountReady(ctx, pod.Name, mntPath, defaultCheckoutTimeout)
+	err = resource.WaitUntilMountReady(ctx, pod.Name, mntPath, defaultCheckoutTimeout)
 	if err != nil {
 		if supFusePass {
 			log.Error(err, "pod is not ready within 60s")

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -436,7 +436,14 @@ func (p *PodMount) createOrAddRef(ctx context.Context, podName string, jfsSettin
 
 func (p *PodMount) waitUtilMountReady(ctx context.Context, jfsSetting *jfsConfig.JfsSetting, podName string) error {
 	logger := util.GenLog(ctx, p.log, "waitUtilMountReady")
-	err := resource.WaitUtilMountReady(ctx, podName, jfsSetting.MountPath, defaultCheckTimeout)
+
+	err := resource.WaitUtilPodRunning(ctx, p.K8sClient, podName, defaultCheckTimeout)
+	if err != nil {
+		// if pod is not running util timeout, return error
+		return err
+	}
+
+	err = resource.WaitUtilMountReady(ctx, podName, jfsSetting.MountPath, defaultCheckTimeout)
 	if err == nil {
 		return nil
 	}

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -439,7 +439,7 @@ func (p *PodMount) waitUtilMountReady(ctx context.Context, jfsSetting *jfsConfig
 
 	err := resource.WaitUtilPodRunning(ctx, p.K8sClient, podName, defaultCheckTimeout)
 	if err != nil {
-		// if pod is not running util timeout, return error
+		// if pod is not running until timeout, return error
 		return err
 	}
 

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -94,7 +94,7 @@ func (p *PodMount) JMount(ctx context.Context, appInfo *jfsConfig.AppInfo, jfsSe
 		return err
 	}
 
-	err = p.waitUtilMountReady(ctx, jfsSetting, podName)
+	err = p.waitUntilMountReady(ctx, jfsSetting, podName)
 	if err != nil {
 		return err
 	}
@@ -234,7 +234,7 @@ func (p *PodMount) JCreateVolume(ctx context.Context, jfsSetting *jfsConfig.JfsS
 	if err := resource.CreateOrUpdateSecret(ctx, p.K8sClient, &secret); err != nil {
 		return err
 	}
-	err = p.waitUtilJobCompleted(ctx, job.Name)
+	err = p.waitUntilJobCompleted(ctx, job.Name)
 	if err != nil {
 		// fall back if err
 		if e := p.K8sClient.DeleteJob(ctx, job.Name, job.Namespace); e != nil {
@@ -267,7 +267,7 @@ func (p *PodMount) JDeleteVolume(ctx context.Context, jfsSetting *jfsConfig.JfsS
 	if err := resource.CreateOrUpdateSecret(ctx, p.K8sClient, &secret); err != nil {
 		return err
 	}
-	err = p.waitUtilJobCompleted(ctx, job.Name)
+	err = p.waitUntilJobCompleted(ctx, job.Name)
 	if err != nil {
 		// fall back if err
 		if e := p.K8sClient.DeleteJob(ctx, job.Name, job.Namespace); e != nil {
@@ -434,16 +434,16 @@ func (p *PodMount) createOrAddRef(ctx context.Context, podName string, jfsSettin
 	}
 }
 
-func (p *PodMount) waitUtilMountReady(ctx context.Context, jfsSetting *jfsConfig.JfsSetting, podName string) error {
-	logger := util.GenLog(ctx, p.log, "waitUtilMountReady")
+func (p *PodMount) waitUntilMountReady(ctx context.Context, jfsSetting *jfsConfig.JfsSetting, podName string) error {
+	logger := util.GenLog(ctx, p.log, "waitUntilMountReady")
 
-	err := resource.WaitUtilPodRunning(ctx, p.K8sClient, podName, defaultCheckTimeout)
+	err := resource.WaitUntilPodRunning(ctx, p.K8sClient, podName, defaultCheckTimeout)
 	if err != nil {
 		// if pod is not running until timeout, return error
 		return err
 	}
 
-	err = resource.WaitUtilMountReady(ctx, podName, jfsSetting.MountPath, defaultCheckTimeout)
+	err = resource.WaitUntilMountReady(ctx, podName, jfsSetting.MountPath, defaultCheckTimeout)
 	if err == nil {
 		return nil
 	}
@@ -461,8 +461,8 @@ func (p *PodMount) waitUtilMountReady(ctx context.Context, jfsSetting *jfsConfig
 	return errors.New(msg)
 }
 
-func (p *PodMount) waitUtilJobCompleted(ctx context.Context, jobName string) error {
-	log := util.GenLog(ctx, p.log, "waitUtilJobCompleted")
+func (p *PodMount) waitUntilJobCompleted(ctx context.Context, jobName string) error {
+	log := util.GenLog(ctx, p.log, "waitUntilJobCompleted")
 	// Wait until the job is completed
 	waitCtx, waitCancel := context.WithTimeout(ctx, 40*time.Second)
 	defer waitCancel()
@@ -470,17 +470,17 @@ func (p *PodMount) waitUtilJobCompleted(ctx context.Context, jobName string) err
 		job, err := p.K8sClient.GetJob(waitCtx, jobName, jfsConfig.Namespace)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
-				log.Info("waitUtilJobCompleted: Job is completed and been recycled", "jobName", jobName)
+				log.Info("waitUntilJobCompleted: Job is completed and been recycled", "jobName", jobName)
 				return nil
 			}
 			if waitCtx.Err() == context.DeadlineExceeded || waitCtx.Err() == context.Canceled {
 				log.V(1).Info("job timeout", "jobName", jobName)
 				break
 			}
-			return fmt.Errorf("waitUtilJobCompleted: Get job %v failed: %v", jobName, err)
+			return fmt.Errorf("waitUntilJobCompleted: Get job %v failed: %v", jobName, err)
 		}
 		if resource.IsJobCompleted(job) {
-			log.Info("waitUtilJobCompleted: Job is completed", "jobName", jobName)
+			log.Info("waitUntilJobCompleted: Job is completed", "jobName", jobName)
 			if resource.IsJobShouldBeRecycled(job) {
 				// try to delete job
 				log.Info("job completed but not be recycled automatically, delete it", "jobName", jobName)
@@ -499,13 +499,13 @@ func (p *PodMount) waitUtilJobCompleted(ctx context.Context, jobName string) err
 		},
 	}, nil)
 	if err != nil || len(pods) == 0 {
-		return fmt.Errorf("waitUtilJobCompleted: get pod from job %s error %v", jobName, err)
+		return fmt.Errorf("waitUntilJobCompleted: get pod from job %s error %v", jobName, err)
 	}
 	cnlog, err := p.getNotCompleteCnLog(ctx, pods[0].Name)
 	if err != nil {
-		return fmt.Errorf("waitUtilJobCompleted: get pod %s log error %v", pods[0].Name, err)
+		return fmt.Errorf("waitUntilJobCompleted: get pod %s log error %v", pods[0].Name, err)
 	}
-	return fmt.Errorf("waitUtilJobCompleted: job %s isn't completed: %v", jobName, cnlog)
+	return fmt.Errorf("waitUntilJobCompleted: job %s isn't completed: %v", jobName, cnlog)
 }
 
 func (p *PodMount) AddRefOfMount(ctx context.Context, target string, podName string) error {
@@ -611,7 +611,7 @@ func (p *PodMount) CleanCache(ctx context.Context, image string, id string, volu
 		log.Error(err, "get or create job err", "jobName", job.Name)
 		return err
 	}
-	err = p.waitUtilJobCompleted(ctx, job.Name)
+	err = p.waitUntilJobCompleted(ctx, job.Name)
 	if err != nil {
 		log.Error(err, "wait for job completed err and fall back to delete job")
 		// fall back if err

--- a/pkg/util/resource/pod.go
+++ b/pkg/util/resource/pod.go
@@ -254,7 +254,10 @@ func WaitUtilPodRunning(ctx context.Context, client *k8sclient.K8sClient, podNam
 	// Wait until the mount pod is running
 	for {
 		if err := util.DoWithTimeout(waitCtx, timeout, func(ctx context.Context) (err error) {
-			pod, err := client.GetPod(ctx, podName, config.Namespace)
+			pod, perr := client.GetPod(ctx, podName, config.Namespace)
+			if perr != nil {
+				return perr
+			}
 			if pod.Status.Phase == corev1.PodRunning {
 				return nil
 			}

--- a/pkg/util/resource/pod.go
+++ b/pkg/util/resource/pod.go
@@ -247,7 +247,7 @@ func GetAllRefKeys(pod corev1.Pod) map[string]string {
 	return annos
 }
 
-func WaitUtilPodRunning(ctx context.Context, client *k8sclient.K8sClient, podName string, timeout time.Duration) error {
+func WaitUntilPodRunning(ctx context.Context, client *k8sclient.K8sClient, podName string, timeout time.Duration) error {
 	log := util.GenLog(ctx, resourceLog, "")
 	waitCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
@@ -277,7 +277,7 @@ func WaitUtilPodRunning(ctx context.Context, client *k8sclient.K8sClient, podNam
 	return fmt.Errorf("mount pod is not running in 60s, please check its event, mountpod: %s", podName)
 }
 
-func WaitUtilMountReady(ctx context.Context, podName, mntPath string, timeout time.Duration) error {
+func WaitUntilMountReady(ctx context.Context, podName, mntPath string, timeout time.Duration) error {
 	log := util.GenLog(ctx, resourceLog, "")
 	waitCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()

--- a/pkg/util/resource/pod.go
+++ b/pkg/util/resource/pod.go
@@ -247,6 +247,33 @@ func GetAllRefKeys(pod corev1.Pod) map[string]string {
 	return annos
 }
 
+func WaitUtilPodRunning(ctx context.Context, client *k8sclient.K8sClient, podName string, timeout time.Duration) error {
+	log := util.GenLog(ctx, resourceLog, "")
+	waitCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	// Wait until the mount pod is running
+	for {
+		if err := util.DoWithTimeout(waitCtx, timeout, func(ctx context.Context) (err error) {
+			pod, err := client.GetPod(ctx, podName, config.Namespace)
+			if pod.Status.Phase == corev1.PodRunning {
+				return nil
+			}
+			return fmt.Errorf("pod %s is not running yet", podName)
+		}); err != nil {
+			if err == context.Canceled || err == context.DeadlineExceeded {
+				break
+			}
+			log.V(1).Info("Mount pod is not running, wait for it.", "podName", podName, "error", err)
+			time.Sleep(timeout)
+			continue
+		}
+		log.Info("Mount pod is running", "podName", podName)
+		return nil
+	}
+
+	return fmt.Errorf("mount pod is not running in 60s, please check its event, mountpod: %s", podName)
+}
+
 func WaitUtilMountReady(ctx context.Context, podName, mntPath string, timeout time.Duration) error {
 	log := util.GenLog(ctx, resourceLog, "")
 	waitCtx, cancel := context.WithTimeout(ctx, 60*time.Second)


### PR DESCRIPTION
When mount pod is not ready because of the container issue, the event of app pod is as follows:

```
  Warning  FailedMount       85s (x11 over 17m)  kubelet            MountVolume.SetUp failed for volume "ee-static" : rpc error: code = Internal desc = Could not mount juicefs: mount pod is not running in 60s, please check its event, mountpod: juicefs-cn-hangzhou.10.0.1.4-ee-static-qtnnyj
```