### PR TITLE
fix: make pod lock acquisition context-aware

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -159,6 +159,28 @@ func GetPodLock(podHashVal string) *sync.Mutex {
 	return &PodLocks[index]
 }
 
+func LockPod(ctx context.Context, podHashVal string) (func(), error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	lock := GetPodLock(podHashVal)
+	if lock.TryLock() {
+		return lock.Unlock, nil
+	}
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			if lock.TryLock() {
+				return lock.Unlock, nil
+			}
+		}
+	}
+}
+
 func MustGetWebPort() int {
 	value, exists := os.LookupEnv("JUICEFS_CSI_WEB_PORT")
 	if exists {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -17,8 +17,10 @@
 package config
 
 import (
+	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -217,6 +219,32 @@ MountPodPatch:
 			},
 		},
 	})
+}
+
+func TestLockPodRespectsContextCancel(t *testing.T) {
+	lockKey := "test-lock-pod-context-cancel"
+	lock := GetPodLock(lockKey)
+	lock.Lock()
+	defer lock.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		unlock, err := LockPod(ctx, lockKey)
+		if err == nil {
+			unlock()
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("LockPod did not return after context cancellation")
+	}
 }
 
 func TestGenMountPodPatch(t *testing.T) {

--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -204,9 +204,11 @@ func getPodStatus(pod *corev1.Pod) podStatus {
 func (p *PodDriver) checkAnnotations(ctx context.Context, pod *corev1.Pod) (Result, error) {
 	log := util.GenLog(ctx, podDriverLog, "")
 	// check refs in mount pod, the corresponding pod exists or not
-	lock := config.GetPodLock(config.GetPodLockKey(pod, ""))
-	lock.Lock()
-	defer lock.Unlock()
+	unlock, err := config.LockPod(ctx, config.GetPodLockKey(pod, ""))
+	if err != nil {
+		return Result{}, err
+	}
+	defer unlock()
 
 	delAnnotations := []string{}
 	var existTargets int
@@ -294,9 +296,11 @@ func (p *PodDriver) podCompleteHandler(ctx context.Context, pod *corev1.Pod) (Re
 	}
 	hashVal := setting.HashVal
 
-	lock := config.GetPodLock(config.GetPodLockKey(pod, hashVal))
-	lock.Lock()
-	defer lock.Unlock()
+	unlock, err := config.LockPod(ctx, config.GetPodLockKey(pod, hashVal))
+	if err != nil {
+		return Result{}, err
+	}
+	defer unlock()
 
 	hasAvailPod := p.getAvailableMountPod(pod.Labels[common.PodUniqueIdLabelKey], resource.GetUpgradeUUID(pod))
 	if !hasAvailPod {
@@ -343,9 +347,11 @@ func (p *PodDriver) podErrorHandler(ctx context.Context, pod *corev1.Pod) (Resul
 		return Result{}, nil
 	}
 	log := util.GenLog(ctx, podDriverLog, "podErrorHandler")
-	lock := config.GetPodLock(config.GetPodLockKey(pod, ""))
-	lock.Lock()
-	defer lock.Unlock()
+	unlock, err := config.LockPod(ctx, config.GetPodLockKey(pod, ""))
+	if err != nil {
+		return Result{}, err
+	}
+	defer unlock()
 
 	// check resource err
 	if resource.IsPodResourceError(pod) {
@@ -453,9 +459,11 @@ func (p *PodDriver) podDeletedHandler(ctx context.Context, pod *corev1.Pod) (Res
 	}
 	hashVal := setting.HashVal
 
-	lock := config.GetPodLock(config.GetPodLockKey(pod, hashVal))
-	lock.Lock()
-	defer lock.Unlock()
+	unlock, err := config.LockPod(ctx, config.GetPodLockKey(pod, hashVal))
+	if err != nil {
+		return Result{}, err
+	}
+	defer unlock()
 
 	for k, v := range pod.Annotations {
 		// annotation is checked in beginning, don't double-check here
@@ -549,9 +557,11 @@ func (p *PodDriver) podPendingHandler(ctx context.Context, pod *corev1.Pod) (Res
 		return Result{}, nil
 	}
 	log := util.GenLog(ctx, podDriverLog, "podPendingHandler")
-	lock := config.GetPodLock(config.GetPodLockKey(pod, ""))
-	lock.Lock()
-	defer lock.Unlock()
+	unlock, err := config.LockPod(ctx, config.GetPodLockKey(pod, ""))
+	if err != nil {
+		return Result{}, err
+	}
+	defer unlock()
 
 	enableAutoRemove := config.GlobalConfig.EnableAutoRemoveRequestResources == nil || *config.GlobalConfig.EnableAutoRemoveRequestResources
 	// check resource err
@@ -635,9 +645,11 @@ func (p *PodDriver) podReadyHandler(ctx context.Context, pod *corev1.Pod) (Resul
 
 	supFusePass := config.SupportFusePass(pod)
 
-	lock := config.GetPodLock(config.GetPodLockKey(pod, ""))
-	lock.Lock()
-	defer lock.Unlock()
+	unlock, err := config.LockPod(ctx, config.GetPodLockKey(pod, ""))
+	if err != nil {
+		return Result{}, err
+	}
+	defer unlock()
 
 	err = resource.WaitUntilMountReady(ctx, pod.Name, mntPath, defaultCheckoutTimeout)
 	if err != nil {

--- a/pkg/fuse/grace/grace.go
+++ b/pkg/fuse/grace/grace.go
@@ -233,9 +233,11 @@ func NewPodUpgrade(ctx context.Context, client *k8s.K8sClient, name string, recr
 }
 
 func (p *PodUpgrade) gracefulShutdown(ctx context.Context, conn net.Conn) error {
-	lock := config.GetPodLock(p.hashVal)
-	lock.Lock()
-	defer lock.Unlock()
+	unlock, lockErr := config.LockPod(ctx, p.hashVal)
+	if lockErr != nil {
+		return lockErr
+	}
+	defer unlock()
 
 	var jfsConf *util.JuiceConf
 	var err error

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -706,9 +706,11 @@ func (j *juicefs) JfsUnmount(ctx context.Context, volumeId, mountPath string) er
 		log.Info("No mount pod found, skip umount mount pod", "mountPath", mountPath, "uniqueId", uniqueId, "volumeId", volumeId)
 		return nil
 	}
-	lock := config.GetPodLock(config.GetPodLockKey(mountPod, ""))
-	lock.Lock()
-	defer lock.Unlock()
+	unlock, err := config.LockPod(ctx, config.GetPodLockKey(mountPod, ""))
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	return j.mnt.JUmount(ctx, mountPath, mountPod.Name)
 }
 

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -87,9 +87,11 @@ func (p *PodMount) JMount(ctx context.Context, appInfo *jfsConfig.AppInfo, jfsSe
 	var err error
 
 	if err = func() error {
-		lock := jfsConfig.GetPodLock(hashVal)
-		lock.Lock()
-		defer lock.Unlock()
+		unlock, err := jfsConfig.LockPod(ctx, hashVal)
+		if err != nil {
+			return err
+		}
+		defer unlock()
 
 		podName, err = p.genMountPodName(ctx, jfsSetting)
 		if err != nil {


### PR DESCRIPTION
When a CSI operation cannot acquire the pod lock for a long time, kubelet may cancel the request after its 2-minute timeout. However, the CSI handler can still remain blocked on `sync.Mutex.Lock()` because the lock wait is not context-aware.

This leaves lingering goroutines in the CSI process after the request context has already been canceled, and may keep the outer volume operation lock held longer than necessary. As a result, subsequent kubelet retries can continue to fail with `Aborted` because the previous operation is still considered in progress.
