### PR TITLE
fix: delete-at timezone mismatch delays mount pod recycling

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -269,12 +269,17 @@ func GetTimeAfterDelay(delayStr string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	delayAt := time.Now().Add(delay)
-	return delayAt.Format("2006-01-02 15:04:05"), nil
+	// RFC3339 in UTC so the timestamp carries its zone and round-trips regardless of local timezone.
+	return time.Now().UTC().Add(delay).Format(time.RFC3339), nil
 }
 
+// GetTime accepts RFC3339 and the legacy zone-less layout, which was written in
+// local time and so must be parsed in local time to avoid a UTC-offset shift.
 func GetTime(str string) (time.Time, error) {
-	return time.Parse("2006-01-02 15:04:05", str)
+	if t, err := time.Parse(time.RFC3339, str); err == nil {
+		return t, nil
+	}
+	return time.ParseInLocation("2006-01-02 15:04:05", str, time.Local)
 }
 
 func QuoteForShell(cmd string) string {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -199,7 +199,7 @@ func TestGetTimeAfterDelay(t *testing.T) {
 			args: args{
 				delayStr: "1h",
 			},
-			want:    now.Add(1 * time.Hour).Format("2006-01-02 15:04:05"),
+			want:    now.UTC().Add(1 * time.Hour).Format(time.RFC3339),
 			wantErr: false,
 		},
 		{
@@ -226,35 +226,85 @@ func TestGetTimeAfterDelay(t *testing.T) {
 }
 
 func TestGetTime(t *testing.T) {
-	type args struct {
-		str string
-	}
 	tests := []struct {
 		name    string
-		args    args
+		str     string
 		want    time.Time
 		wantErr bool
 	}{
 		{
-			name: "test",
-			args: args{
-				str: "2006-01-02 15:04:05",
-			},
-			want:    time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC),
-			wantErr: false,
+			name: "rfc3339-utc",
+			str:  "2026-05-29T12:20:38Z",
+			want: time.Date(2026, 5, 29, 12, 20, 38, 0, time.UTC),
+		},
+		{
+			name: "rfc3339-offset",
+			str:  "2026-05-29T20:20:38+08:00",
+			want: time.Date(2026, 5, 29, 12, 20, 38, 0, time.UTC),
+		},
+		{
+			name:    "invalid",
+			str:     "not-a-time",
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetTime(tt.args.str)
+			got, err := GetTime(tt.str)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetTime() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetTime() got = %v, want %v", got, tt.want)
+			if tt.wantErr {
+				return
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("GetTime() got = %v, want (same instant) %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// legacy zone-less values were written in local time, so GetTime must parse them in local time.
+func TestGetTimeLegacyFormat(t *testing.T) {
+	orig := time.Local
+	defer func() { time.Local = orig }()
+	time.Local = time.FixedZone("CST", 8*3600) // UTC+8
+
+	got, err := GetTime("2026-05-29 12:20:38")
+	if err != nil {
+		t.Fatalf("GetTime legacy error: %v", err)
+	}
+	wantLocal := time.Date(2026, 5, 29, 12, 20, 38, 0, time.Local) // 12:20:38 CST
+	if !got.Equal(wantLocal) {
+		t.Errorf("legacy value parsed as %v, want %v (parsed in local zone, not UTC)", got, wantLocal)
+	}
+}
+
+// round-trip GetTime(GetTimeAfterDelay(d)) must be ~d regardless of local timezone.
+func TestGetTimeAfterDelayRoundTrip(t *testing.T) {
+	orig := time.Local
+	defer func() { time.Local = orig }()
+
+	for _, tz := range []*time.Location{
+		time.UTC,
+		time.FixedZone("CST", 8*3600),  // UTC+8
+		time.FixedZone("EST", -5*3600), // UTC-5
+	} {
+		time.Local = tz
+		const delay = 3 * time.Hour
+		s, err := GetTimeAfterDelay(delay.String())
+		if err != nil {
+			t.Fatalf("tz=%s GetTimeAfterDelay error: %v", tz, err)
+		}
+		at, err := GetTime(s)
+		if err != nil {
+			t.Fatalf("tz=%s GetTime error: %v", tz, err)
+		}
+		got := time.Until(at)
+		if diff := got - delay; diff < -2*time.Second || diff > 2*time.Second {
+			t.Errorf("tz=%s round-trip delay = %v, want ~%v (off by %v); writer/reader timezone mismatch", tz, got, delay, diff)
+		}
 	}
 }
 


### PR DESCRIPTION
## What this PR does

  Fixes a timezone bug in the mount pod delayed-deletion (`delete-delay`) mechanism that causes mount pods to be recycled much later than configured (and, in negative-offset timezones, **earlier** than intended).

  ## Problem

  The `juicefs-delete-at` annotation is written and read by two helpers that disagree on timezone:

  ```go
  // write: time.Now() is LOCAL time, formatted into a zone-less string
  func GetTimeAfterDelay(delayStr string) (string, error) {
      delay, _ := time.ParseDuration(delayStr)
      delayAt := time.Now().Add(delay)
      return delayAt.Format("2006-01-02 15:04:05"), nil
  }

  // read: time.Parse on a zone-less layout interprets the value as UTC
  func GetTime(str string) (time.Time, error) {
      return time.Parse("2006-01-02 15:04:05", str)
  }
  ```

  The value is **formatted in local time but parsed back as UTC**, so the effective delay is shifted by the node's UTC offset.

  ### Concrete example (container TZ = `Asia/Shanghai`, UTC+8)

  A mount pod loses its last reference at `07:00:43` local. With `juicefs-delete-delay=3h` the driver stamps:

  ```
  juicefs-delete-at = "2026-06-01 10:00:43"   // intended: 10:00:43 local
  ```

  `ShouldDelay` later calls `GetTime("2026-06-01 10:00:43")`, which returns `10:00:43 UTC` = `18:00:43` local. The pod is therefore only eligible for deletion at `18:00`, and is indeed deleted at `18:01` — **8 hours late**. Effective delay becomes `3h + 8h = 11h`.

  ## Impact

  - Mount pods that should be recycled after the configured `delete-delay` linger for `delay + localUTCOffset`, holding cache, memory and a metrics port long after their last consumer is
  gone.
  - In **negative-offset** timezones (e.g. `America/New_York`, UTC−5) the parsed time is *earlier* than intended, so a mount pod could be deleted before its grace window elapses.
  - A cluster running in UTC is unaffected, which is why this can go unnoticed.

  ## Fix

  - Write the timestamp as **RFC3339 in UTC** (`...Z`), so it is self-describing and round-trips unambiguously regardless of the process timezone.
  - `GetTime` accepts RFC3339, and for **backward compatibility** still parses the legacy zone-less layout — but in `time.Local`, matching how those existing values were originally
  written. This way already-stored `juicefs-delete-at` annotations keep their intended meaning after upgrade instead of being shifted (no migration / manual cleanup needed).

  ```go
  func GetTimeAfterDelay(delayStr string) (string, error) {
      delay, err := time.ParseDuration(delayStr)
      if err != nil {
          return "", err
      }
      return time.Now().UTC().Add(delay).Format(time.RFC3339), nil
  }

  func GetTime(str string) (time.Time, error) {
      if t, err := time.Parse(time.RFC3339, str); err == nil {
          return t, nil
      }
      return time.ParseInLocation("2006-01-02 15:04:05", str, time.Local)
  }
  ```

  ## Verification

  - `go test ./pkg/util/` — passes.
  - Added tests:
    - `TestGetTimeAfterDelayRoundTrip` — `GetTime(GetTimeAfterDelay(d))` ≈ `d` under `UTC`, `UTC+8`, `UTC−5`. **Fails before the fix** (off by +8h / −5h).
    - `TestGetTimeLegacyFormat` — legacy zone-less value is parsed in local time, preserving its original meaning.
    - `TestGetTime` — RFC3339 `Z` and explicit-offset forms parse to the same instant.

  Minimal reproducer:

  ```go
  time.Local = time.FixedZone("CST", 8*3600)
  s, _ := GetTimeAfterDelay("3h")
  at, _ := GetTime(s)
  fmt.Println(time.Until(at)) // before fix: ~11h ; after fix: ~3h
  ```

  ## Notes

  - Backward compatible: existing `juicefs-delete-at` annotations remain valid and are now interpreted at their intended time.
  - No API/CRD changes.