### PR TITLE
chore: remove static file in dockerfile

### DIFF
--- a/docker/csi.Dockerfile
+++ b/docker/csi.Dockerfile
@@ -83,11 +83,11 @@ RUN apt-get update && apt-get install -y curl fuse procps iputils-ping strace ip
     mkdir /root/.acl && cp /etc/passwd /root/.acl/passwd && cp /etc/group /root/.acl/group && \
     ln -sf /root/.acl/passwd /etc/passwd && ln -sf /root/.acl/group  /etc/group
 
-RUN jfs_mount_path=${JFS_MOUNT_PATH} && \
+RUN jfs_mount_path=${JFS_MOUNT_PATH} && mkdir -p /tmp/juicefs-static && cd /tmp/juicefs-static && \
     bash -c "if [[ '${JFSCHAN}' == beta ]]; then curl -sSL https://static.juicefs.com/release/bin_pkgs/beta_full.tar.gz | tar -xz; jfs_mount_path=${JFS_MOUNT_PATH}.beta; \
     else curl -sSL https://static.juicefs.com/release/bin_pkgs/latest_stable_full.tar.gz | tar -xz; fi;" && \
     bash -c "mkdir -p /usr/local/juicefs/mount; if [[ '${TARGETARCH}' == amd64 ]]; then cp Linux/mount.ceph $jfs_mount_path; else cp Linux/mount.aarch64 $jfs_mount_path; fi;" && \
-    chmod +x ${jfs_mount_path} && cp juicefs.py ${JUICEFS_CLI} && chmod +x ${JUICEFS_CLI}
+    chmod +x ${jfs_mount_path} && cp juicefs.py ${JUICEFS_CLI} && chmod +x ${JUICEFS_CLI} && rm -rf /tmp/juicefs-static && cd /app
 
 COPY --from=csi-builder /workspace/bin/juicefs-csi-driver /usr/local/bin/
 COPY --from=juicefs-builder /workspace/juicefs/juicefs /usr/local/bin/

--- a/docker/ee.juicefs.Dockerfile
+++ b/docker/ee.juicefs.Dockerfile
@@ -54,6 +54,8 @@ INSTALL-TOOLS
 
 RUN <<INSTALL-JUICEFS
 set -e
+mkdir -p /tmp/juicefs-static
+cd /tmp/juicefs-static
 jfs_mount_path=${JFS_MOUNT_PATH}
 jfs_chan=${JFSCHAN}
 targetarch=${TARGETARCH:-amd64}
@@ -74,6 +76,7 @@ elif [[ '${targetarch}' == amd64 ]]; then
 else
   cp Linux/mount.aarch64 $jfs_mount_path
 fi
+rm -rf /tmp/juicefs-static
 "
 chmod +x ${jfs_mount_path}
 cp juicefs.py ${JUICEFS_CLI}

--- a/docker/ee.juicefs.Dockerfile
+++ b/docker/ee.juicefs.Dockerfile
@@ -76,11 +76,11 @@ elif [[ '${targetarch}' == amd64 ]]; then
 else
   cp Linux/mount.aarch64 $jfs_mount_path
 fi
-rm -rf /tmp/juicefs-static
 "
 chmod +x ${jfs_mount_path}
 cp juicefs.py ${JUICEFS_CLI}
 chmod +x ${JUICEFS_CLI}
+rm -rf /tmp/juicefs-static
 INSTALL-JUICEFS
 
 RUN /usr/bin/juicefs version


### PR DESCRIPTION
```
REPOSITORY                     TAG        SIZE       BLOB SIZE
juicedata/mount                ee-test1   1.176GB    589.2MB
juicedata/mount                ee-test2   484.1MB    180.5MB
juicedata/juicefs-csi-driver   test1      1.431GB    710.2MB
juicedata/juicefs-csi-driver   test12     739.3MB    301.4MB
```

这个我们没有用到，并且包含了 windows 和 darwin，预计可节省 `~700MiB (blob ~400MiB)` 