### PR TITLE
fix: preserve metadata for snapshot clone operations

### DIFF
--- a/docs/en/guide/snapshot.md
+++ b/docs/en/guide/snapshot.md
@@ -27,7 +27,7 @@ JuiceFS CSI Driver supports the CSI Volume Snapshot feature. You can use the `Vo
 
 JuiceFS CSI Driver uses the [`juicefs clone`](https://juicefs.com/docs/cloud/reference/command_reference/#snapshot) command to implement the snapshot feature.
 
-- **Create a Snapshot**: The CSI Driver starts a Job to clone the source directory to `.snapshots/<sourceVolumeID>/<snapshotID>` directory.
+- **Create a Snapshot**: The CSI Driver starts a Job to clone the source directory to `.snapshots/<sourceVolumeID>/<snapshotID>` directory. The clone command uses `-p` to preserve file UID, GID, and mode.
 
 - **Restore a Snapshot**: The CSI Driver starts a Job to clone the snapshot directory to the new PV directory.
 

--- a/docs/zh_cn/guide/snapshot.md
+++ b/docs/zh_cn/guide/snapshot.md
@@ -27,7 +27,7 @@ JuiceFS CSI Driver 支持 CSI 卷快照功能。你可以使用 `VolumeSnapshot`
 
 JuiceFS CSI Driver 使用 [`juicefs clone`](https://juicefs.com/docs/zh/cloud/reference/command_reference/#snapshot) 命令来实现快照功能。
 
-- **创建快照**：CSI Driver 会启动一个 Job，将源目录克隆到 PV 对应的文件系统的 `.snapshots/<sourceVolumeID>/<snapshotID>` 目录。
+- **创建快照**：CSI Driver 会启动一个 Job，将源目录克隆到 PV 对应的文件系统的 `.snapshots/<sourceVolumeID>/<snapshotID>` 目录。默认会在 `clone` 命令中带上 `-p`，保留文件的 UID、GID 和权限位。
 
 - **恢复快照**：CSI Driver 会启动一个 Job，将快照目录克隆到新的 PV 目录。
   

--- a/pkg/juicefs/mount/builder/job.go
+++ b/pkg/juicefs/mount/builder/job.go
@@ -410,7 +410,7 @@ echo "Creating snapshot directory..."
 mkdir -p /mnt/jfs/.snapshots/%s
 
 echo "Cloning volume to snapshot..."
-juicefs clone /mnt/jfs%s /mnt/jfs/.snapshots/%s/%s
+juicefs clone -p /mnt/jfs%s /mnt/jfs/.snapshots/%s/%s
 
 echo "=========================================="
 echo "Snapshot created successfully!"
@@ -474,7 +474,7 @@ if [ -d "/mnt/jfs/%s" ]; then
 fi
 
 echo "Cloning snapshot to new volume using native juicefs clone..."
-juicefs clone /mnt/jfs/.snapshots/%s/%s /mnt/jfs/%s
+juicefs clone -p /mnt/jfs/.snapshots/%s/%s /mnt/jfs/%s
 
 echo "=========================================="
 echo "Restore completed successfully!"


### PR DESCRIPTION
## Summary
- make snapshot and restore clone jobs use `juicefs clone -p` by default to preserve uid, gid, and mode

## Why
Snapshot clone operations were not preserving file ownership and mode by default. That could change metadata during snapshot creation or restore.

## Root cause
The snapshot and restore job builders always invoked `juicefs clone` without `-p`, snapshot request parameters were not passed into the backend implementation, and restore was not tied to snapshot-specific preserve configuration.

close: #1552