### PR TITLE
feat: support sidecar resource percentages

### DIFF
--- a/.github/scripts/e2e-test.py
+++ b/.github/scripts/e2e-test.py
@@ -47,6 +47,7 @@ from test_case import (
     test_dynamic_pvc_delete_not_last_with_path_pattern,
     test_webhook_two_volume,
     test_sidecar_config_with_node_selector,
+    test_sidecar_config_resource_percentages_with_node_selector,
     test_dynamic_expand,
     test_multi_pvc,
     test_mountpod_recreated,
@@ -172,6 +173,7 @@ if __name__ == "__main__":
                     test_job_complete_using_storage()
                     test_deployment_using_storage_rw()
                     test_sidecar_config_with_node_selector()
+                    test_sidecar_config_resource_percentages_with_node_selector()
                     test_dynamic_mount_image_with_webhook()
                     test_deployment_dynamic_patch_pv_with_webhook()
                     test_quota_using_storage_rw()
@@ -190,6 +192,7 @@ if __name__ == "__main__":
                     test_delete_pvc()
                     test_deployment_using_storage_rw()
                     test_sidecar_config_with_node_selector()
+                    test_sidecar_config_resource_percentages_with_node_selector()
                     test_deployment_dynamic_patch_pv_with_webhook()
                     test_dynamic_mount_image_with_webhook()
                     test_path_pattern_in_storage_class()

--- a/.github/scripts/model.py
+++ b/.github/scripts/model.py
@@ -271,7 +271,7 @@ class PV:
 
 
 class Deployment:
-    def __init__(self, *, name, pvc, replicas, out_put="", pvcs=[], node_selector=None):
+    def __init__(self, *, name, pvc, replicas, out_put="", pvcs=[], node_selector=None, resources=None):
         self.name = RESOURCE_PREFIX + name
         self.namespace = "default"
         self.image = "ubuntu"
@@ -283,6 +283,7 @@ class Deployment:
         if pvcs:
             self.pvcs = pvcs
         self.node_selector = node_selector
+        self.resources = resources
 
     def create(self):
         output = "out.txt"
@@ -310,6 +311,7 @@ class Deployment:
             command=["/bin/sh"],
             args=["-c", cmd],
             volume_mounts=volume_mounts,
+            resources=self.resources,
         )
         template = client.V1PodTemplateSpec(
             metadata=client.V1ObjectMeta(labels={"deployment": self.name}),

--- a/.github/scripts/test_case.py
+++ b/.github/scripts/test_case.py
@@ -2641,6 +2641,122 @@ def test_sidecar_config_with_node_selector():
     return
 
 
+def test_sidecar_config_resource_percentages_with_node_selector():
+    LOG.info("[test case] Sidecar resourcePercentages nodeSelector config begin..")
+    node_selector_key = "jfs-e2e-sidecar-resource-percentages"
+    test_cfg = {
+        "mountPodPatch": [
+            {
+                "nodeSelector": {
+                    "matchLabels": {
+                        node_selector_key: "matched"
+                    }
+                },
+                "resourcePercentages": {
+                    "requests": {
+                        "cpu": "30%",
+                        "memory": "30%"
+                    },
+                    "limits": {
+                        "cpu": "30%",
+                        "memory": "30%"
+                    },
+                    "minLimits": {
+                        "cpu": "800m",
+                        "memory": "128Mi"
+                    }
+                },
+                "mountOptions": [
+                    "buffer-size=50%"
+                ]
+            }
+        ]
+    }
+    update_config(test_cfg)
+    subprocess.check_call(
+        ["kubectl", "annotate", "pods", "--overwrite", "-n", KUBE_SYSTEM, "-l", "app=juicefs-csi-controller",
+         "updatedAt=" + str(int(time.time()))])
+
+    time.sleep(2)
+    pvc = PVC(name="pvc-sidecar-resource-percentages", access_mode="ReadWriteMany", storage_name=STORAGECLASS_NAME,
+              pv="")
+    LOG.info("Deploy pvc {}".format(pvc.name))
+    pvc.create()
+
+    for i in range(0, 60):
+        if pvc.check_is_bound():
+            break
+        time.sleep(1)
+
+    deployment = Deployment(name="app-sidecar-resource-percentages", pvc=pvc.name, replicas=1,
+                            node_selector={node_selector_key: "matched"},
+                            resources=client.V1ResourceRequirements(
+                                requests={
+                                    "cpu": "2",
+                                    "memory": "1Gi",
+                                }
+                            ))
+    LOG.info("Deploy deployment {}".format(deployment.name))
+    deployment.create()
+
+    pod = None
+    for i in range(0, 60):
+        pods = client.CoreV1Api().list_namespaced_pod(
+            namespace="default",
+            label_selector="deployment={}".format(deployment.name)
+        )
+        if len(pods.items) == 1:
+            pod = pods.items[0]
+            break
+        time.sleep(1)
+    if pod is None:
+        raise Exception("Pod of deployment {} is not created within 1 min.".format(deployment.name))
+
+    mount_container = None
+    for container in pod.spec.containers or []:
+        if container.name == "jfs-mount":
+            mount_container = container
+    if mount_container is None and pod.spec.init_containers:
+        for container in pod.spec.init_containers:
+            if container.name == "jfs-mount":
+                mount_container = container
+    if mount_container is None:
+        raise Exception("Pod {} should have jfs-mount container".format(pod.metadata.name))
+
+    requests = mount_container.resources.requests or {}
+    limits = mount_container.resources.limits or {}
+    if requests.get("cpu") != "600m":
+        raise Exception("sidecar cpu request should be 600m, got {}".format(requests.get("cpu")))
+    if requests.get("memory") != "308Mi":
+        raise Exception("sidecar memory request should be 308Mi, got {}".format(requests.get("memory")))
+    if limits.get("cpu") != "800m":
+        raise Exception("sidecar cpu limit should be 800m, got {}".format(limits.get("cpu")))
+    if limits.get("memory") != "308Mi":
+        raise Exception("sidecar memory limit should be 308Mi, got {}".format(limits.get("memory")))
+
+    command = " ".join(mount_container.command or [])
+    if "buffer-size=154" not in command:
+        raise Exception("sidecar buffer-size should be 154, command: {}".format(command))
+
+    LOG.info("Remove deployment {}".format(deployment.name))
+    deployment.delete()
+    deploy_pod = Pod(name="", deployment_name=deployment.name, replicas=deployment.replicas)
+    LOG.info("Watch for pods of deployment {} for delete.".format(deployment.name))
+    result = deploy_pod.watch_for_delete(deployment.replicas)
+    if not result:
+        raise Exception("Pods of deployment {} are not delete within 5 min.".format(deployment.name))
+    LOG.info("Remove pvc {}".format(pvc.name))
+    pvc.delete()
+
+    update_config({})
+    subprocess.check_call(
+        ["kubectl", "annotate", "pods", "--overwrite", "-n", KUBE_SYSTEM, "-l", "app=juicefs-csi-controller",
+         "updatedAt=" + str(int(time.time()))])
+
+    LOG.info("Test pass.")
+    return
+
+
 def test_dynamic_expand():
     if not is_quota_supported():
         LOG.info("juicefs donot support quota, skip.")

--- a/.github/scripts/test_case.py
+++ b/.github/scripts/test_case.py
@@ -2694,6 +2694,10 @@ def test_sidecar_config_resource_percentages_with_node_selector():
                                 requests={
                                     "cpu": "2",
                                     "memory": "1Gi",
+                                },
+                                limits={
+                                    "cpu": "4",
+                                    "memory": "2Gi",
                                 }
                             ))
     LOG.info("Deploy deployment {}".format(deployment.name))
@@ -2729,14 +2733,14 @@ def test_sidecar_config_resource_percentages_with_node_selector():
         raise Exception("sidecar cpu request should be 600m, got {}".format(requests.get("cpu")))
     if requests.get("memory") != "308Mi":
         raise Exception("sidecar memory request should be 308Mi, got {}".format(requests.get("memory")))
-    if limits.get("cpu") != "800m":
-        raise Exception("sidecar cpu limit should be 800m, got {}".format(limits.get("cpu")))
-    if limits.get("memory") != "308Mi":
-        raise Exception("sidecar memory limit should be 308Mi, got {}".format(limits.get("memory")))
+    if limits.get("cpu") != "1200m":
+        raise Exception("sidecar cpu limit should be 1200m, got {}".format(limits.get("cpu")))
+    if limits.get("memory") != "615Mi":
+        raise Exception("sidecar memory limit should be 615Mi, got {}".format(limits.get("memory")))
 
     command = " ".join(mount_container.command or [])
-    if "buffer-size=154" not in command:
-        raise Exception("sidecar buffer-size should be 154, command: {}".format(command))
+    if "buffer-size=308" not in command:
+        raise Exception("sidecar buffer-size should be 308, command: {}".format(command))
 
     LOG.info("Remove deployment {}".format(deployment.name))
     deployment.delete()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -212,6 +212,14 @@ type MountPatchCacheDir struct {
 	AccessModes      []corev1.PersistentVolumeAccessMode `json:"accessModes,omitempty"`
 }
 
+type ResourcePercentages struct {
+	Limits    ResourcePercentageList `json:"limits,omitempty"`
+	Requests  ResourcePercentageList `json:"requests,omitempty"`
+	MinLimits corev1.ResourceList    `json:"minLimits,omitempty"`
+}
+
+type ResourcePercentageList map[corev1.ResourceName]string
+
 type MountPodPatch struct {
 	// used to specify the selector for the PVC that will be patched
 	// omit will patch for all PVC
@@ -237,6 +245,7 @@ type MountPodPatch struct {
 	StartupProbe                  *corev1.Probe                `json:"startupProbe,omitempty"`
 	Lifecycle                     *corev1.Lifecycle            `json:"lifecycle,omitempty"`
 	Resources                     *corev1.ResourceRequirements `json:"resources,omitempty"`
+	ResourcePercentages           *ResourcePercentages         `json:"resourcePercentages,omitempty"`
 	TerminationGracePeriodSeconds *int64                       `json:"terminationGracePeriodSeconds,omitempty"`
 	Volumes                       []corev1.Volume              `json:"volumes,omitempty"`
 	VolumeDevices                 []corev1.VolumeDevice        `json:"volumeDevices,omitempty"`
@@ -332,6 +341,9 @@ func (mpp *MountPodPatch) merge(mp MountPodPatch) {
 	}
 	if mp.Resources != nil {
 		mpp.Resources = mp.Resources
+	}
+	if mp.ResourcePercentages != nil {
+		mpp.ResourcePercentages = mp.ResourcePercentages
 	}
 	if mp.TerminationGracePeriodSeconds != nil {
 		mpp.TerminationGracePeriodSeconds = mp.TerminationGracePeriodSeconds

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -1288,7 +1288,7 @@ func applyPatchResourcePercentages(setting *JfsSetting, patch MountPodPatch, app
 	minLimits := corev1.ResourceList{
 		// TODO: change me
 		corev1.ResourceCPU:    resource.MustParse("100m"),
-		corev1.ResourceMemory: resource.MustParse("100Mi"),
+		corev1.ResourceMemory: resource.MustParse("300Mi"),
 	}
 	for name, quantity := range patch.ResourcePercentages.MinLimits {
 		minLimits[name] = quantity

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -567,19 +567,6 @@ func genAndValidOptions(JfsSetting *JfsSetting) error {
 				mountOptions = append(mountOptions, mountOption)
 				continue
 			}
-			if strings.HasSuffix(strings.TrimSpace(ops[1]), "%") {
-				percentage, err := util.ParsePercentageToFloat(ops[1])
-				if err != nil {
-					return fmt.Errorf("invalid mount option: %s", mountOption)
-				}
-				if percentage > 100 {
-					return fmt.Errorf("buffer-size %s is greater than pod memory limit %s", ops[1], memLimit.String())
-				}
-				bufferSize := int64(math.Ceil(float64(memLimitByte) * percentage / 100))
-				const mib = int64(1024 * 1024)
-				mountOptions = append(mountOptions, fmt.Sprintf("%s=%d", ops[0], (bufferSize+mib-1)/mib))
-				continue
-			}
 			// buffer-size is in MiB, turn to byte
 			bufferSize, err := util.ParseToBytes(ops[1])
 			if err != nil {

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -1176,8 +1176,12 @@ func processOption(option string, resources corev1.ResourceRequirements) string 
 			log.Error(err, "parse buffer-size error, ignore buffer-size option", "buffer-size", pair[1])
 			return ""
 		}
-		bufferSize := int64(math.Ceil(float64(memLimitByte) * percentage / 100))
 		const mib = int64(1024 * 1024)
+		if percentage > 100 {
+			percentage = 100
+			log.Info("buffer-size is greater than pod memory limit, fallback to memory limit", "buffer-size", pair[1], "memory limit", strconv.FormatInt(memLimitByte, 10))
+		}
+		bufferSize := int64(math.Ceil(float64(memLimitByte) * percentage / 100))
 		pair[1] = strconv.FormatInt((bufferSize+mib-1)/mib, 10)
 		return strings.Join(pair, "=")
 	}
@@ -1197,7 +1201,7 @@ func processOption(option string, resources corev1.ResourceRequirements) string 
 	return option
 }
 
-func getAppContainerRequests(pod *corev1.Pod, pvc *corev1.PersistentVolumeClaim) corev1.ResourceList {
+func getAppContainerResources(pod *corev1.Pod, pvc *corev1.PersistentVolumeClaim) corev1.ResourceRequirements {
 	volumeNames := map[string]bool{}
 	for _, volume := range pod.Spec.Volumes {
 		if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == pvc.Name {
@@ -1206,6 +1210,7 @@ func getAppContainerRequests(pod *corev1.Pod, pvc *corev1.PersistentVolumeClaim)
 	}
 
 	requests := corev1.ResourceList{}
+	limits := corev1.ResourceList{}
 	for _, container := range pod.Spec.Containers {
 		mounted := false
 		for _, mount := range container.VolumeMounts {
@@ -1227,8 +1232,21 @@ func getAppContainerRequests(pod *corev1.Pod, pvc *corev1.PersistentVolumeClaim)
 			sum.Add(memory)
 			requests[corev1.ResourceMemory] = sum
 		}
+		if cpu, ok := container.Resources.Limits[corev1.ResourceCPU]; ok {
+			sum := limits[corev1.ResourceCPU]
+			sum.Add(cpu)
+			limits[corev1.ResourceCPU] = sum
+		}
+		if memory, ok := container.Resources.Limits[corev1.ResourceMemory]; ok {
+			sum := limits[corev1.ResourceMemory]
+			sum.Add(memory)
+			limits[corev1.ResourceMemory] = sum
+		}
 	}
-	return requests
+	return corev1.ResourceRequirements{
+		Requests: requests,
+		Limits:   limits,
+	}
 }
 
 func applyResourcePercentages(resources *corev1.ResourceList, percentages ResourcePercentageList, minimums corev1.ResourceList, appRequests corev1.ResourceList) {
@@ -1241,7 +1259,6 @@ func applyResourcePercentages(resources *corev1.ResourceList, percentages Resour
 	for name, percentageValue := range percentages {
 		request, ok := appRequests[name]
 		if !ok {
-			delete(*resources, name)
 			continue
 		}
 		if name != corev1.ResourceCPU && name != corev1.ResourceMemory {
@@ -1274,13 +1291,12 @@ func calculateResourcePercentage(name corev1.ResourceName, base resource.Quantit
 	return *resource.NewQuantity(value, resource.BinarySI)
 }
 
-func applyPatchResourcePercentages(setting *JfsSetting, patch MountPodPatch) {
+func applyPatchResourcePercentages(setting *JfsSetting, patch MountPodPatch, appResources corev1.ResourceRequirements) {
 	if patch.ResourcePercentages == nil {
 		return
 	}
-	appRequests := corev1.ResourceList{}
-	if setting.AppPod != nil && setting.PVC != nil {
-		appRequests = getAppContainerRequests(setting.AppPod, setting.PVC)
+	if setting.AppPod == nil || setting.PVC == nil {
+		return
 	}
 	minLimits := corev1.ResourceList{
 		// TODO: change me
@@ -1290,14 +1306,18 @@ func applyPatchResourcePercentages(setting *JfsSetting, patch MountPodPatch) {
 	for name, quantity := range patch.ResourcePercentages.MinLimits {
 		minLimits[name] = quantity
 	}
-	applyResourcePercentages(&setting.Attr.Resources.Requests, patch.ResourcePercentages.Requests, nil, appRequests)
-	applyResourcePercentages(&setting.Attr.Resources.Limits, patch.ResourcePercentages.Limits, minLimits, appRequests)
+	applyResourcePercentages(&setting.Attr.Resources.Requests, patch.ResourcePercentages.Requests, nil, appResources.Requests)
+	applyResourcePercentages(&setting.Attr.Resources.Limits, patch.ResourcePercentages.Limits, minLimits, appResources.Limits)
 }
 
 func applyConfigPatch(setting *JfsSetting, replaceTemplate bool) {
 	attr := setting.Attr
 	// overwrite by mountpod patch
 	patch := GlobalConfig.GenMountPodPatch(*setting, replaceTemplate, setting.Node)
+	appResources := corev1.ResourceRequirements{}
+	if setting.AppPod != nil && setting.PVC != nil {
+		appResources = getAppContainerResources(setting.AppPod, setting.PVC)
+	}
 	if patch.Image != "" {
 		attr.Image = patch.Image
 	}
@@ -1322,7 +1342,7 @@ func applyConfigPatch(setting *JfsSetting, replaceTemplate bool) {
 	if patch.Resources != nil {
 		attr.Resources = *patch.Resources
 	}
-	applyPatchResourcePercentages(setting, patch)
+	applyPatchResourcePercentages(setting, patch, appResources)
 	if patch.HostnameKey != "" {
 		attr.HostnameKey = patch.HostnameKey
 	}

--- a/pkg/config/setting.go
+++ b/pkg/config/setting.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -96,7 +97,8 @@ type JfsSetting struct {
 	PVC  *corev1.PersistentVolumeClaim `json:"-"`
 	Node *corev1.Node                  `json:"-"`
 
-	MountShareMode string `json:"-"`
+	AppPod         *corev1.Pod `json:"-"`
+	MountShareMode string      `json:"-"`
 }
 
 func (s *JfsSetting) String() string {
@@ -563,6 +565,19 @@ func genAndValidOptions(JfsSetting *JfsSetting) error {
 			memLimitByte := memLimit.Value()
 			if !ok || memLimitByte <= 0 {
 				mountOptions = append(mountOptions, mountOption)
+				continue
+			}
+			if strings.HasSuffix(strings.TrimSpace(ops[1]), "%") {
+				percentage, err := util.ParsePercentageToFloat(ops[1])
+				if err != nil {
+					return fmt.Errorf("invalid mount option: %s", mountOption)
+				}
+				if percentage > 100 {
+					return fmt.Errorf("buffer-size %s is greater than pod memory limit %s", ops[1], memLimit.String())
+				}
+				bufferSize := int64(math.Ceil(float64(memLimitByte) * percentage / 100))
+				const mib = int64(1024 * 1024)
+				mountOptions = append(mountOptions, fmt.Sprintf("%s=%d", ops[0], (bufferSize+mib-1)/mib))
 				continue
 			}
 			// buffer-size is in MiB, turn to byte
@@ -1155,6 +1170,18 @@ func processOption(option string, resources corev1.ResourceRequirements) string 
 		return option
 	}
 
+	if strings.HasSuffix(strings.TrimSpace(pair[1]), "%") {
+		percentage, err := util.ParsePercentageToFloat(pair[1])
+		if err != nil {
+			log.Error(err, "parse buffer-size error, ignore buffer-size option", "buffer-size", pair[1])
+			return ""
+		}
+		bufferSize := int64(math.Ceil(float64(memLimitByte) * percentage / 100))
+		const mib = int64(1024 * 1024)
+		pair[1] = strconv.FormatInt((bufferSize+mib-1)/mib, 10)
+		return strings.Join(pair, "=")
+	}
+
 	bufferSize, err := util.ParseToBytes(pair[1])
 	if err != nil {
 		log.Error(err, "parse buffer-size error, ignore buffer-size option", "buffer-size", pair[1])
@@ -1168,6 +1195,103 @@ func processOption(option string, resources corev1.ResourceRequirements) string 
 	}
 
 	return option
+}
+
+func getAppContainerRequests(pod *corev1.Pod, pvc *corev1.PersistentVolumeClaim) corev1.ResourceList {
+	volumeNames := map[string]bool{}
+	for _, volume := range pod.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == pvc.Name {
+			volumeNames[volume.Name] = true
+		}
+	}
+
+	requests := corev1.ResourceList{}
+	for _, container := range pod.Spec.Containers {
+		mounted := false
+		for _, mount := range container.VolumeMounts {
+			if volumeNames[mount.Name] {
+				mounted = true
+				break
+			}
+		}
+		if !mounted {
+			continue
+		}
+		if cpu, ok := container.Resources.Requests[corev1.ResourceCPU]; ok {
+			sum := requests[corev1.ResourceCPU]
+			sum.Add(cpu)
+			requests[corev1.ResourceCPU] = sum
+		}
+		if memory, ok := container.Resources.Requests[corev1.ResourceMemory]; ok {
+			sum := requests[corev1.ResourceMemory]
+			sum.Add(memory)
+			requests[corev1.ResourceMemory] = sum
+		}
+	}
+	return requests
+}
+
+func applyResourcePercentages(resources *corev1.ResourceList, percentages ResourcePercentageList, minimums corev1.ResourceList, appRequests corev1.ResourceList) {
+	if len(percentages) == 0 {
+		return
+	}
+	if *resources == nil {
+		*resources = corev1.ResourceList{}
+	}
+	for name, percentageValue := range percentages {
+		request, ok := appRequests[name]
+		if !ok {
+			delete(*resources, name)
+			continue
+		}
+		if name != corev1.ResourceCPU && name != corev1.ResourceMemory {
+			log.Error(fmt.Errorf("resourcePercentages only supports cpu and memory"), "invalid resource percentage", "resource", name, "value", percentageValue)
+			continue
+		}
+		percentage, err := util.ParsePercentageToFloat(percentageValue)
+		if err != nil {
+			log.Error(err, "invalid resource percentage", "resource", name, "value", percentageValue)
+			continue
+		}
+		quantity := calculateResourcePercentage(name, request, percentage)
+		if minimum, ok := minimums[name]; ok && quantity.Cmp(minimum) < 0 {
+			quantity = minimum
+		}
+		(*resources)[name] = quantity
+	}
+}
+
+func calculateResourcePercentage(name corev1.ResourceName, base resource.Quantity, percentage float64) resource.Quantity {
+	if name == corev1.ResourceCPU {
+		milliValue := int64(math.Ceil(float64(base.MilliValue()) * percentage / 100))
+		return *resource.NewMilliQuantity(milliValue, resource.DecimalSI)
+	}
+	value := int64(math.Ceil(float64(base.Value()) * percentage / 100))
+	if value > 0 {
+		const mib = int64(1024 * 1024)
+		value = (value + mib - 1) / mib * mib
+	}
+	return *resource.NewQuantity(value, resource.BinarySI)
+}
+
+func applyPatchResourcePercentages(setting *JfsSetting, patch MountPodPatch) {
+	if patch.ResourcePercentages == nil {
+		return
+	}
+	appRequests := corev1.ResourceList{}
+	if setting.AppPod != nil && setting.PVC != nil {
+		appRequests = getAppContainerRequests(setting.AppPod, setting.PVC)
+	}
+	minLimits := corev1.ResourceList{
+		// TODO: change me
+		corev1.ResourceCPU:    resource.MustParse("100m"),
+		corev1.ResourceMemory: resource.MustParse("100Mi"),
+	}
+	for name, quantity := range patch.ResourcePercentages.MinLimits {
+		minLimits[name] = quantity
+	}
+	applyResourcePercentages(&setting.Attr.Resources.Requests, patch.ResourcePercentages.Requests, nil, appRequests)
+	applyResourcePercentages(&setting.Attr.Resources.Limits, patch.ResourcePercentages.Limits, minLimits, appRequests)
 }
 
 func applyConfigPatch(setting *JfsSetting, replaceTemplate bool) {
@@ -1198,6 +1322,7 @@ func applyConfigPatch(setting *JfsSetting, replaceTemplate bool) {
 	if patch.Resources != nil {
 		attr.Resources = *patch.Resources
 	}
+	applyPatchResourcePercentages(setting, patch)
 	if patch.HostnameKey != "" {
 		attr.HostnameKey = patch.HostnameKey
 	}

--- a/pkg/config/setting_test.go
+++ b/pkg/config/setting_test.go
@@ -1678,6 +1678,35 @@ func Test_applyConfigPatch(t *testing.T) {
 			},
 		},
 		{
+			name: "test-large-percentage-buff-size",
+			args: args{
+				setting: &JfsSetting{
+					Attr: &PodAttr{
+						Resources: corev1.ResourceRequirements{
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceMemory: resource.MustParse("100Mi"),
+							},
+						},
+					},
+				},
+				patch: MountPodPatch{
+					MountOptions: []string{"buffer-size=150%"},
+				},
+			},
+			want: &JfsSetting{
+				Attr: &PodAttr{
+					Resources: corev1.ResourceRequirements{
+						Limits: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					},
+				},
+				Options: []string{
+					"buffer-size=100",
+				},
+			},
+		},
+		{
 			name: "test-large-buff-size-in-pv",
 			args: args{
 				setting: &JfsSetting{
@@ -1844,119 +1873,151 @@ func TestApplyConfigPatchResourcePercentages(t *testing.T) {
 				},
 				MinLimits: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("800m"),
-					corev1.ResourceMemory: resource.MustParse("128Mi"),
+					corev1.ResourceMemory: resource.MustParse("300Mi"),
 				},
 			},
 		},
 	}
 
-	setting := &JfsSetting{
-		PVC: &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: "jfs-pvc"},
-		},
-		AppPod: &corev1.Pod{
-			Spec: corev1.PodSpec{
-				Volumes: []corev1.Volume{
-					{
-						Name: "data",
-						VolumeSource: corev1.VolumeSource{
-							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "jfs-pvc"},
+	tests := []struct {
+		name              string
+		setting           *JfsSetting
+		wantRequestCPU    int64
+		wantRequestMemory string
+		wantLimitCPU      int64
+		wantLimitMemory   string
+		wantOptions       []string
+	}{
+		{
+			name: "default patch",
+			setting: &JfsSetting{
+				PVC: &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "jfs-pvc"},
+				},
+				AppPod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{
+							{
+								Name: "data",
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "jfs-pvc"},
+								},
+							},
+						},
+						Containers: []corev1.Container{
+							{
+								Name: "app-1",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("50m"),
+										corev1.ResourceMemory: resource.MustParse("50Mi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("200m"),
+										corev1.ResourceMemory: resource.MustParse("200Mi"),
+									},
+								},
+								VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
+							},
+							{
+								Name: "app-2",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("50m"),
+										corev1.ResourceMemory: resource.MustParse("51Mi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("300m"),
+										corev1.ResourceMemory: resource.MustParse("300Mi"),
+									},
+								},
+								VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
+							},
+							{
+								Name: "unrelated",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("10"),
+										corev1.ResourceMemory: resource.MustParse("10Gi"),
+									},
+								},
+							},
 						},
 					},
 				},
-				Containers: []corev1.Container{
-					{
-						Name: "app-1",
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("50m"),
-								corev1.ResourceMemory: resource.MustParse("50Mi"),
-							},
-						},
-						VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
-					},
-					{
-						Name: "app-2",
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("50m"),
-								corev1.ResourceMemory: resource.MustParse("51Mi"),
-							},
-						},
-						VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
-					},
-					{
-						Name: "unrelated",
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("10"),
-								corev1.ResourceMemory: resource.MustParse("10Gi"),
-							},
-						},
-					},
+				Attr: &PodAttr{
+					Resources: corev1.ResourceRequirements{},
 				},
 			},
+			wantRequestCPU:    30,
+			wantRequestMemory: "31Mi",
+			wantLimitCPU:      150,
+			wantLimitMemory:   "150Mi",
+			wantOptions:       []string{"buffer-size=75"},
 		},
-		Attr: &PodAttr{
-			Resources: corev1.ResourceRequirements{},
+		{
+			name: "node selector min limits",
+			setting: &JfsSetting{
+				PVC: &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "jfs-pvc"},
+				},
+				Node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"juicefs-test-node": "true"},
+					},
+				},
+				AppPod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						NodeSelector: map[string]string{"juicefs-test-node": "true"},
+						Volumes: []corev1.Volume{
+							{
+								Name: "data",
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "jfs-pvc"},
+								},
+							},
+						},
+						Containers: []corev1.Container{
+							{
+								Name: "app",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("2"),
+										corev1.ResourceMemory: resource.MustParse("1Gi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("4"),
+										corev1.ResourceMemory: resource.MustParse("2Gi"),
+									},
+								},
+								VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
+							},
+						},
+					},
+				},
+				Attr: &PodAttr{
+					Resources: corev1.ResourceRequirements{},
+				},
+			},
+			wantRequestCPU:    200,
+			wantRequestMemory: "103Mi",
+			wantLimitCPU:      800,
+			wantLimitMemory:   "300Mi",
+			wantOptions:       []string{"buffer-size=150"},
 		},
 	}
 
-	applyConfigPatch(setting, true)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyConfigPatch(tt.setting, true)
 
-	defaultCPURequest := resource.MustParse("100m")
-	assert.Equal(t, int64(30), setting.Attr.Resources.Requests.Cpu().MilliValue())
-	assert.Equal(t, "31Mi", setting.Attr.Resources.Requests.Memory().String())
-	assert.Equal(t, defaultCPURequest.MilliValue(), setting.Attr.Resources.Limits.Cpu().MilliValue())
-	assert.Equal(t, "100Mi", setting.Attr.Resources.Limits.Memory().String())
-	assert.Equal(t, []string{"buffer-size=50"}, setting.Options)
-
-	nodeSelectorSetting := &JfsSetting{
-		PVC: &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: "jfs-pvc"},
-		},
-		Node: &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{"juicefs-test-node": "true"},
-			},
-		},
-		AppPod: &corev1.Pod{
-			Spec: corev1.PodSpec{
-				NodeSelector: map[string]string{"juicefs-test-node": "true"},
-				Volumes: []corev1.Volume{
-					{
-						Name: "data",
-						VolumeSource: corev1.VolumeSource{
-							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "jfs-pvc"},
-						},
-					},
-				},
-				Containers: []corev1.Container{
-					{
-						Name: "app",
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("2"),
-								corev1.ResourceMemory: resource.MustParse("1Gi"),
-							},
-						},
-						VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
-					},
-				},
-			},
-		},
-		Attr: &PodAttr{
-			Resources: corev1.ResourceRequirements{},
-		},
+			assert.Equal(t, tt.wantRequestCPU, tt.setting.Attr.Resources.Requests.Cpu().MilliValue())
+			assert.Equal(t, tt.wantRequestMemory, tt.setting.Attr.Resources.Requests.Memory().String())
+			assert.Equal(t, tt.wantLimitCPU, tt.setting.Attr.Resources.Limits.Cpu().MilliValue())
+			assert.Equal(t, tt.wantLimitMemory, tt.setting.Attr.Resources.Limits.Memory().String())
+			assert.Equal(t, tt.wantOptions, tt.setting.Options)
+		})
 	}
-
-	applyConfigPatch(nodeSelectorSetting, true)
-
-	assert.Equal(t, int64(200), nodeSelectorSetting.Attr.Resources.Requests.Cpu().MilliValue())
-	assert.Equal(t, "103Mi", nodeSelectorSetting.Attr.Resources.Requests.Memory().String())
-	assert.Equal(t, int64(800), nodeSelectorSetting.Attr.Resources.Limits.Cpu().MilliValue())
-	assert.Equal(t, "128Mi", nodeSelectorSetting.Attr.Resources.Limits.Memory().String())
-	assert.Equal(t, []string{"buffer-size=64"}, nodeSelectorSetting.Options)
 }
 
 func TestGenHashOfSetting(t *testing.T) {

--- a/pkg/config/setting_test.go
+++ b/pkg/config/setting_test.go
@@ -1253,40 +1253,6 @@ func Test_genAndValidOptions(t *testing.T) {
 			want:    []string{"buffer-size=10M"},
 			wantErr: false,
 		},
-		{
-			name: "test-buffersize-percentage",
-			args: args{
-				JfsSetting: &JfsSetting{
-					Options: []string{"buffer-size=30%"},
-					Attr: &PodAttr{
-						Resources: corev1.ResourceRequirements{
-							Limits: map[corev1.ResourceName]resource.Quantity{
-								corev1.ResourceMemory: resource.MustParse("112Mi"),
-							},
-						},
-					},
-				},
-			},
-			want:    []string{"buffer-size=34"},
-			wantErr: false,
-		},
-		{
-			name: "test-buffersize-percentage-too-large",
-			args: args{
-				JfsSetting: &JfsSetting{
-					Options: []string{"buffer-size=101%"},
-					Attr: &PodAttr{
-						Resources: corev1.ResourceRequirements{
-							Limits: map[corev1.ResourceName]resource.Quantity{
-								corev1.ResourceMemory: resource.MustParse("100Mi"),
-							},
-						},
-					},
-				},
-			},
-			want:    nil,
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/config/setting_test.go
+++ b/pkg/config/setting_test.go
@@ -1918,8 +1918,8 @@ func TestApplyConfigPatchResourcePercentages(t *testing.T) {
 			wantRequestCPU:    30,
 			wantRequestMemory: "31Mi",
 			wantLimitCPU:      150,
-			wantLimitMemory:   "150Mi",
-			wantOptions:       []string{"buffer-size=75"},
+			wantLimitMemory:   "300Mi",
+			wantOptions:       []string{"buffer-size=150"},
 		},
 		{
 			name: "node selector min limits",

--- a/pkg/config/setting_test.go
+++ b/pkg/config/setting_test.go
@@ -1253,6 +1253,40 @@ func Test_genAndValidOptions(t *testing.T) {
 			want:    []string{"buffer-size=10M"},
 			wantErr: false,
 		},
+		{
+			name: "test-buffersize-percentage",
+			args: args{
+				JfsSetting: &JfsSetting{
+					Options: []string{"buffer-size=30%"},
+					Attr: &PodAttr{
+						Resources: corev1.ResourceRequirements{
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceMemory: resource.MustParse("112Mi"),
+							},
+						},
+					},
+				},
+			},
+			want:    []string{"buffer-size=34"},
+			wantErr: false,
+		},
+		{
+			name: "test-buffersize-percentage-too-large",
+			args: args{
+				JfsSetting: &JfsSetting{
+					Options: []string{"buffer-size=101%"},
+					Attr: &PodAttr{
+						Resources: corev1.ResourceRequirements{
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceMemory: resource.MustParse("100Mi"),
+							},
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1615,6 +1649,35 @@ func Test_applyConfigPatch(t *testing.T) {
 			},
 		},
 		{
+			name: "test-percentage-buff-size",
+			args: args{
+				setting: &JfsSetting{
+					Attr: &PodAttr{
+						Resources: corev1.ResourceRequirements{
+							Limits: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceMemory: resource.MustParse("100Mi"),
+							},
+						},
+					},
+				},
+				patch: MountPodPatch{
+					MountOptions: []string{"buffer-size=30%"},
+				},
+			},
+			want: &JfsSetting{
+				Attr: &PodAttr{
+					Resources: corev1.ResourceRequirements{
+						Limits: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					},
+				},
+				Options: []string{
+					"buffer-size=30",
+				},
+			},
+		},
+		{
 			name: "test-large-buff-size-in-pv",
 			args: args{
 				setting: &JfsSetting{
@@ -1747,6 +1810,155 @@ func Test_applyConfigPatch(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyConfigPatchResourcePercentages(t *testing.T) {
+	GlobalConfig.Reset()
+	defer GlobalConfig.Reset()
+
+	GlobalConfig.MountPodPatch = []MountPodPatch{
+		{
+			ResourcePercentages: &ResourcePercentages{
+				Limits: ResourcePercentageList{
+					corev1.ResourceCPU:    "30%",
+					corev1.ResourceMemory: "30%",
+				},
+				Requests: ResourcePercentageList{
+					corev1.ResourceCPU:    "30%",
+					corev1.ResourceMemory: "30%",
+				},
+			},
+			MountOptions: []string{"buffer-size=50%"},
+		},
+		{
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"juicefs-test-node": "true"},
+			},
+			ResourcePercentages: &ResourcePercentages{
+				Limits: ResourcePercentageList{
+					corev1.ResourceCPU:    "10%",
+					corev1.ResourceMemory: "10%",
+				},
+				Requests: ResourcePercentageList{
+					corev1.ResourceCPU:    "10%",
+					corev1.ResourceMemory: "10%",
+				},
+				MinLimits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("800m"),
+					corev1.ResourceMemory: resource.MustParse("128Mi"),
+				},
+			},
+		},
+	}
+
+	setting := &JfsSetting{
+		PVC: &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "jfs-pvc"},
+		},
+		AppPod: &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "jfs-pvc"},
+						},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name: "app-1",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("50m"),
+								corev1.ResourceMemory: resource.MustParse("50Mi"),
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
+					},
+					{
+						Name: "app-2",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("50m"),
+								corev1.ResourceMemory: resource.MustParse("51Mi"),
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
+					},
+					{
+						Name: "unrelated",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10"),
+								corev1.ResourceMemory: resource.MustParse("10Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+		Attr: &PodAttr{
+			Resources: corev1.ResourceRequirements{},
+		},
+	}
+
+	applyConfigPatch(setting, true)
+
+	defaultCPURequest := resource.MustParse("100m")
+	assert.Equal(t, int64(30), setting.Attr.Resources.Requests.Cpu().MilliValue())
+	assert.Equal(t, "31Mi", setting.Attr.Resources.Requests.Memory().String())
+	assert.Equal(t, defaultCPURequest.MilliValue(), setting.Attr.Resources.Limits.Cpu().MilliValue())
+	assert.Equal(t, "100Mi", setting.Attr.Resources.Limits.Memory().String())
+	assert.Equal(t, []string{"buffer-size=50"}, setting.Options)
+
+	nodeSelectorSetting := &JfsSetting{
+		PVC: &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "jfs-pvc"},
+		},
+		Node: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"juicefs-test-node": "true"},
+			},
+		},
+		AppPod: &corev1.Pod{
+			Spec: corev1.PodSpec{
+				NodeSelector: map[string]string{"juicefs-test-node": "true"},
+				Volumes: []corev1.Volume{
+					{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "jfs-pvc"},
+						},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("2"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
+					},
+				},
+			},
+		},
+		Attr: &PodAttr{
+			Resources: corev1.ResourceRequirements{},
+		},
+	}
+
+	applyConfigPatch(nodeSelectorSetting, true)
+
+	assert.Equal(t, int64(200), nodeSelectorSetting.Attr.Resources.Requests.Cpu().MilliValue())
+	assert.Equal(t, "103Mi", nodeSelectorSetting.Attr.Resources.Requests.Memory().String())
+	assert.Equal(t, int64(800), nodeSelectorSetting.Attr.Resources.Limits.Cpu().MilliValue())
+	assert.Equal(t, "128Mi", nodeSelectorSetting.Attr.Resources.Limits.Memory().String())
+	assert.Equal(t, []string{"buffer-size=64"}, nodeSelectorSetting.Options)
+}
+
 func TestGenHashOfSetting(t *testing.T) {
 	type args struct {
 		setting JfsSetting

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -476,6 +476,25 @@ func NewPrometheus(nodeName string) (prometheus.Registerer, *prometheus.Registry
 	return registerer, registry
 }
 
+func ParsePercentageToFloat(value string) (float64, error) {
+	value = strings.TrimSpace(value)
+	if !strings.HasSuffix(value, "%") {
+		return 0, fmt.Errorf("percentage must end with %%")
+	}
+	value = strings.TrimSpace(strings.TrimSuffix(value, "%"))
+	if value == "" {
+		return 0, fmt.Errorf("empty percentage")
+	}
+	percentage, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, err
+	}
+	if percentage < 0 || math.IsInf(percentage, 0) || math.IsNaN(percentage) {
+		return 0, fmt.Errorf("percentage must be a non-negative number")
+	}
+	return percentage, nil
+}
+
 // ParseToBytes parses a string with a unit suffix (e.g. "1M", "2G") to bytes.
 // default unit is M
 func ParseToBytes(value string) (uint64, error) {

--- a/pkg/webhook/handler/mutate/sidecar.go
+++ b/pkg/webhook/handler/mutate/sidecar.go
@@ -155,6 +155,7 @@ func (s *SidecarMutate) mutate(ctx context.Context, pod *corev1.Pod, pair resour
 
 	jfsSetting.Attr.Namespace = pod.Namespace
 	jfsSetting.SecretName = pair.PVC.Name + "-jfs-secret"
+	jfsSetting.AppPod = pod
 	s.jfsSetting = jfsSetting
 	quotaEnabled := config.GlobalConfig.EnableSetQuota == nil || *config.GlobalConfig.EnableSetQuota
 	capacity := pair.PVC.Spec.Resources.Requests.Storage().Value()
@@ -177,17 +178,17 @@ func (s *SidecarMutate) mutate(ctx context.Context, pod *corev1.Pod, pair resour
 		r = builder.NewServerlessBuilder(jfsSetting, cap, *pod, *pair.PVC)
 	}
 
+	// gen mount pod
+	mountPod := r.NewMountSidecar()
+	podStr, _ := json.Marshal(mountPod)
+	sidecarLog.V(1).Info("generate mount pod", "mount pod", string(podStr))
+
 	// create secret per PVC
 	secret := r.NewSecret()
 	builder.SetPVCAsOwner(&secret, pair.PVC)
 	if err = s.createOrUpdateSecret(ctx, &secret); err != nil {
 		return
 	}
-
-	// gen mount pod
-	mountPod := r.NewMountSidecar()
-	podStr, _ := json.Marshal(mountPod)
-	sidecarLog.V(1).Info("generate mount pod", "mount pod", string(podStr))
 
 	// deduplicate container name and volume name in pod when multiple volumes are mounted
 	s.Deduplicate(pod, mountPod, index)


### PR DESCRIPTION
## What this PR does

This PR adds support for configuring JuiceFS sidecar resources as percentages of the application containers that mount the same PVC.

A new `mountPodPatch.resourcePercentages` field is introduced, supporting percentage-based `requests` and `limits` for CPU and memory. Optional `minLimits` can be used to enforce minimum sidecar limits.

Example:

```yaml
mountPodPatch:
  - resourcePercentages:
      requests:
        cpu: "30%"
        memory: "30%"
      limits:
        cpu: "30%"
        memory: "30%"
      minLimits:
        cpu: "800m"
        memory: "128Mi"
    mountOptions:
      - buffer-size=50%
```