### PR TITLE
fix upgrade pid when hostpid is enabled

### DIFF
--- a/pkg/fuse/grace/grace.go
+++ b/pkg/fuse/grace/grace.go
@@ -374,7 +374,17 @@ func (p *PodUpgrade) prepareShutdown(ctx context.Context, conn net.Conn) (*util.
 		}
 
 		// close fuse fd in mount pod
-		commPath, err := resource.GetCommPath("/tmp", *p.pod)
+		ppid := jfsConf.PPid
+		if ppid == 0 {
+			if idx := strings.LastIndex(jfsConf.CommPath, "."); idx >= 0 {
+				ppid, _ = strconv.Atoi(jfsConf.CommPath[idx+1:])
+			}
+		}
+		if ppid <= 0 {
+			return nil, fmt.Errorf("mount pod %s/%s: unable to determine ppid (PPid=%d, CommPath=%q)",
+				p.pod.Namespace, p.pod.Name, jfsConf.PPid, jfsConf.CommPath)
+		}
+		commPath, err := resource.GetCommPath("/tmp", *p.pod, ppid)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/fuse/grace/grace.go
+++ b/pkg/fuse/grace/grace.go
@@ -374,15 +374,9 @@ func (p *PodUpgrade) prepareShutdown(ctx context.Context, conn net.Conn) (*util.
 		}
 
 		// close fuse fd in mount pod
-		ppid := jfsConf.PPid
-		if ppid == 0 {
-			if idx := strings.LastIndex(jfsConf.CommPath, "."); idx >= 0 {
-				ppid, _ = strconv.Atoi(jfsConf.CommPath[idx+1:])
-			}
-		}
-		if ppid <= 0 {
-			return nil, fmt.Errorf("mount pod %s/%s: unable to determine ppid (PPid=%d, CommPath=%q)",
-				p.pod.Namespace, p.pod.Name, jfsConf.PPid, jfsConf.CommPath)
+		ppid, err := resolvePpid(jfsConf, p.pod.Spec.HostPID)
+		if err != nil {
+			return nil, fmt.Errorf("mount pod %s/%s: %w", p.pod.Namespace, p.pod.Name, err)
 		}
 		commPath, err := resource.GetCommPath("/tmp", *p.pod, ppid)
 		if err != nil {
@@ -572,4 +566,26 @@ func sendMessage(conn net.Conn, message string) {
 	if err != nil {
 		log.V(1).Info("error sending message", "message", message, "error", err)
 	}
+}
+
+// resolvePpid determines the PID used to locate the fuse_fd_comm socket.
+// Resolution order:
+//  1. jfsConf.PPid if non-zero
+//  2. suffix of path.Base(jfsConf.CommPath) after the last "." (e.g. "fuse_fd_comm.3551359" → 3551359)
+//  3. 1 for non-HostPID pods (mount process is PID 1 in its own namespace)
+//  4. error for HostPID pods where the real host PID cannot be determined
+func resolvePpid(jfsConf *util.JuiceConf, hostPID bool) (int, error) {
+	if jfsConf.PPid != 0 {
+		return jfsConf.PPid, nil
+	}
+	base := path.Base(jfsConf.CommPath)
+	if idx := strings.LastIndex(base, "."); idx >= 0 {
+		if ppid, err := strconv.Atoi(base[idx+1:]); err == nil && ppid > 0 {
+			return ppid, nil
+		}
+	}
+	if !hostPID {
+		return 1, nil
+	}
+	return 0, fmt.Errorf("unable to determine ppid (PPid=%d, CommPath=%q)", jfsConf.PPid, jfsConf.CommPath)
 }

--- a/pkg/fuse/grace/grace_test.go
+++ b/pkg/fuse/grace/grace_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/util"
 )
 
 func Test_parseRequest(t *testing.T) {
@@ -68,6 +70,80 @@ func Test_parseRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := parseRequest(tt.args.message); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("parseRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_resolvePpid(t *testing.T) {
+	tests := []struct {
+		name     string
+		ppid     int
+		commPath string
+		hostPID  bool
+		wantPpid int
+		wantErr  bool
+	}{
+		{
+			name:     "PPid field is used directly",
+			ppid:     3551359,
+			commPath: "",
+			hostPID:  true,
+			wantPpid: 3551359,
+		},
+		{
+			name:     "CommPath suffix parsed when PPid is zero",
+			ppid:     0,
+			commPath: "/tmp/fuse_fd_comm.3551359",
+			hostPID:  true,
+			wantPpid: 3551359,
+		},
+		{
+			name:     "CommPath with dotted directory does not mislead parser",
+			ppid:     0,
+			commPath: "/tmp/dir.99/fuse_fd_comm.1234",
+			hostPID:  true,
+			wantPpid: 1234,
+		},
+		{
+			name:     "non-HostPID falls back to 1 when both fields are absent",
+			ppid:     0,
+			commPath: "",
+			hostPID:  false,
+			wantPpid: 1,
+		},
+		{
+			name:     "non-HostPID falls back to 1 when CommPath has no parseable suffix",
+			ppid:     0,
+			commPath: "/tmp/fuse_fd_comm",
+			hostPID:  false,
+			wantPpid: 1,
+		},
+		{
+			name:     "HostPID errors when neither field is parseable",
+			ppid:     0,
+			commPath: "",
+			hostPID:  true,
+			wantErr:  true,
+		},
+		{
+			name:     "HostPID errors when CommPath suffix is not a valid number",
+			ppid:     0,
+			commPath: "/tmp/fuse_fd_comm.abc",
+			hostPID:  true,
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &util.JuiceConf{PPid: tt.ppid, CommPath: tt.commPath}
+			got, err := resolvePpid(conf, tt.hostPID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("resolvePpid() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.wantPpid {
+				t.Errorf("resolvePpid() = %d, want %d", got, tt.wantPpid)
 			}
 		})
 	}

--- a/pkg/util/resource/pod.go
+++ b/pkg/util/resource/pod.go
@@ -427,12 +427,12 @@ func GetPVWithVolumeHandleOrAppInfo(ctx context.Context, client *k8s.K8sClient, 
 	return pv, pvc, nil
 }
 
-func GetCommPath(basePath string, pod corev1.Pod) (string, error) {
+func GetCommPath(basePath string, pod corev1.Pod, pid int) (string, error) {
 	upgradeUUID := GetUpgradeUUID(&pod)
 	if upgradeUUID == "" {
 		return "", fmt.Errorf("pod %s/%s has no hash label", pod.Namespace, pod.Name)
 	}
-	return path.Join(basePath, upgradeUUID, "fuse_fd_comm.1"), nil
+	return path.Join(basePath, upgradeUUID, fmt.Sprintf("fuse_fd_comm.%d", pid)), nil
 }
 
 func GetUniqueId(pod corev1.Pod) string {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -737,8 +737,9 @@ type JuiceConf struct {
 	Meta struct {
 		Sid uint64
 	}
-	Pid  int
-	PPid int
+	Pid      int
+	PPid     int
+	CommPath string // e.g. /tmp/fuse_fd_comm.355135
 }
 
 func ParseConfig(conf []byte) (*JuiceConf, error) {


### PR DESCRIPTION
fix https://github.com/juicedata/juicefs-csi-driver/issues/1586

When HostPID is enabled, ppid in mount pod is not 1, parse it from jfsConfig