### PR TITLE
fix: add vol lock for node publish/unpublish operation

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Setup upterm session
         if: ${{ failure() }}
         timeout-minutes: 60
-        uses: lhotari/action-upterm@v1
+        run: curl -sSf https://sshx.io/get | sh -s run
 
   build-matrix:
     runs-on: ubuntu-latest

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -32,6 +32,7 @@ import (
 	k8s "github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util/dispatch"
+	"github.com/juicedata/juicefs-csi-driver/pkg/util/resource"
 )
 
 func TestNewDriver(t *testing.T) {
@@ -46,7 +47,9 @@ func TestNewDriver(t *testing.T) {
 			})
 			defer patch1.Reset()
 			patch3 := ApplyFunc(newNodeService, func(nodeID string, k8sClient *k8s.K8sClient) (*nodeService, error) {
-				return &nodeService{}, nil
+				return &nodeService{
+					volLocks: resource.NewVolumeLocks(),
+				}, nil
 			})
 			defer patch3.Reset()
 
@@ -83,7 +86,9 @@ func TestNewDriver(t *testing.T) {
 			})
 			defer patch1.Reset()
 			patch3 := ApplyFunc(newNodeService, func(nodeID string, k8sClient *k8s.K8sClient) (*nodeService, error) {
-				return &nodeService{}, errors.New("test")
+				return &nodeService{
+					volLocks: resource.NewVolumeLocks(),
+				}, errors.New("test")
 			})
 			defer patch3.Reset()
 			mockCtl := gomock.NewController(t)

--- a/pkg/driver/fakes.go
+++ b/pkg/driver/fakes.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util/dispatch"
+	"github.com/juicedata/juicefs-csi-driver/pkg/util/resource"
 )
 
 // NewFakeDriver creates a new mock driver used for testing
@@ -57,6 +58,7 @@ func NewFakeDriver(endpoint string, fakeProvider juicefs.Interface) *Driver {
 			metrics:            metrics,
 			SafeFormatAndMount: fakeMounter,
 			unmountedPaths:     &sync.Map{},
+			volLocks:           resource.NewVolumeLocks(),
 		},
 	}
 }

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -186,7 +186,7 @@ func (d *nodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 
 	if acquired := d.volLocks.TryAcquire(volumeID); !acquired {
-		return nil, status.Errorf(codes.Aborted, "volume %s is already being published, try again later", volumeID)
+		return nil, status.Errorf(codes.Aborted, "volume %s operation is already in progress, try again later", volumeID)
 	}
 	defer d.volLocks.Release(volumeID)
 
@@ -298,7 +298,7 @@ func (d *nodeService) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	volumeId := req.GetVolumeId()
 	log.Info("get volume_id", "volumeId", volumeId)
 	if acquired := d.volLocks.TryAcquire(volumeId); !acquired {
-		return nil, status.Errorf(codes.Aborted, "volume %s is already being unpublished, try again later", volumeId)
+		return nil, status.Errorf(codes.Aborted, "volume %s operation is in progress, try again later", volumeId)
 	}
 	defer d.volLocks.Release(volumeId)
 

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -66,6 +66,7 @@ type nodeService struct {
 	k8sClient      *k8sclient.K8sClient
 	metrics        *nodeMetrics
 	unmountedPaths *sync.Map
+	volLocks       *resource.VolumeLocks
 }
 
 type nodeMetrics struct {
@@ -109,6 +110,7 @@ func newNodeService(nodeID string, k8sClient *k8sclient.K8sClient, reg prometheu
 		k8sClient:          k8sClient,
 		metrics:            metrics,
 		unmountedPaths:     &sync.Map{},
+		volLocks:           resource.NewVolumeLocks(),
 	}
 	go ns.cleanupUnmountedPaths()
 
@@ -182,6 +184,11 @@ func (d *nodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if !isValidVolumeCapabilities([]*csi.VolumeCapability{volCap}) {
 		return nil, status.Error(codes.InvalidArgument, "Volume capability not supported")
 	}
+
+	if acquired := d.volLocks.TryAcquire(volumeID); !acquired {
+		return nil, status.Errorf(codes.Aborted, "volume %s is already being published, try again later", volumeID)
+	}
+	defer d.volLocks.Release(volumeID)
 
 	notMnt, notMntErr := d.IsLikelyNotMountPoint(target)
 	if notMntErr != nil && !errors.Is(notMntErr, os.ErrNotExist) {
@@ -290,6 +297,10 @@ func (d *nodeService) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 
 	volumeId := req.GetVolumeId()
 	log.Info("get volume_id", "volumeId", volumeId)
+	if acquired := d.volLocks.TryAcquire(volumeId); !acquired {
+		return nil, status.Errorf(codes.Aborted, "volume %s is already being unpublished, try again later", volumeId)
+	}
+	defer d.volLocks.Release(volumeId)
 
 	err := d.juicefs.JfsUnmount(ctxWithLog, volumeId, target)
 	if err != nil {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/juicedata/juicefs-csi-driver/pkg/juicefs/mocks"
 	k8s "github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util"
+	"github.com/juicedata/juicefs-csi-driver/pkg/util/resource"
 )
 
 var _ = Describe("nodeService", func() {
@@ -65,6 +66,7 @@ var _ = Describe("nodeService", func() {
 			metrics:            metrics,
 			SafeFormatAndMount: *mounter,
 			unmountedPaths:     &sync.Map{},
+			volLocks:           resource.NewVolumeLocks(),
 		}
 	})
 
@@ -570,6 +572,7 @@ func Test_nodeService_NodeGetCapabilities(t *testing.T) {
 				nodeID:    tt.fields.nodeID,
 				k8sClient: tt.fields.k8sClient,
 				metrics:   metrics,
+				volLocks:  resource.NewVolumeLocks(),
 			}
 			got, err := d.NodeGetCapabilities(tt.args.ctx, tt.args.req)
 			if (err != nil) != tt.wantErr {
@@ -619,6 +622,7 @@ func Test_nodeService_NodeGetInfo(t *testing.T) {
 				nodeID:    tt.fields.nodeID,
 				k8sClient: tt.fields.k8sClient,
 				metrics:   metrics,
+				volLocks:  resource.NewVolumeLocks(),
 			}
 			got, err := d.NodeGetInfo(tt.args.ctx, tt.args.req)
 			if (err != nil) != tt.wantErr {
@@ -695,6 +699,7 @@ func Test_nodeService_NodeExpandVolume(t *testing.T) {
 				nodeID:    tt.fields.nodeID,
 				k8sClient: tt.fields.k8sClient,
 				metrics:   metrics,
+				volLocks:  resource.NewVolumeLocks(),
 			}
 			got, err := d.NodeExpandVolume(tt.args.ctx, tt.args.req)
 			if (err != nil) != tt.wantErr {
@@ -742,6 +747,7 @@ func Test_nodeService_NodeGetVolumeStats(t *testing.T) {
 				nodeID:    tt.fields.nodeID,
 				k8sClient: tt.fields.k8sClient,
 				metrics:   metrics,
+				volLocks:  resource.NewVolumeLocks(),
 			}
 			got, err := d.NodeGetVolumeStats(tt.args.ctx, tt.args.req)
 			if (err != nil) != tt.wantErr {
@@ -789,6 +795,7 @@ func Test_nodeService_NodeStageVolume(t *testing.T) {
 				nodeID:    tt.fields.nodeID,
 				k8sClient: tt.fields.k8sClient,
 				metrics:   metrics,
+				volLocks:  resource.NewVolumeLocks(),
 			}
 			got, err := d.NodeStageVolume(tt.args.ctx, tt.args.req)
 			if (err != nil) != tt.wantErr {
@@ -836,6 +843,7 @@ func Test_nodeService_NodeUnstageVolume(t *testing.T) {
 				nodeID:    tt.fields.nodeID,
 				k8sClient: tt.fields.k8sClient,
 				metrics:   metrics,
+				volLocks:  resource.NewVolumeLocks(),
 			}
 			got, err := d.NodeUnstageVolume(tt.args.ctx, tt.args.req)
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
ref: 

Aliyun: 
https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver/blob/013c936f22a124ba4396e4ab599622263cdf1822/pkg/disk/nodeserver.go#L267-L270

Azure:
https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/b86b8675a73609cde0345811abb614cda3b0a021/pkg/azuredisk/nodeserver.go#L101-L104

