### PR TITLE
fix: avoid subPath race condition for check_mount.sh secret volume

### DIFF
--- a/pkg/juicefs/mount/builder/cci-serverless.go
+++ b/pkg/juicefs/mount/builder/cci-serverless.go
@@ -150,10 +150,12 @@ func (r *CCIBuilder) genCCIServerlessVolumes() ([]corev1.Volume, []corev1.Volume
 		},
 	}
 	volumeMounts := []corev1.VolumeMount{
+		// Mount the entire secret directory instead of using subPath to avoid
+		// race condition with projected volumes (kubernetes/kubernetes#63726).
 		{
 			Name:      "jfs-check-mount",
-			MountPath: checkMountScriptPath,
-			SubPath:   checkMountScriptName,
+			MountPath: checkMountScriptDir,
+			ReadOnly:  true,
 		},
 	}
 

--- a/pkg/juicefs/mount/builder/cci-serverless.go
+++ b/pkg/juicefs/mount/builder/cci-serverless.go
@@ -145,6 +145,9 @@ func (r *CCIBuilder) genCCIServerlessVolumes() ([]corev1.Volume, []corev1.Volume
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  secretName,
 					DefaultMode: ptr.To(mode),
+					Items: []corev1.KeyToPath{
+						{Key: checkMountScriptName, Path: checkMountScriptName},
+					},
 				},
 			},
 		},

--- a/pkg/juicefs/mount/builder/container.go
+++ b/pkg/juicefs/mount/builder/container.go
@@ -132,6 +132,9 @@ func (r *ContainerBuilder) genSidecarVolumes() (volumes []corev1.Volume, volumeM
 			Secret: &corev1.SecretVolumeSource{
 				SecretName:  secretName,
 				DefaultMode: ptr.To(mode),
+				Items: []corev1.KeyToPath{
+					{Key: checkMountScriptName, Path: checkMountScriptName},
+				},
 			},
 		},
 	}}

--- a/pkg/juicefs/mount/builder/container.go
+++ b/pkg/juicefs/mount/builder/container.go
@@ -135,10 +135,14 @@ func (r *ContainerBuilder) genSidecarVolumes() (volumes []corev1.Volume, volumeM
 			},
 		},
 	}}
+	// Mount the entire secret directory instead of using subPath to avoid
+	// race condition with projected volumes (kubernetes/kubernetes#63726).
+	// When using subPath, the container runtime may try to bind-mount the
+	// specific file before kubelet has finished projecting it to disk.
 	volumeMounts = []corev1.VolumeMount{{
 		Name:      "jfs-check-mount",
-		MountPath: checkMountScriptPath,
-		SubPath:   checkMountScriptName,
+		MountPath: checkMountScriptDir,
+		ReadOnly:  true,
 	}}
 	return
 }

--- a/pkg/juicefs/mount/builder/secret.go
+++ b/pkg/juicefs/mount/builder/secret.go
@@ -28,7 +28,11 @@ import (
 
 const (
 	checkMountScriptName = "check_mount.sh"
-	checkMountScriptPath = "/" + checkMountScriptName
+	// checkMountScriptDir is the directory where the check mount script is mounted.
+	// We mount the entire secret directory instead of using subPath to avoid the
+	// race condition with projected volumes (kubernetes/kubernetes#63726).
+	checkMountScriptDir  = "/jfs-scripts"
+	checkMountScriptPath = checkMountScriptDir + "/" + checkMountScriptName
 )
 
 var (

--- a/pkg/juicefs/mount/builder/serverless.go
+++ b/pkg/juicefs/mount/builder/serverless.go
@@ -136,6 +136,9 @@ func (r *ServerlessBuilder) genServerlessVolumes() ([]corev1.Volume, []corev1.Vo
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  secretName,
 					DefaultMode: ptr.To(mode),
+					Items: []corev1.KeyToPath{
+						{Key: checkMountScriptName, Path: checkMountScriptName},
+					},
 				},
 			},
 		},

--- a/pkg/juicefs/mount/builder/serverless.go
+++ b/pkg/juicefs/mount/builder/serverless.go
@@ -146,10 +146,12 @@ func (r *ServerlessBuilder) genServerlessVolumes() ([]corev1.Volume, []corev1.Vo
 			MountPath:        r.jfsSetting.MountPath,
 			MountPropagation: &mp,
 		},
+		// Mount the entire secret directory instead of using subPath to avoid
+		// race condition with projected volumes (kubernetes/kubernetes#63726).
 		{
 			Name:      "jfs-check-mount",
-			MountPath: checkMountScriptPath,
-			SubPath:   checkMountScriptName,
+			MountPath: checkMountScriptDir,
+			ReadOnly:  true,
 		},
 	}
 

--- a/pkg/juicefs/mount/builder/vci-serverless.go
+++ b/pkg/juicefs/mount/builder/vci-serverless.go
@@ -173,6 +173,9 @@ func (r *VCIBuilder) genVCIServerlessVolumes() ([]corev1.Volume, []corev1.Volume
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  secretName,
 					DefaultMode: ptr.To(mode),
+					Items: []corev1.KeyToPath{
+						{Key: checkMountScriptName, Path: checkMountScriptName},
+					},
 				},
 			},
 		},

--- a/pkg/juicefs/mount/builder/vci-serverless.go
+++ b/pkg/juicefs/mount/builder/vci-serverless.go
@@ -182,10 +182,12 @@ func (r *VCIBuilder) genVCIServerlessVolumes() ([]corev1.Volume, []corev1.Volume
 			Name:      sharedVolumeName,
 			MountPath: r.jfsSetting.MountPath,
 		},
+		// Mount the entire secret directory instead of using subPath to avoid
+		// race condition with projected volumes (kubernetes/kubernetes#63726).
 		{
 			Name:      "jfs-check-mount",
-			MountPath: checkMountScriptPath,
-			SubPath:   checkMountScriptName,
+			MountPath: checkMountScriptDir,
+			ReadOnly:  true,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Replace `subPath` mounts with directory mounts for the `check_mount.sh` script to avoid intermittent init container failures caused by a known Kubernetes race condition with projected volumes.

## Problem

We discovered this issue in production running **Kubeflow Pipelines** with **Argo Workflows** on **AWS EKS 1.30** using JuiceFS CSI driver v0.30.0 in **sidecar mode**.

### The Failure Pattern

Pods would intermittently fail with this error:

```
Error: failed to create containerd task: OCI runtime create failed: 
runc create failed: unable to start container process: error during container init: 
error mounting "/var/lib/kubelet/pods/<pod-id>/volume-subpaths/jfs-check-mount/jfs-mount/3" 
to rootfs at "/check_mount.sh": mount src=..., dst=/check_mount.sh: no such file or directory
```

### What Was Happening

1. **Pod is scheduled** → Kubelet starts setting up volumes
2. **JuiceFS init containers start** → Try to mount `/check_mount.sh` using `subPath` from the secret volume
3. **Race condition** → Container runtime (containerd/runc) attempts to bind-mount the specific file BEFORE kubelet has finished projecting the secret to disk
4. **Container fails** at OCI layer with "no such file or directory"
5. **Kubernetes retries** (due to `restartPolicy: Always`) and succeeds
6. **BUT: Argo Workflows detects the transient failure** and marks the workflow as **Failed**

The confusing part: **the Pod succeeds** (all containers eventually complete with exit code 0), but **the Workflow fails** because Argo detected the init container's non-zero exit code before Kubernetes retried.

### Root Cause

The issue is in how `subPath` works with projected volumes (secrets, configmaps). When using `subPath`, the container runtime must bind-mount the specific file at container creation time (OCI layer). If the kubelet hasn't finished writing that file to the projected volume directory, the bind-mount fails.

This is a **known Kubernetes limitation**:
- https://github.com/kubernetes/kubernetes/issues/63726
- https://github.com/kubernetes/kubernetes/issues/50345

The current code in `container.go`, `serverless.go`, etc.:

```go
volumeMounts = []corev1.VolumeMount{{
    Name:      "jfs-check-mount",
    MountPath: checkMountScriptPath,  // "/check_mount.sh"
    SubPath:   checkMountScriptName,  // "check_mount.sh" ← CAUSES RACE
}}
```

### Impact in Production

- **Kubeflow Pipelines** workflows randomly fail
- **Argo Workflows** marks workflows as Failed even though pods succeed
- Users see confusing failures where logs show successful execution
- ML training jobs that take hours fail at random points due to this race
- `restartCount: 1` appears on JuiceFS init containers

## Solution

Mount the **entire secret directory** instead of using `subPath`:

```go
const (
    checkMountScriptDir  = "/jfs-scripts"
    checkMountScriptPath = checkMountScriptDir + "/" + checkMountScriptName
)

volumeMounts = []corev1.VolumeMount{{
    Name:      "jfs-check-mount",
    MountPath: checkMountScriptDir,  // Mount entire directory
    ReadOnly:  true,                  // No subPath needed
}}
```

Directory mounts don't have this race condition because:
1. The mount happens at the volume level, not individual file level
2. The container can start even if files are still being projected
3. The script path changes from `/check_mount.sh` to `/jfs-scripts/check_mount.sh` (which is already handled by `checkMountScriptPath` constant)

## Files Changed

| File | Change |
|------|--------|
| `secret.go` | Add `checkMountScriptDir` constant, update path |
| `container.go` | Use directory mount for sidecar mode |
| `serverless.go` | Use directory mount for serverless mode |
| `vci-serverless.go` | Use directory mount for VCI serverless mode |
| `cci-serverless.go` | Use directory mount for CCI serverless mode |

## Testing

- [x] Code compiles successfully
- [x] Verified fix concept works using PodDefault workaround in production (pods no longer have restarts on JuiceFS init containers)
- [ ] Unit tests (need to verify existing tests pass)
- [ ] Integration tests

## Backwards Compatibility

✅ **Fully backwards compatible**:
- The script path changes from `/check_mount.sh` to `/jfs-scripts/check_mount.sh`
- All usages are internal to the generated pod spec
- The `checkMountScriptPath` constant is already used everywhere the path is referenced
- No user-facing configuration changes required

## Workaround (for those who cannot upgrade immediately)

We successfully mitigated this in production using a Kubeflow PodDefault that injects a small init container before JuiceFS containers:

```yaml
apiVersion: kubeflow.org/v1alpha1
kind: PodDefault
metadata:
  name: juicefs-volume-wait
  namespace: gateway
spec:
  selector:
    matchLabels:
      pipelines.kubeflow.org/v2_component: "true"
  initContainers:
    - name: wait-for-volume-projection
      image: busybox:1.36
      command: ["sh", "-c", "sleep 2"]
```

This gives kubelet time to finish projecting secrets before JuiceFS containers attempt their subPath mounts.

## Environment

- Kubernetes: 1.30.x (AWS EKS)
- JuiceFS CSI Driver: v0.30.0
- Mount mode: sidecar
- Container runtime: containerd
- Orchestrator: Argo Workflows / Kubeflow Pipelines