### PR TITLE
ci: cleanup unused libs for free space

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -103,6 +103,12 @@ jobs:
       matrix:
         testmode: ${{ fromJson(needs.build-matrix.outputs.wmatrix) }}
     steps:
+      - name: "node-cleanup"
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+      - run: df -h
       - uses: actions/checkout@v2
       - name: Prepare microk8s environment
         run: ${GITHUB_WORKSPACE}/.github/scripts/k8s-deps.sh
@@ -156,6 +162,12 @@ jobs:
       matrix:
         testmode: ${{ fromJson(needs.build-matrix.outputs.wmatrix) }}
     steps:
+      - name: "node-cleanup"
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+      - run: df -h
       - uses: actions/checkout@v2
       - name: Prepare microk8s environment
         run: ${GITHUB_WORKSPACE}/.github/scripts/k8s-deps.sh
@@ -210,6 +222,12 @@ jobs:
       matrix:
         testmode: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
     steps:
+      - name: "node-cleanup"
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+      - run: df -h
       - uses: actions/checkout@v2
       - name: Prepare microk8s environment
         run: ${GITHUB_WORKSPACE}/.github/scripts/k8s-deps.sh
@@ -262,6 +280,12 @@ jobs:
       matrix:
         testmode: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
     steps:
+      - name: "node-cleanup"
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+      - run: df -h
       - uses: actions/checkout@v2
       - name: Prepare microk8s environment
         run: ${GITHUB_WORKSPACE}/.github/scripts/k8s-deps.sh

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -39,6 +39,12 @@ jobs:
       matrix:
         testmode: ${{ fromJson(needs.build-matrix.outputs.wmatrix) }}
     steps:
+      - name: "node-cleanup"
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+      - run: df -h
       - uses: actions/checkout@v2
       - name: Build docker image nightly
         env:
@@ -82,6 +88,12 @@ jobs:
       matrix:
         testmode: ${{ fromJson(needs.build-matrix.outputs.wmatrix) }}
     steps:
+      - name: "node-cleanup"
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+      - run: df -h
       - uses: actions/checkout@v2
       - name: Build docker image nightly
         env:
@@ -127,6 +139,12 @@ jobs:
       matrix:
         testmode: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
     steps:
+      - name: "node-cleanup"
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+      - run: df -h
       - uses: actions/checkout@v2
       - name: Build docker image nightly
         env:
@@ -170,6 +188,12 @@ jobs:
       matrix:
         testmode: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
     steps:
+      - name: "node-cleanup"
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+      - run: df -h
       - uses: actions/checkout@v2
       - name: Build docker image nightly
         env:

--- a/.github/workflows/release_check_ce.yaml
+++ b/.github/workflows/release_check_ce.yaml
@@ -33,6 +33,12 @@ jobs:
       matrix:
         testmode: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
     steps:
+      - name: "node-cleanup"
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+      - run: df -h
       - uses: actions/checkout@v2
       - name: Prepare microk8s environment
         run: ${GITHUB_WORKSPACE}/.github/scripts/k8s-deps.sh

--- a/.github/workflows/release_check_ee.yaml
+++ b/.github/workflows/release_check_ee.yaml
@@ -28,6 +28,13 @@ jobs:
       matrix:
         testmode: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
     steps:
+      - run: df -h
+      - name: "node-cleanup"
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+      - run: df -h
       - uses: actions/checkout@v2
       - name: Prepare microk8s environment
         run: ${GITHUB_WORKSPACE}/.github/scripts/k8s-deps.sh


### PR DESCRIPTION
github runner includes some unnecessary librarys, remove them so that they have enough space

- Android SDK (~12GiB)
- Haskell compiler (~7GiB)
- Dotnet SDK (~4GiB)
- CodeQL Cache (~2GiB)