### PR TITLE
fix(dashboard): fix duplicate sys pods when stale index items are removed

### DIFF
--- a/pkg/dashboard/services/pods/cache_pod_service.go
+++ b/pkg/dashboard/services/pods/cache_pod_service.go
@@ -282,6 +282,7 @@ func (c *CachePodService) Reconcile(ctx context.Context, req reconcile.Request) 
 	}
 	if pod.DeletionTimestamp != nil {
 		c.appIndexes.RemoveIndex(req.NamespacedName)
+		c.sysIndexes.RemoveIndex(req.NamespacedName)
 		if utils.IsCsiNode(pod) {
 			c.csiNodeLock.Lock()
 			delete(c.csiNodeIndex, pod.Spec.NodeName)

--- a/pkg/dashboard/utils/index.go
+++ b/pkg/dashboard/utils/index.go
@@ -81,11 +81,13 @@ func (i *TimeOrderedIndexes[T]) AddIndex(resource *T, metaGetter func(*T) metav1
 		Namespace: meta.Namespace,
 		Name:      meta.Name,
 	}
-	for e := i.list.Back(); e != nil; e = e.Prev() {
+	for e := i.list.Back(); e != nil; {
 		currentResource, err := resourceGetter(e.Value.(types.NamespacedName))
 		if err != nil || currentResource == nil {
 			indexLog.V(1).Info("failed to get resource", "namespacedName", e.Value.(types.NamespacedName), "error", err)
+			prev := e.Prev()
 			i.list.Remove(e)
+			e = prev
 			continue
 		}
 		currentMeta := metaGetter(currentResource)
@@ -96,6 +98,7 @@ func (i *TimeOrderedIndexes[T]) AddIndex(resource *T, metaGetter func(*T) metav1
 			i.list.InsertAfter(name, e)
 			return
 		}
+		e = e.Prev()
 	}
 	i.list.PushFront(name)
 }

--- a/pkg/dashboard/utils/index_test.go
+++ b/pkg/dashboard/utils/index_test.go
@@ -95,3 +95,70 @@ func TestIndexAdd(t *testing.T) {
 		t.Errorf("expected index to be [pod1, pod2], got %v", i.Debug())
 	}
 }
+
+func TestIndexAddNoDuplicateWhenStaleEntryRemoved(t *testing.T) {
+	i := NewTimeIndexes[corev1.Pod]()
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: "default",
+			UID:       "1",
+			CreationTimestamp: metav1.Time{
+				Time: time.Now().Add(-1 * time.Hour),
+			},
+		},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod2",
+			Namespace:         "default",
+			UID:               "2",
+			CreationTimestamp: metav1.Now(),
+		},
+	}
+
+	metaGetter := func(p *corev1.Pod) metav1.ObjectMeta {
+		return p.ObjectMeta
+	}
+
+	// Initially both pods are available
+	allAvailable := func(n types.NamespacedName) (*corev1.Pod, error) {
+		if n.Name == "pod1" {
+			return pod1, nil
+		}
+		if n.Name == "pod2" {
+			return pod2, nil
+		}
+		return nil, nil
+	}
+
+	i.AddIndex(pod1, metaGetter, allAvailable)
+	i.AddIndex(pod2, metaGetter, allAvailable)
+	if i.Length() != 2 {
+		t.Fatalf("expected length of 2, got %d", i.Length())
+	}
+
+	// Now pod2 is deleted from K8s but its entry is still in the list.
+	// When pod1 gets an update, AddIndex is called with a resourceGetter
+	// that returns nil for pod2 (stale entry).
+	pod2Deleted := func(n types.NamespacedName) (*corev1.Pod, error) {
+		if n.Name == "pod1" {
+			return pod1, nil
+		}
+		// pod2 is gone
+		return nil, nil
+	}
+
+	// Re-add pod1 (simulates a reconcile update event for pod1)
+	i.AddIndex(pod1, metaGetter, pod2Deleted)
+
+	// Should still have only 1 entry (pod2 removed, pod1 deduped)
+	if i.Length() != 1 {
+		t.Errorf("expected length of 1, got %d; list: %v", i.Length(), i.Debug())
+	}
+	if !reflect.DeepEqual(i.Debug(), []types.NamespacedName{
+		{Namespace: "default", Name: "pod1"},
+	}) {
+		t.Errorf("expected index to be [pod1], got %v", i.Debug())
+	}
+}


### PR DESCRIPTION
<img width="1632" height="655" alt="image" src="https://github.com/user-attachments/assets/bd3b0209-5b3a-4873-9604-ecc7aabeb3c2" />

With dashboard manager mode enabled, the System Pod page could occasionally show the same Pod multiple times. 

The issue was in TimeOrderedIndexes.AddIndex().

While iterating backward through the linked list, if the code encountered a stale entry, it removed that element and then continued traversal using the removed list node. With container/list, continuing traversal from a removed element is unsafe and can cause the scan to stop early.

When that happened, the code could miss an older existing entry for the same Pod and insert it again, producing duplicate rows in the dashboard list.

A representative case is:

- The index already contains an older pod1
- A newer stale pod2 is still present in the list
- pod1 receives an update and triggers AddIndex()
- Traversal first hits stale pod2, removes it, and stops effectively too early
- The existing pod1 entry is never reached
- pod1 gets inserted again, resulting in duplicate entries