### PR TITLE
fix: add disable lazy umount target flag

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -458,6 +458,8 @@ type Config struct {
 	EnableAutoRemoveRequestResources *bool `json:"enableAutoRemoveRequestResources,omitempty"`
 	// enable auto abort stuck mount pod after timeout, the default is true
 	EnableAutoAbortStuckMountPod *bool `json:"enableAutoAbortStuckMountPod,omitempty"`
+	// enable lazy umount target, the default is true
+	EnableLazyUmountTarget *bool `json:"enableLazyUmountTarget,omitempty"`
 	// use kubelet API to list mount pods on the node
 	// if enabled, the driver will try to use kubelet API to list mount pods on the node, and fall back to request api-server if kubelet API fails
 	// Kubelet synchronization of pods may have delays, which in high-concurrency scenarios could lead to mountpods not being reused.

--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -245,18 +245,30 @@ func (p *PodMount) UmountTarget(ctx context.Context, target, podName string) err
 	// targetPath may be mount bind many times when mount point recovered.
 	// umount until it's not mounted.
 	log := util.GenLog(ctx, p.log, "UmountTarget")
-	log.Info("lazy umount", "target", target)
+	enableLazyUmountTarget := jfsConfig.GlobalConfig.EnableLazyUmountTarget == nil || *jfsConfig.GlobalConfig.EnableLazyUmountTarget
+	log.Info("umount target", "target", target, "lazy", enableLazyUmountTarget)
 	for {
-		command := exec.Command("umount", "-l", target)
+		args := []string{target}
+		if enableLazyUmountTarget {
+			args = []string{"-l", target}
+		}
+		command := exec.CommandContext(ctx, "umount", args...)
 		out, err := command.CombinedOutput()
 		if err == nil {
 			continue
 		}
-		log.V(1).Info(string(out))
-		if !strings.Contains(string(out), "not mounted") &&
-			!strings.Contains(string(out), "mountpoint not found") &&
-			!strings.Contains(string(out), "no mount point specified") {
-			log.Error(err, "Could not lazy unmount", "target", target, "out", string(out))
+		outStr := string(out)
+		log.V(1).Info(outStr)
+		if !enableLazyUmountTarget && strings.Contains(outStr, "busy") {
+			if err := util.UmountPath(ctx, target, true); err != nil {
+				return err
+			}
+			continue
+		}
+		if !strings.Contains(outStr, "not mounted") &&
+			!strings.Contains(outStr, "mountpoint not found") &&
+			!strings.Contains(outStr, "no mount point specified") {
+			log.Error(err, "Could not unmount", "target", target, "lazy", enableLazyUmountTarget, "out", outStr)
 			return err
 		}
 		break


### PR DESCRIPTION
## Summary

Add a global `enableLazyUmountTarget` config flag to control target unmount behavior in pod mount mode.

The current implementation always uses `umount -l` for target mount points. In environments with a large number of target mount points, most targets are usually not busy during normal CSI teardown, and normal `umount` can complete the cleanup synchronously and faster than lazy umount. 

By default, behavior remains unchanged and target unmount uses `umount -l`. When `enableLazyUmountTarget` is set to `false`, the driver first tries normal `umount` and falls back to lazy umount only when the target is busy.