### PR TITLE
fix send on close channel when parsing fusefd

### DIFF
--- a/pkg/fuse/passfd/passfd.go
+++ b/pkg/fuse/passfd/passfd.go
@@ -122,13 +122,14 @@ func (fs *Fds) ParseFuseFds(ctx context.Context) {
 			continue
 		}
 		var subEntries []os.DirEntry
+		parentPath := path.Join(fs.basePath, entry.Name())
 		err = util.DoWithTimeout(ctx, 2*time.Second, func(ctx context.Context) error {
-			subEntries, err = os.ReadDir(path.Join(fs.basePath, entry.Name()))
+			subEntries, err = os.ReadDir(parentPath)
 			return err
 		})
 		if err != nil {
-			fdLog.Error(err, "read dir error", "basePath", fs.basePath)
-			return
+			fdLog.Error(err, "read dir error", "basePath", fs.basePath, "path", parentPath)
+			continue
 		}
 		shouldRemove := true
 		for _, subEntry := range subEntries {
@@ -140,15 +141,15 @@ func (fs *Fds) ParseFuseFds(ctx context.Context) {
 					continue
 				}
 				fdLog.V(1).Info("parse fuse fd", "path", subdir)
+				limitCh <- struct{}{}
 				wg.Add(1)
-				go func() {
+				go func(upgradeUUID, fusePath string) {
 					defer func() {
-						wg.Done()
 						<-limitCh
+						wg.Done()
 					}()
-					limitCh <- struct{}{}
-					fs.parseFuse(ctx, entry.Name(), subdir)
-				}()
+					fs.parseFuse(ctx, upgradeUUID, fusePath)
+				}(entry.Name(), subdir)
 			}
 		}
 		if shouldRemove {

--- a/pkg/fuse/passfd/passfd_test.go
+++ b/pkg/fuse/passfd/passfd_test.go
@@ -1,0 +1,129 @@
+/*
+ Copyright 2026 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package passfd
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	. "github.com/agiledragon/gomonkey/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/common"
+	"github.com/juicedata/juicefs-csi-driver/pkg/config"
+	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+)
+
+type testDirEntry struct {
+	name  string
+	isDir bool
+}
+
+func (d testDirEntry) Name() string               { return d.name }
+func (d testDirEntry) IsDir() bool                { return d.isDir }
+func (d testDirEntry) Type() fs.FileMode          { return 0 }
+func (d testDirEntry) Info() (fs.FileInfo, error) { return nil, nil }
+
+func TestParseFuseFdsContinuesWhenSubdirDisappears(t *testing.T) {
+	oldNodeName := config.NodeName
+	oldNamespace := config.Namespace
+	config.NodeName = "test-node"
+	config.Namespace = "default"
+	t.Cleanup(func() {
+		config.NodeName = oldNodeName
+		config.Namespace = oldNamespace
+	})
+
+	basePath := t.TempDir()
+	const missingUUID = "uuid-missing"
+	var entries []os.DirEntry
+	var pods []runtime.Object
+	for i := 0; i < 25; i++ {
+		upgradeUUID := fmt.Sprintf("uuid-%02d", i)
+		entries = append(entries, testDirEntry{name: upgradeUUID, isDir: true})
+		pods = append(pods, newFusePassPod(upgradeUUID))
+	}
+	entries = append(entries, testDirEntry{name: missingUUID, isDir: true})
+
+	var activeParsers int32
+	patches := ApplyFunc(os.ReadDir, func(name string) ([]os.DirEntry, error) {
+		switch {
+		case name == basePath:
+			return entries, nil
+		case filepath.Base(name) == missingUUID:
+			return nil, os.ErrNotExist
+		default:
+			return []os.DirEntry{testDirEntry{name: "fuse_fd_comm.1"}}, nil
+		}
+	})
+	patches.ApplyFunc(GetFuseFd, func(string, bool) (int, []byte) {
+		atomic.AddInt32(&activeParsers, 1)
+		defer atomic.AddInt32(&activeParsers, -1)
+		time.Sleep(10 * time.Millisecond)
+		return -1, nil
+	})
+	defer patches.Reset()
+
+	fds := &Fds{
+		client:   &k8sclient.K8sClient{Interface: fake.NewSimpleClientset(pods...)},
+		basePath: basePath,
+		fds:      map[string]*fd{},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fds.ParseFuseFds(context.Background())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("ParseFuseFds did not return")
+	}
+	if got := atomic.LoadInt32(&activeParsers); got != 0 {
+		t.Fatalf("ParseFuseFds returned before parsers finished, active parsers: %d", got)
+	}
+}
+
+func newFusePassPod(upgradeUUID string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      upgradeUUID,
+			Namespace: config.Namespace,
+			Labels: map[string]string{
+				common.PodTypeKey:             common.PodTypeValue,
+				common.PodUpgradeUUIDLabelKey: upgradeUUID,
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: config.NodeName,
+			Containers: []corev1.Container{
+				{Image: config.DefaultCEMountImage},
+			},
+		},
+	}
+}


### PR DESCRIPTION
When csi node is initing, mountpod is deleted before csi node parsing fuse fd. So the fuse fd path is deleted and parsed fail. csi node returned the parse function and close channel, but there still has some goroutine trying to send msg to channel. The solution is continue instead of return when parsing failed.


```
I0707 06:06:06.455065       7 pod_driver.go:268] "There are no refs in pod annotation, delete it" logger="pod-driver" podName="juicefs-cn-hangzhou.172.22.118.155-pvc-1e3f35dd-f27e-4862-990d-31f698a52a2d-hxgjho"
I0707 06:06:06.456585       7 pod_driver.go:268] "There are no refs in pod annotation, delete it" logger="pod-driver" podName="juicefs-cn-hangzhou.172.22.118.155-pvc-363840d5-2cc8-42da-870b-98ebc09a500c-vosola"
I0707 06:06:06.458454       7 passfd.go:473] "get fd and msg" logger="passfd" fd=[39,40]
I0707 06:06:06.458607       7 passfd.go:487] "send FUSE fd" logger="passfd" fd=40
I0707 06:06:06.458671       7 passfd.go:276] "fuse fd path of pod" logger="passfd" upgradeUUID="01f480be-5f1e-4fa8-b10b-9a7eea20bae5" fusePath="/tmp/01f480be-5f1e-4fa8-b10b-9a7eea20bae5/fuse_fd_comm.1"
I0707 06:06:06.459102       7 passfd.go:473] "get fd and msg" logger="passfd" fd=[39,41]
I0707 06:06:06.459114       7 passfd.go:487] "send FUSE fd" logger="passfd" fd=41
I0707 06:06:06.459157       7 passfd.go:276] "fuse fd path of pod" logger="passfd" upgradeUUID="023436a5-a111-42a1-a8ba-010a79d423b3" fusePath="/tmp/023436a5-a111-42a1-a8ba-010a79d423b3/fuse_fd_comm.1"
I0707 06:06:06.459214       7 passfd.go:142] "parse fuse fd" logger="passfd" path="/tmp/02424cdd-b122-43f3-b41f-1680d31ed394/fuse_fd_comm.1"
I0707 06:06:06.459474       7 passfd.go:142] "parse fuse fd" logger="passfd" path="/tmp/0421907c-e6ca-42d2-bac6-b17b0dab1692/fuse_fd_comm.1"
I0707 06:06:06.459759       7 passfd.go:142] "parse fuse fd" logger="passfd" path="/tmp/06ac931a-ebfe-440e-b7e3-d80976c275e6/fuse_fd_comm.1"
I0707 06:06:06.459794       7 passfd.go:142] "parse fuse fd" logger="passfd" path="/tmp/06f1f508-1fae-4ef3-ac74-d9a26494ff5c/fuse_fd_comm.1"
I0707 06:06:06.459827       7 passfd.go:142] "parse fuse fd" logger="passfd" path="/tmp/06f3e860-6551-498e-ba9f-136264d240ba/fuse_fd_comm.1"
I0707 06:06:06.459936       7 passfd.go:142] "parse fuse fd" logger="passfd" path="/tmp/08d02ff6-0056-41ec-94a4-c5dba7405c0d/fuse_fd_comm.1"
E0707 06:06:06.459970       7 passfd.go:130] "read dir error" err="open /tmp/08dbd837-a3c7-4b2a-9cd7-4aebdfe92746: no such file or directory" logger="passfd" basePath="/tmp"
I0707 06:06:05.834843       7 pod.go:353] "delayDelete: computed delay time already passed, skip adding annotation" logger="util" time="2026-07-07T06:06:05Z" podName="juicefs-cn-hangzhou.172.22.118.155-pvc-22effd1c-316f-417d-b3e1-add8a2eaeebb-uuwstq"
I0707 06:06:06.460621       7 pod.go:353] "delayDelete: computed delay time already passed, skip adding annotation" logger="util" time="2026-07-07T06:06:06Z" podName="juicefs-cn-hangzhou.172.22.118.155-pvc-fa1b5968-a982-4834-8669-1e63918061c8-dqsoyz"
I0707 06:06:05.835310       7 pod.go:353] "delayDelete: computed delay time already passed, skip adding annotation" logger="util" time="2026-07-07T06:06:05Z" podName="juicefs-cn-hangzhou.172.22.118.155-pvc-9f1d51bb-bc48-4f3c-8589-e76356cb4bce-kpkbzq"
I0707 06:06:05.835433       7 pod.go:353] "delayDelete: computed delay time already passed, skip adding annotation" logger="util" time="2026-07-07T06:06:05Z" podName="juicefs-cn-hangzhou.172.22.118.155-pvc-8a08152d-7e6a-4a41-a037-b92ffce90684-hzwgbl"
I0707 06:06:05.835849       7 pod.go:353] "delayDelete: computed delay time already passed, skip adding annotation" logger="util" time="2026-07-07T06:06:05Z" podName="juicefs-cn-hangzhou.172.22.118.155-pvc-53ea3c33-fede-46d8-8e0c-feda7e2e619c-jygxds"
I0707 06:06:05.835890       7 pod.go:353] "delayDelete: computed delay time already passed, skip adding annotation" logger="util" time="2026-07-07T06:06:05Z" podName="juicefs-cn-hangzhou.172.22.118.155-pvc-d6fc0d5c-1ac7-46d0-a60c-3d9c23aacac1-tseaki"
I0707 06:06:06.470292       7 pod.go:353] "delayDelete: computed delay time already passed, skip adding annotation" logger="util" time="2026-07-07T06:06:06Z" podName="juicefs-cn-hangzhou.172.22.118.155-pvc-8ad3ef6e-66d1-4521-81fb-4fd586d84745-gadelt"
I0707 06:06:06.529673       7 pod_driver.go:268] "There are no refs in pod annotation, delete it" logger="pod-driver" podName="juicefs-cn-hangzhou.172.22.118.155-pvc-b928027f-16d3-47aa-817c-ffaae937288a-gtuqdx"
I0707 06:06:05.836463       7 pod.go:353] "delayDelete: computed delay time already passed, skip adding annotation" logger="util" time="2026-07-07T06:06:05Z" podName="juicefs-cn-hangzhou.172.22.118.155-pvc-4735ad15-9bf0-4313-9298-dcf5e3443dd2-uikrjm"
panic: send on closed channel

goroutine 7555 [running]:
github.com/juicedata/juicefs-csi-driver/pkg/fuse/passfd.(*Fds).ParseFuseFds.func3()
	/workspace/pkg/fuse/passfd/passfd.go:149 +0xaa
created by github.com/juicedata/juicefs-csi-driver/pkg/fuse/passfd.(*Fds).ParseFuseFds in goroutine 65
	/workspace/pkg/fuse/passfd/passfd.go:144 +0xed4
```