### PR TITLE
fix: support cleanup of pending mount pods with custom schedulers

### DIFF
--- a/pkg/controller/mount_controller.go
+++ b/pkg/controller/mount_controller.go
@@ -64,9 +64,18 @@ func (m MountController) Reconcile(ctx context.Context, request reconcile.Reques
 		return reconcile.Result{}, nil
 	}
 
+	// Scenario 1: Handle pending mount pod without nodeName (not scheduled yet)
+	// This handles the case where mount pod is stuck in Pending state due to custom scheduler
+	if mountPod.DeletionTimestamp == nil &&
+		mountPod.Status.Phase == corev1.PodPending &&
+		mountPod.Spec.NodeName == "" {
+		return m.handlePendingMountPod(ctx, mountPod)
+	}
+
+	// Scenario 2: Handle mount pod being deleted (original logic)
 	// check mount pod deleted
 	if mountPod.DeletionTimestamp == nil {
-		mountCtrlLog.V(1).Info("pod is not deleted", "name", mountPod.Name)
+		mountCtrlLog.V(1).Info("pod is not deleted and not pending", "name", mountPod.Name)
 		return reconcile.Result{}, nil
 	}
 	if !util.ContainsString(mountPod.GetFinalizers(), common.Finalizer) {
@@ -102,6 +111,124 @@ func (m MountController) Reconcile(ctx context.Context, request reconcile.Reques
 	return reconcile.Result{}, err
 }
 
+// handlePendingMountPod handles pending mount pod that is not scheduled yet (nodeName is empty)
+// It checks if all referenced app pods are deleted, and if so, deletes the mount pod
+func (m *MountController) handlePendingMountPod(ctx context.Context, mountPod *corev1.Pod) (reconcile.Result, error) {
+	mountCtrlLog.V(1).Info("Handling pending mount pod", "name", mountPod.Name, "namespace", mountPod.Namespace)
+
+	// Get target node name from mount pod's nodeSelector
+	// This helps optimize pod search by limiting to a specific node
+	targetNodeName := ""
+	if mountPod.Spec.NodeSelector != nil {
+		targetNodeName = mountPod.Spec.NodeSelector["kubernetes.io/hostname"]
+	}
+
+	// Check all references in mount pod annotations
+	var existingRefs int
+	for k, target := range mountPod.Annotations {
+		if k == util.GetReferenceKey(target) {
+			// Extract pod UID from target path
+			// Target format: /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~csi/<volume-id>/mount
+			targetUid := getPodUid(target)
+			if targetUid == "" {
+				mountCtrlLog.V(1).Info("Could not extract pod UID from target", "target", target)
+				continue
+			}
+
+			// Find pod by UID, optimized by searching only on target node
+			targetPod, err := m.GetPodByUidAndNode(ctx, targetUid, targetNodeName)
+			if err != nil {
+				mountCtrlLog.Error(err, "Failed to search for app pod by UID", "appPodUid", targetUid)
+				return reconcile.Result{}, err
+			}
+
+			if targetPod != nil {
+				mountCtrlLog.V(1).Info("Referenced app pod still exists",
+					"appPod", targetPod.Name,
+					"appPodNamespace", targetPod.Namespace,
+					"appPodUid", targetUid,
+					"mountPod", mountPod.Name)
+				existingRefs++
+			} else {
+				mountCtrlLog.Info("Referenced app pod has been deleted",
+					"appPodUid", targetUid,
+					"mountPod", mountPod.Name)
+			}
+		}
+	}
+
+	// If no app pods reference this mount pod anymore, delete it
+	if existingRefs == 0 {
+		mountCtrlLog.Info("No app pods reference this pending mount pod, deleting it",
+			"mountPod", mountPod.Name,
+			"namespace", mountPod.Namespace)
+
+		if err := m.DeletePod(ctx, mountPod); err != nil {
+			mountCtrlLog.Error(err, "Failed to delete pending mount pod", "mountPod", mountPod.Name)
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{}, nil
+	}
+
+	// Still has references, check again after 10 seconds
+	mountCtrlLog.V(1).Info("Mount pod still has references",
+		"mountPod", mountPod.Name,
+		"existingRefs", existingRefs)
+	return reconcile.Result{RequeueAfter: 10 * time.Minute}, nil
+}
+
+// GetPodByUidAndNode finds a pod by its UID, optimized by label and optional node filter
+func (m *MountController) GetPodByUidAndNode(ctx context.Context, uid string, nodeName string) (*corev1.Pod, error) {
+	// Use label selector to filter app pods (those with juicefs-uniqueid label)
+	labelSelector := metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      common.UniqueId,
+			Operator: metav1.LabelSelectorOpExists,
+		}},
+	}
+	labelSelectorStr, err := metav1.LabelSelectorAsSelector(&labelSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: labelSelectorStr.String(),
+	}
+
+	// Add node filter if nodeName is provided (optimized path)
+	if nodeName != "" {
+		listOptions.FieldSelector = fields.Set{"spec.nodeName": nodeName}.AsSelector().String()
+	}
+
+	// List pods with filters
+	pods, err := m.K8sClient.CoreV1().Pods("").List(ctx, listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	if nodeName != "" {
+		mountCtrlLog.V(1).Info("Searching for pod by UID on specific node with label filter",
+			"uid", uid,
+			"nodeName", nodeName,
+			"filteredPods", len(pods.Items))
+	} else {
+		mountCtrlLog.V(1).Info("Searching for pod by UID across all nodes with label filter",
+			"uid", uid,
+			"filteredPods", len(pods.Items))
+	}
+
+	// Find pod with matching UID
+	for i := range pods.Items {
+		if string(pods.Items[i].UID) == uid {
+			return &pods.Items[i], nil
+		}
+	}
+
+	// Pod not found
+	return nil, nil
+}
+
 func shouldInQueue(pod *corev1.Pod) bool {
 	if pod == nil {
 		return false
@@ -124,12 +251,18 @@ func (m *MountController) SetupWithManager(mgr ctrl.Manager) error {
 		CreateFunc: func(event event.TypedCreateEvent[*corev1.Pod]) bool {
 			pod := event.Object
 			mountCtrlLog.V(1).Info("watch pod created", "name", pod.GetName())
-			// check mount pod deleted
-			if pod.DeletionTimestamp == nil {
-				mountCtrlLog.V(1).Info("pod is not deleted", "name", pod.Name)
-				return false
+
+			// Scenario 1: Mount pod being deleted (original logic)
+			if pod.DeletionTimestamp != nil {
+				return shouldInQueue(pod)
 			}
-			return shouldInQueue(pod)
+
+			// Scenario 2: Pending mount pod not scheduled yet (new logic for handling orphaned pending pods)
+			if pod.Status.Phase == corev1.PodPending && pod.Spec.NodeName == "" {
+				return shouldInQueue(pod)
+			}
+
+			return false
 		},
 		UpdateFunc: func(updateEvent event.TypedUpdateEvent[*corev1.Pod]) bool {
 			podNew, podOld := updateEvent.ObjectNew, updateEvent.ObjectOld
@@ -137,19 +270,24 @@ func (m *MountController) SetupWithManager(mgr ctrl.Manager) error {
 				mountCtrlLog.V(1).Info("pod.onUpdateFunc Skip due to resourceVersion not changed")
 				return false
 			}
-			// check mount pod deleted
-			if podNew.DeletionTimestamp == nil {
-				mountCtrlLog.V(1).Info("pod is not deleted", "name", podNew.Name)
-				return false
+
+			// Scenario 1: Mount pod being deleted (original logic)
+			if podNew.DeletionTimestamp != nil {
+				return shouldInQueue(podNew)
 			}
-			return shouldInQueue(podNew)
+
+			// Scenario 2: Pending mount pod not scheduled yet
+			if podNew.Status.Phase == corev1.PodPending && podNew.Spec.NodeName == "" {
+				return shouldInQueue(podNew)
+			}
+
+			return false
 		},
 		DeleteFunc: func(deleteEvent event.TypedDeleteEvent[*corev1.Pod]) bool {
 			pod := deleteEvent.Object
 			mountCtrlLog.V(1).Info("watch pod deleted", "name", pod.GetName())
-			// check mount pod deleted
+			// Only handle pods being deleted with finalizer
 			if pod.DeletionTimestamp == nil {
-				mountCtrlLog.V(1).Info("pod is not deleted", "name", pod.Name)
 				return false
 			}
 			return shouldInQueue(pod)

--- a/pkg/controller/mountinfo.go
+++ b/pkg/controller/mountinfo.go
@@ -230,6 +230,7 @@ type mountItem struct {
 }
 
 func getPodUid(target string) string {
+	// Target format: /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~csi/<volume-id>/mount
 	pair := strings.Split(target, containerCsiDirectory)
 	if len(pair) != 2 {
 		return ""


### PR DESCRIPTION
This commit addresses the issue where mount pods with custom schedulers
remain stuck in Pending state forever and are not cleaned up when their
corresponding app pods are deleted.

Root Cause:
When mount pods use custom schedulers, they may remain in Pending state
(spec.nodeName is empty) if the scheduler rejects them.  The csi not will not
delete it.

Testing:
Verified that pending mount pods are correctly cleaned up when their
app pods are deleted, even when using custom schedulers.