### PR TITLE
fix: mount config secrets to local dirs before conroller auth

### DIFF
--- a/pkg/controller/secret_controller.go
+++ b/pkg/controller/secret_controller.go
@@ -173,6 +173,55 @@ func refreshSecretInitConfig(ctx context.Context, client *k8sclient.K8sClient, n
 	}
 	defer os.RemoveAll(tempConfDir)
 
+	// Prepare config secrets at their specified mount paths for auth.
+	// Only needed for storage backends that rely on local credential files (ceph, gs).
+	// jfsSetting.Configs maps Kubernetes Secret name → local directory path.
+	type configDir struct {
+		path    string
+		files   []string
+		created bool
+	}
+	var configDirs []configDir
+	defer func() {
+		for _, cd := range configDirs {
+			if cd.created {
+				os.RemoveAll(cd.path)
+			} else {
+				for _, f := range cd.files {
+					os.Remove(f)
+				}
+			}
+		}
+	}()
+	storage := jfsSetting.Storage
+	if storage == "ceph" || storage == "gs" {
+		for secretName, mountPath := range jfsSetting.Configs {
+			configSecret, err := client.GetSecret(ctx, secretName, config.Namespace)
+			if err != nil {
+				secretCtrlLog.Error(err, "get config secret failed", "secret", secretName)
+				return err
+			}
+			_, statErr := os.Stat(mountPath)
+			dirCreated := os.IsNotExist(statErr)
+			if dirCreated {
+				if err := os.MkdirAll(mountPath, 0755); err != nil {
+					secretCtrlLog.Error(err, "mkdir for config failed", "path", mountPath)
+					return err
+				}
+			}
+			cd := configDir{path: mountPath, created: dirCreated}
+			for k, v := range configSecret.Data {
+				p := filepath.Join(mountPath, k)
+				if err := os.WriteFile(p, v, 0600); err != nil {
+					secretCtrlLog.Error(err, "write config file failed", "path", p)
+					return err
+				}
+				cd.files = append(cd.files, p)
+			}
+			configDirs = append(configDirs, cd)
+		}
+	}
+
 	initconfigs := ""
 	jfsSetting.ClientConfPath = tempConfDir
 	output, err := jfs.AuthFs(ctx, secretsMap, jfsSetting, true)

--- a/pkg/controller/secret_controller.go
+++ b/pkg/controller/secret_controller.go
@@ -202,6 +202,10 @@ func refreshSecretInitConfig(ctx context.Context, client *k8sclient.K8sClient, n
 				return err
 			}
 			_, statErr := os.Stat(mountPath)
+			if statErr != nil && !os.IsNotExist(statErr) {
+				secretCtrlLog.Error(statErr, "stat for config mount path failed", "path", mountPath)
+				return statErr
+			}
 			dirCreated := os.IsNotExist(statErr)
 			if dirCreated {
 				if err := os.MkdirAll(mountPath, 0755); err != nil {
@@ -212,6 +216,15 @@ func refreshSecretInitConfig(ctx context.Context, client *k8sclient.K8sClient, n
 			cd := configDir{path: mountPath, created: dirCreated}
 			for k, v := range configSecret.Data {
 				p := filepath.Join(mountPath, k)
+				_, err := os.Stat(p)
+				if err == nil {
+					statErr := fmt.Errorf("config file already exists at %s", p)
+					secretCtrlLog.Error(statErr, "config file already exists", "path", p)
+					return statErr
+				} else if !os.IsNotExist(err) {
+					secretCtrlLog.Error(err, "stat config file failed", "path", p)
+					return err
+				}
 				if err := os.WriteFile(p, v, 0600); err != nil {
 					secretCtrlLog.Error(err, "write config file failed", "path", p)
 					return err

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -720,9 +720,7 @@ func (j *juicefs) AuthFs(ctx context.Context, secrets map[string]string, setting
 	for key, val := range setting.Envs {
 		envs = append(envs, fmt.Sprintf("%s=%s", key, val))
 	}
-	if secrets["storage"] == "ceph" || secrets["storage"] == "gs" {
-		envs = append(envs, "JFS_NO_CHECK_OBJECT_STORAGE=1")
-	}
+
 	authCmd.SetEnv(envs)
 	res, err := authCmd.CombinedOutput()
 	log.Info("auth output", "output", res)
@@ -901,9 +899,6 @@ func (j *juicefs) ceFormat(ctx context.Context, secrets map[string]string, noUpd
 	envs := syscall.Environ()
 	for key, val := range setting.Envs {
 		envs = append(envs, fmt.Sprintf("%s=%s", key, val))
-	}
-	if secrets["storage"] == "ceph" || secrets["storage"] == "gs" {
-		envs = append(envs, "JFS_NO_CHECK_OBJECT_STORAGE=1")
 	}
 	formatCmd.SetEnv(envs)
 	res, err := formatCmd.CombinedOutput()


### PR DESCRIPTION
When a JuiceFS secret contains a `configs` field (e.g. `"gc-secret: /root/.config/gcloud"` `"ceph-conf": "/etc/ceph"`), the secret controller now fetches each referenced Kubernetes Secret and writes its data keys as files into the specified local directory prior to calling `AuthFs`. The written files (and any newly created directories) are removed after auth completes.