### PR TITLE
fix: remove incorrect shell escaping for env vars passed to exec

### DIFF
--- a/pkg/config/command.go
+++ b/pkg/config/command.go
@@ -207,7 +207,7 @@ func GetJfsVolUUID(ctx context.Context, s *JfsSetting) (string, error) {
 	statusCmd := exec.CommandContext(cmdCtx, CeCliPath, "status", s.Source)
 	envs := syscall.Environ()
 	for key, val := range s.Envs {
-		envs = append(envs, fmt.Sprintf("%s=%s", security.EscapeBashStr(key), security.EscapeBashStr(val)))
+		envs = append(envs, fmt.Sprintf("%s=%s", key, val))
 	}
 	statusCmd.SetEnv(envs)
 	stdout, err := statusCmd.CombinedOutput()

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -45,7 +45,6 @@ import (
 	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util/resource"
-	"github.com/juicedata/juicefs-csi-driver/pkg/util/security"
 )
 
 const (
@@ -719,7 +718,7 @@ func (j *juicefs) AuthFs(ctx context.Context, secrets map[string]string, setting
 	authCmd := j.Exec.CommandContext(cmdCtx, config.CliPath, args...)
 	envs := syscall.Environ()
 	for key, val := range setting.Envs {
-		envs = append(envs, fmt.Sprintf("%s=%s", security.EscapeBashStr(key), security.EscapeBashStr(val)))
+		envs = append(envs, fmt.Sprintf("%s=%s", key, val))
 	}
 	if secrets["storage"] == "ceph" || secrets["storage"] == "gs" {
 		envs = append(envs, "JFS_NO_CHECK_OBJECT_STORAGE=1")
@@ -767,7 +766,7 @@ func (j *juicefs) SetQuota(ctx context.Context, secrets map[string]string, jfsSe
 	defer cmdCancel()
 	envs := syscall.Environ()
 	for key, val := range jfsSetting.Envs {
-		envs = append(envs, fmt.Sprintf("%s=%s", security.EscapeBashStr(key), security.EscapeBashStr(val)))
+		envs = append(envs, fmt.Sprintf("%s=%s", key, val))
 	}
 	var err error
 	if !jfsSetting.IsCe {
@@ -901,7 +900,7 @@ func (j *juicefs) ceFormat(ctx context.Context, secrets map[string]string, noUpd
 	formatCmd := j.Exec.CommandContext(cmdCtx, "/bin/bash", "-c", strings.Join(shArgs, " "))
 	envs := syscall.Environ()
 	for key, val := range setting.Envs {
-		envs = append(envs, fmt.Sprintf("%s=%s", security.EscapeBashStr(key), security.EscapeBashStr(val)))
+		envs = append(envs, fmt.Sprintf("%s=%s", key, val))
 	}
 	if secrets["storage"] == "ceph" || secrets["storage"] == "gs" {
 		envs = append(envs, "JFS_NO_CHECK_OBJECT_STORAGE=1")

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -42,7 +42,6 @@ import (
 	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util/resource"
-	"github.com/juicedata/juicefs-csi-driver/pkg/util/security"
 )
 
 type PodMount struct {
@@ -566,7 +565,7 @@ func (p *PodMount) GetJfsVolUUID(ctx context.Context, jfsSetting *jfsConfig.JfsS
 	statusCmd := p.Exec.CommandContext(cmdCtx, jfsConfig.CeCliPath, "status", jfsSetting.Source)
 	envs := syscall.Environ()
 	for key, val := range jfsSetting.Envs {
-		envs = append(envs, fmt.Sprintf("%s=%s", security.EscapeBashStr(key), security.EscapeBashStr(val)))
+		envs = append(envs, fmt.Sprintf("%s=%s", key, val))
 	}
 	statusCmd.SetEnv(envs)
 	stdout, err := statusCmd.CombinedOutput()


### PR DESCRIPTION
Resolves https://github.com/juicedata/juicefs-csi-driver/issues/1477