### PR TITLE
chore: update Go version to 1.25

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -48,10 +48,10 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - name: Set up Go 1.24.x
+      - name: Set up Go 1.25.x
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+version: "2"
+
+linters:
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - "-QF1003"
+        - "-QF1007"
+        - "-QF1008"
+        - "-QF1012"
+        - "-ST1003"
+        - "-ST1012"
+        - "-ST1016"
+        - "-ST1019"
+  exclusions:
+    presets:
+      - comments
+      - legacy
+      - std-error-handling

--- a/docker/ce.juicefs.Dockerfile
+++ b/docker/ce.juicefs.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.24-bullseye as binaryimage
+FROM golang:1.25-bullseye as binaryimage
 
 ARG GOPROXY
 ARG TARGETARCH

--- a/docker/csi.Dockerfile
+++ b/docker/csi.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.24-bookworm AS csi-builder
+FROM golang:1.25-bookworm AS csi-builder
 ARG GOPROXY
 ARG TARGETARCH
 
@@ -27,7 +27,7 @@ COPY --from=project Makefile .
 ENV GOPROXY=${GOPROXY:-https://proxy.golang.org}
 RUN make
 
-FROM golang:1.24-bullseye AS juicefs-builder
+FROM golang:1.25-bullseye AS juicefs-builder
 ARG GOPROXY
 ARG TARGETARCH
 ARG JUICEFS_REPO_URL=https://github.com/juicedata/juicefs

--- a/docker/dashboard.Dockerfile
+++ b/docker/dashboard.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.24-alpine as builder
+FROM golang:1.25-alpine as builder
 ARG GOPROXY
 ARG HTTPS_PROXY
 ARG HTTP_PROXY

--- a/docker/dev.juicefs.Dockerfile
+++ b/docker/dev.juicefs.Dockerfile
@@ -14,7 +14,7 @@
 
 FROM golang:1.20-buster as binaryimage
 
-ARG GO_VERSION=1.24.7
+ARG GO_VERSION=1.25.0
 ARG GOPROXY
 ARG TARGETARCH=amd64
 

--- a/go.mod
+++ b/go.mod
@@ -109,4 +109,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
-go 1.24.0
+go 1.25.0

--- a/hack/verify-golint
+++ b/hack/verify-golint
@@ -18,7 +18,7 @@ set -euo pipefail
 
 if ! which golangci-lint > /dev/null; then
     echo "Cannot find golangci-lint. Installing golangci-lint..."
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
+    GOTOOLCHAIN="$(go env GOVERSION)" GOBIN="$(go env GOPATH)/bin" go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
     export PATH="$(go env GOPATH)/bin:$PATH"
 fi
 

--- a/hack/verify-golint
+++ b/hack/verify-golint
@@ -18,7 +18,7 @@ set -euo pipefail
 
 if ! which golangci-lint > /dev/null; then
     echo "Cannot find golangci-lint. Installing golangci-lint..."
-    GOTOOLCHAIN="$(go env GOVERSION)" GOBIN="$(go env GOPATH)/bin" go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+    GOTOOLCHAIN="$(go env GOVERSION)" GOBIN="$(go env GOPATH)/bin" go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
     export PATH="$(go env GOPATH)/bin:$PATH"
 fi
 


### PR DESCRIPTION
目前 CI build juicefs 客户端会失败，同步 juicefs 社区版升级 go 版本