### PR TITLE
fix: align sidecar mount hook behavior

### DIFF
--- a/pkg/juicefs/mount/builder/cci-serverless.go
+++ b/pkg/juicefs/mount/builder/cci-serverless.go
@@ -67,7 +67,10 @@ func (r *CCIBuilder) NewMountSidecar() *corev1.Pod {
 	pod := r.genCommonJuicePod(r.genNonPrivilegedContainer)
 
 	// check mount & create subpath & set quota
-	capacity := strconv.FormatInt(r.capacity, 10)
+	capacity := ""
+	if r.capacity > 0 {
+		capacity = strconv.FormatInt(r.capacity, 10)
+	}
 	subpath := r.jfsSetting.SubPath
 	community := "ce"
 	if !r.jfsSetting.IsCe {

--- a/pkg/juicefs/mount/builder/container.go
+++ b/pkg/juicefs/mount/builder/container.go
@@ -72,7 +72,10 @@ func (r *ContainerBuilder) NewMountSidecar() *corev1.Pod {
 	}
 
 	// check mount & create subpath & set quota
-	capacity := strconv.FormatInt(r.capacity, 10)
+	capacity := ""
+	if r.capacity > 0 {
+		capacity = strconv.FormatInt(r.capacity, 10)
+	}
 	subpath := r.jfsSetting.SubPath
 	community := "ce"
 	if !r.jfsSetting.IsCe {

--- a/pkg/juicefs/mount/builder/secret.go
+++ b/pkg/juicefs/mount/builder/secret.go
@@ -42,7 +42,7 @@ while ! mount | grep $ConditionPathIsMountPoint | grep JuiceFS
 do
     sleep 3
     count=¬expr $count + 1¬
-    if test $count -eq 10
+    if test $count -eq 20
     then
         echo "timed out!"
         exit 1

--- a/pkg/juicefs/mount/builder/serverless.go
+++ b/pkg/juicefs/mount/builder/serverless.go
@@ -62,7 +62,10 @@ func (r *ServerlessBuilder) NewMountSidecar() *corev1.Pod {
 	pod.Labels = map[string]string{}
 
 	// check mount & create subpath & set quota
-	capacity := strconv.FormatInt(r.capacity, 10)
+	capacity := ""
+	if r.capacity > 0 {
+		capacity = strconv.FormatInt(r.capacity, 10)
+	}
 	subpath := r.jfsSetting.SubPath
 	community := "ce"
 	if !r.jfsSetting.IsCe {

--- a/pkg/juicefs/mount/builder/vci-serverless.go
+++ b/pkg/juicefs/mount/builder/vci-serverless.go
@@ -95,7 +95,10 @@ func (r *VCIBuilder) NewMountSidecar() *corev1.Pod {
 	pod.Annotations[VCIPropagation] = string(VCIPropagationBytes)
 
 	// check mount & create subpath & set quota
-	capacity := strconv.FormatInt(r.capacity, 10)
+	capacity := ""
+	if r.capacity > 0 {
+		capacity = strconv.FormatInt(r.capacity, 10)
+	}
 	subpath := r.jfsSetting.SubPath
 	community := "ce"
 	if !r.jfsSetting.IsCe {

--- a/pkg/webhook/handler/mutate/sidecar.go
+++ b/pkg/webhook/handler/mutate/sidecar.go
@@ -156,10 +156,14 @@ func (s *SidecarMutate) mutate(ctx context.Context, pod *corev1.Pod, pair resour
 	jfsSetting.Attr.Namespace = pod.Namespace
 	jfsSetting.SecretName = pair.PVC.Name + "-jfs-secret"
 	s.jfsSetting = jfsSetting
+	quotaEnabled := config.GlobalConfig.EnableSetQuota == nil || *config.GlobalConfig.EnableSetQuota
 	capacity := pair.PVC.Spec.Resources.Requests.Storage().Value()
 	cap := capacity / 1024 / 1024 / 1024
-	if cap <= 0 {
+	if quotaEnabled && cap <= 0 {
 		return nil, fmt.Errorf("capacity %d is too small, at least 1GiB for quota", capacity)
+	}
+	if !quotaEnabled {
+		cap = 0
 	}
 
 	var r builder.SidecarInterface


### PR DESCRIPTION
- In sidecar mutation, quota capacity validation is now skipped when `EnableSetQuota` is disabled.
- Mount check script timeout increased from 30 seconds to 60 seconds.
