### PR TITLE
fix(dashboard): fix list fs shared mountpods

### DIFF
--- a/pkg/dashboard/services/pods/cache_pod_service.go
+++ b/pkg/dashboard/services/pods/cache_pod_service.go
@@ -126,7 +126,7 @@ func (s *CachePodService) ListAppPods(c *gin.Context) (*ListAppPodResult, error)
 				podLog.Error(err, "list pvcs of pod error", "namespace", pod.Namespace, "name", pod.Name)
 				continue
 			}
-			extraPods.MountPods, err = s.listMountPodOfPV(c, &pod, extraPods.Pvs)
+			extraPods.MountPods, err = s.listMountPodsOfAppPod(c, &pod)
 			if err != nil {
 				podLog.Error(err, "list mountpods of pod error", "namespace", pod.Namespace, "name", pod.Name)
 			}

--- a/pkg/dashboard/services/pods/pod_service.go
+++ b/pkg/dashboard/services/pods/pod_service.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	corev1 "k8s.io/api/core/v1"
@@ -96,7 +95,7 @@ func (s *podService) listMountPodsOfAppPod(ctx context.Context, pod *corev1.Pod)
 	}
 	for i, item := range pods.Items {
 		for _, v := range item.Annotations {
-			if strings.Contains(v, string(pod.UID)) {
+			if utils.GetTargetUID(v) == string(pod.UID) {
 				mountPods = append(mountPods, pods.Items[i])
 				break
 			}

--- a/pkg/dashboard/services/pods/pod_service.go
+++ b/pkg/dashboard/services/pods/pod_service.go
@@ -76,22 +76,29 @@ func (s *podService) listPVsOfPVC(ctx context.Context, pvcs []corev1.PersistentV
 	return pvs, nil
 }
 
-func (s *podService) listMountPodOfPV(ctx context.Context, pod *corev1.Pod, pvs []corev1.PersistentVolume) ([]corev1.Pod, error) {
+func (s *podService) listMountPodsOfAppPod(ctx context.Context, pod *corev1.Pod) ([]corev1.Pod, error) {
 	mountPods := make([]corev1.Pod, 0)
-	for _, pv := range pvs {
-		var pods corev1.PodList
-		err := s.client.List(ctx, &pods, &client.ListOptions{
-			LabelSelector: utils.LabelSelectorOfMount(pv),
-		})
-		if err != nil {
-			continue
-		}
-		for i, item := range pods.Items {
-			for _, v := range item.Annotations {
-				if strings.Contains(v, string(pod.UID)) {
-					mountPods = append(mountPods, pods.Items[i])
-					break
-				}
+	if pod.Spec.NodeName == "" {
+		return mountPods, nil
+	}
+	labelSelector := labels.SelectorFromSet(map[string]string{
+		"app.kubernetes.io/name": "juicefs-mount",
+	})
+	fieldSelector := fields.SelectorFromSet(fields.Set{"spec.nodeName": pod.Spec.NodeName})
+
+	var pods corev1.PodList
+	err := s.client.List(ctx, &pods, &client.ListOptions{
+		LabelSelector: labelSelector,
+		FieldSelector: fieldSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for i, item := range pods.Items {
+		for _, v := range item.Annotations {
+			if strings.Contains(v, string(pod.UID)) {
+				mountPods = append(mountPods, pods.Items[i])
+				break
 			}
 		}
 	}
@@ -258,11 +265,7 @@ func (s *podService) ListPodPVCs(ctx context.Context, pod *corev1.Pod) ([]corev1
 }
 
 func (s *podService) ListAppPodMountPods(ctx context.Context, pod *corev1.Pod) ([]corev1.Pod, error) {
-	pvs, err := s.ListPodPVs(ctx, pod)
-	if err != nil {
-		return nil, err
-	}
-	mountPods, err := s.listMountPodOfPV(ctx, pod, pvs)
+	mountPods, err := s.listMountPodsOfAppPod(ctx, pod)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When fsShare is enabled, it is not possible to obtain the app pod's mountpod from the dashboard because the unique-id is the name of the file system.

fix:
List all mountpods on the node and match the app pod uid based on the annotation.