### PR TITLE
fix: handle case where PVC is not found in parseSetting

### DIFF
--- a/pkg/util/resource/pod.go
+++ b/pkg/util/resource/pod.go
@@ -410,6 +410,10 @@ func GetPVWithVolumeHandleOrAppInfo(ctx context.Context, client *k8s.K8sClient, 
 		return nil, nil, fmt.Errorf("pv not found by volumeHandle %s", volumeHandle)
 	}
 
+	if pv.Spec.ClaimRef == nil {
+		return pv, nil, fmt.Errorf("pv %s has no ClaimRef", pv.Name)
+	}
+
 	pvc, err := client.GetPersistentVolumeClaim(ctx, pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace)
 	if err != nil {
 		// maybe pvc is already deleted

--- a/pkg/util/resource/pod.go
+++ b/pkg/util/resource/pod.go
@@ -412,6 +412,15 @@ func GetPVWithVolumeHandleOrAppInfo(ctx context.Context, client *k8s.K8sClient, 
 
 	pvc, err := client.GetPersistentVolumeClaim(ctx, pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace)
 	if err != nil {
+		// maybe pvc is already deleted
+		if k8serrors.IsNotFound(err) {
+			return pv, &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pv.Spec.ClaimRef.Name,
+					Namespace: pv.Spec.ClaimRef.Namespace,
+				},
+			}, nil
+		}
 		return nil, nil, err
 	}
 	return pv, pvc, nil


### PR DESCRIPTION
configmap 里面有基于某个 pvc 单独指定的参数的情况下，当删除 pvc 的时候，pvc 会早于 pv 删除。获取不到具体的 pvc，删除 job 会应用到错误的配置。