### PR TITLE
fix: resolve concurrent map read and write panic in passfd

### DIFF
--- a/pkg/juicefs/mount/builder/container.go
+++ b/pkg/juicefs/mount/builder/container.go
@@ -116,6 +116,7 @@ func (r *ContainerBuilder) OverwriteVolumes(volume *corev1.Volume, mountPath str
 	volume.VolumeSource = corev1.VolumeSource{
 		HostPath: &corev1.HostPathVolumeSource{
 			Path: hostMount,
+			Type: ptr.To(corev1.HostPathDirectoryOrCreate),
 		},
 	}
 }


### PR DESCRIPTION
I1208 09:41:25.243781       7 main.go:136] "Run CSI node" logger="main"
I1208 09:41:25.270871       7 grace.go:71] "Serve gracefully shutdown is listening" logger="grace" addr="/tmp/juicefs-csi-shutdown.sock"
fatal error: concurrent map read and map write

goroutine 310 [running]:
github.com/juicedata/juicefs-csi-driver/pkg/fuse/passfd.(*Fds).handleFDRequest(0xc000843ec0, {0xc0002ad110, 0x24}, 0xc0006a4158)
	/workspace/pkg/fuse/passfd/passfd.go:336 +0x99
created by github.com/juicedata/juicefs-csi-driver/pkg/fuse/passfd.(*Fds).serveFuseFD.func3 in goroutine 309
	/workspace/pkg/fuse/passfd/passfd.go:329 +0xf2