### PR TITLE
release csi 0.32.0

### DIFF
--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -587,8 +587,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: DASHBOARD_IMAGE
-          value: juicedata/csi-dashboard:v0.31.3
-        image: juicedata/csi-dashboard:v0.31.3
+          value: juicedata/csi-dashboard:v0.32.0
+        image: juicedata/csi-dashboard:v0.32.0
         name: dashboard
         ports:
         - containerPort: 8088
@@ -657,7 +657,7 @@ spec:
           value: /var/lib/juicefs/volume
         - name: JUICEFS_CONFIG_PATH
           value: /var/lib/juicefs/config
-        image: juicedata/juicefs-csi-driver:v0.31.3
+        image: juicedata/juicefs-csi-driver:v0.32.0
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -812,7 +812,7 @@ spec:
           value: /var/lib/juicefs/volume
         - name: JUICEFS_CONFIG_PATH
           value: /var/lib/juicefs/config
-        image: juicedata/juicefs-csi-driver:v0.31.3
+        image: juicedata/juicefs-csi-driver:v0.32.0
         livenessProbe:
           failureThreshold: 5
           httpGet:

--- a/deploy/k8s_before_v1_18.yaml
+++ b/deploy/k8s_before_v1_18.yaml
@@ -587,8 +587,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: DASHBOARD_IMAGE
-          value: juicedata/csi-dashboard:v0.31.3
-        image: juicedata/csi-dashboard:v0.31.3
+          value: juicedata/csi-dashboard:v0.32.0
+        image: juicedata/csi-dashboard:v0.32.0
         name: dashboard
         ports:
         - containerPort: 8088
@@ -657,7 +657,7 @@ spec:
           value: /var/lib/juicefs/volume
         - name: JUICEFS_CONFIG_PATH
           value: /var/lib/juicefs/config
-        image: juicedata/juicefs-csi-driver:v0.31.3
+        image: juicedata/juicefs-csi-driver:v0.32.0
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -812,7 +812,7 @@ spec:
           value: /var/lib/juicefs/volume
         - name: JUICEFS_CONFIG_PATH
           value: /var/lib/juicefs/config
-        image: juicedata/juicefs-csi-driver:v0.31.3
+        image: juicedata/juicefs-csi-driver:v0.32.0
         livenessProbe:
           failureThreshold: 5
           httpGet:

--- a/deploy/kubernetes/base/resources.yaml
+++ b/deploy/kubernetes/base/resources.yaml
@@ -401,7 +401,7 @@ spec:
           operator: Exists
       containers:
         - name: juicefs-plugin
-          image: juicedata/juicefs-csi-driver:v0.31.3
+          image: juicedata/juicefs-csi-driver:v0.32.0
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
@@ -557,7 +557,7 @@ spec:
         - name: juicefs-plugin
           securityContext:
             privileged: true
-          image: juicedata/juicefs-csi-driver:v0.31.3
+          image: juicedata/juicefs-csi-driver:v0.32.0
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
@@ -838,7 +838,7 @@ spec:
       serviceAccountName: juicefs-csi-dashboard-sa
       containers:
         - name: dashboard
-          image: juicedata/csi-dashboard:v0.31.3
+          image: juicedata/csi-dashboard:v0.32.0
           args:
             - --static-dir=/dist
           env:
@@ -847,7 +847,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: DASHBOARD_IMAGE
-              value: juicedata/csi-dashboard:v0.31.3
+              value: juicedata/csi-dashboard:v0.32.0
           ports:
             - containerPort: 8088
           resources:

--- a/deploy/webhook-with-certmanager.yaml
+++ b/deploy/webhook-with-certmanager.yaml
@@ -484,8 +484,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: DASHBOARD_IMAGE
-          value: juicedata/csi-dashboard:v0.31.3
-        image: juicedata/csi-dashboard:v0.31.3
+          value: juicedata/csi-dashboard:v0.32.0
+        image: juicedata/csi-dashboard:v0.32.0
         name: dashboard
         ports:
         - containerPort: 8088
@@ -557,7 +557,7 @@ spec:
           value: /var/lib/juicefs/volume
         - name: JUICEFS_CONFIG_PATH
           value: /var/lib/juicefs/config
-        image: juicedata/juicefs-csi-driver:v0.31.3
+        image: juicedata/juicefs-csi-driver:v0.32.0
         livenessProbe:
           failureThreshold: 5
           httpGet:

--- a/deploy/webhook.yaml
+++ b/deploy/webhook.yaml
@@ -512,8 +512,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: DASHBOARD_IMAGE
-          value: juicedata/csi-dashboard:v0.31.3
-        image: juicedata/csi-dashboard:v0.31.3
+          value: juicedata/csi-dashboard:v0.32.0
+        image: juicedata/csi-dashboard:v0.32.0
         name: dashboard
         ports:
         - containerPort: 8088
@@ -585,7 +585,7 @@ spec:
           value: /var/lib/juicefs/volume
         - name: JUICEFS_CONFIG_PATH
           value: /var/lib/juicefs/config
-        image: juicedata/juicefs-csi-driver:v0.31.3
+        image: juicedata/juicefs-csi-driver:v0.32.0
         livenessProbe:
           failureThreshold: 5
           httpGet:

--- a/docs/en/guide/resource-optimization.md
+++ b/docs/en/guide/resource-optimization.md
@@ -40,6 +40,39 @@ globalConfig:
 
 After changes are applied, rollout the application Pods or delete the Mount Pods to take effect.
 
+### Define sidecar resources by percentage {#sidecar-resource-percentages}
+
+Starting from v0.32.0, when using [sidecar mode](../introduction.md#sidecar), you can define sidecar container resources as percentages of the application containers that mount the same PVC:
+
+```yaml title="values-mycluster.yaml" {3-12}
+globalConfig:
+  mountPodPatch:
+    - resourcePercentages:
+        requests:
+          cpu: "50%"
+          memory: "50%"
+        limits:
+          cpu: "80%"
+          memory: "80%"
+      mountOptions:
+        - buffer-size=50%
+```
+
+`resourcePercentages.requests` is calculated from the application containers' resource requests, and `resourcePercentages.limits` is calculated from their resource limits. If multiple application containers mount the same PVC, their resources are summed before applying the percentage. Only `cpu` and `memory` are supported.
+
+If the calculated limits are too small, `minLimits` is used as the lower bound. When `minLimits` is not set, the default lower bounds are 100m CPU and 300Mi memory. If `minLimits` is set too low, the mount container may fail to start; the actual minimum resources required may vary with the file system scale.
+
+For example, to customize the lower bound:
+
+```yaml
+resourcePercentages:
+  minLimits:
+    cpu: 500m
+    memory: 512Mi
+```
+
+The `buffer-size` mount option also supports percentages. `buffer-size=50%` is calculated from the final memory limit of the mount container or sidecar container, and is converted to MiB before being passed to JuiceFS. If the percentage is greater than 100%, it is capped at the memory limit.
+
 ### Declare resources in PVC annotations (deprecated) {#mount-pod-resources-pvc}
 
 :::tip

--- a/docs/zh_cn/guide/resource-optimization.md
+++ b/docs/zh_cn/guide/resource-optimization.md
@@ -40,6 +40,39 @@ globalConfig:
 
 修改完毕以后，滚动升级应用或者删除重建 Mount Pod，便会按照新的资源定义重建。
 
+### 按比例配置 sidecar 资源声明 {#sidecar-resource-percentages}
+
+从 v0.32.0 开始，如果使用 [Sidecar 模式](../introduction.md#sidecar)，可以将 sidecar 容器资源配置为使用同一个 PVC 的应用容器资源的一定比例：
+
+```yaml title="values-mycluster.yaml" {3-12}
+globalConfig:
+  mountPodPatch:
+    - resourcePercentages:
+        requests:
+          cpu: "50%"
+          memory: "50%"
+        limits:
+          cpu: "80%"
+          memory: "80%"
+      mountOptions:
+        - buffer-size=50%
+```
+
+`resourcePercentages.requests` 根据应用容器的资源请求计算，`resourcePercentages.limits` 根据应用容器的资源限制计算。如果多个应用容器挂载了同一个 PVC，会先累加这些容器的资源，再按比例计算。该配置只支持 `cpu` 和 `memory`。
+
+如果计算出来的 limits 太小，会使用 `minLimits` 作为下限。未设置 `minLimits` 时，默认下限是 100m CPU 和 300Mi 内存。如果 `minLimits` 设置过低，mount 容器可能无法启动；实际所需的最小资源可能和文件系统规模有关。
+
+如果需要自定义下限，可以单独设置：
+
+```yaml
+resourcePercentages:
+  minLimits:
+    cpu: 500m
+    memory: 512Mi
+```
+
+`buffer-size` 挂载参数也支持百分比。`buffer-size=50%` 会按照 mount 容器或 sidecar 容器最终的 memory limit 计算，并转换为 MiB 后传给 JuiceFS。如果百分比超过 100%，会按 memory limit 封顶。
+
 ### 在 PVC 配置资源声明（不推荐） {#mount-pod-resources-pvc}
 
 :::tip

--- a/scripts/juicefs-csi-webhook-install.sh
+++ b/scripts/juicefs-csi-webhook-install.sh
@@ -583,8 +583,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: DASHBOARD_IMAGE
-          value: juicedata/csi-dashboard:v0.31.3
-        image: juicedata/csi-dashboard:v0.31.3
+          value: juicedata/csi-dashboard:v0.32.0
+        image: juicedata/csi-dashboard:v0.32.0
         name: dashboard
         ports:
         - containerPort: 8088
@@ -656,7 +656,7 @@ spec:
           value: /var/lib/juicefs/volume
         - name: JUICEFS_CONFIG_PATH
           value: /var/lib/juicefs/config
-        image: juicedata/juicefs-csi-driver:v0.31.3
+        image: juicedata/juicefs-csi-driver:v0.32.0
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -1417,8 +1417,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: DASHBOARD_IMAGE
-          value: juicedata/csi-dashboard:v0.31.3
-        image: juicedata/csi-dashboard:v0.31.3
+          value: juicedata/csi-dashboard:v0.32.0
+        image: juicedata/csi-dashboard:v0.32.0
         name: dashboard
         ports:
         - containerPort: 8088
@@ -1490,7 +1490,7 @@ spec:
           value: /var/lib/juicefs/volume
         - name: JUICEFS_CONFIG_PATH
           value: /var/lib/juicefs/config
-        image: juicedata/juicefs-csi-driver:v0.31.3
+        image: juicedata/juicefs-csi-driver:v0.32.0
         livenessProbe:
           failureThreshold: 5
           httpGet:


### PR DESCRIPTION
## What's Changed

* fix: add disable lazy umount target flag @zxh326 in https://github.com/juicedata/juicefs-csi-driver/pull/1612
* feat: support mount pod image pull policy @zxh326 in https://github.com/juicedata/juicefs-csi-driver/pull/1611
* fix: make pod lock acquisition context-aware @zxh326 in https://github.com/juicedata/juicefs-csi-driver/pull/1607
* feat: support sidecar resource percentages @zxh326 in https://github.com/juicedata/juicefs-csi-driver/pull/1601
* Add `xxd` to the ee mount image @zxh326 in https://github.com/juicedata/juicefs-csi-driver/pull/1603
* dashboard: check config error @zwwhdls in https://github.com/juicedata/juicefs-csi-driver/pull/1600
* fix upgrade pid when hostpid is enabled @zwwhdls in https://github.com/juicedata/juicefs-csi-driver/pull/1599
* fix: restrict unsafe PVC mount pod annotations @zxh326 in https://github.com/juicedata/juicefs-csi-driver/pull/1584
* fix: use bookworm Go image for 1.25 @zxh326 in https://github.com/juicedata/juicefs-csi-driver/pull/1572
* chore: update Go version to 1.25 @zxh326 in https://github.com/juicedata/juicefs-csi-driver/pull/1570
* chore: update dependencies @dependabot[bot] @zxh326 in https://github.com/juicedata/juicefs-csi-driver/pull/1609 https://github.com/juicedata/juicefs-csi-driver/pull/1596 https://github.com/juicedata/juicefs-csi-driver/pull/1563 https://github.com/juicedata/juicefs-csi-driver/pull/1559 https://github.com/juicedata/juicefs-csi-driver/pull/1558 https://github.com/juicedata/juicefs-csi-driver/pull/1547 https://github.com/juicedata/juicefs-csi-driver/pull/1545 https://github.com/juicedata/juicefs-csi-driver/pull/1544 https://github.com/juicedata/juicefs-csi-driver/pull/1539

## Included JuiceFS

* the included JuiceFS community version is `v1.4.0`
* the included JuiceFS enterprise version is `5.3.10`
* default mount pod image of community is [mount:ce-v1.4.0](https://hub.docker.com/r/juicedata/mount/tags?name=ce-v1.4.0)
* default mount pod image of enterprise is [ee-5.3.10-5968bc1](https://hub.docker.com/layers/juicedata/mount/ee-5.3.10-5968bc1/images/sha256-f297fb7004e2d9d978686cfad61bab1ff14135b7a8547a0dabd2c58df22630ae)

**Full Changelog**: https://github.com/juicedata/juicefs-csi-driver/compare/v0.31.10...v0.32.0