### PR TITLE
fix: parse image tag correctly when registry has a port

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -584,12 +584,23 @@ func parseClientVersionFromImage(image string) ClientVersion {
 	if image == "" {
 		return ClientVersion{}
 	}
-	imageSplits := strings.SplitN(image, ":", 2)
+	// Strip digest so "repo:tag@sha256:..." / "repo@sha256:..." are handled correctly.
+	if at := strings.LastIndex(image, "@"); at >= 0 {
+		image = image[:at]
+	}
+	// Tag lives in the last path component. Splitting the whole reference on the first
+	// ":" breaks images whose registry includes a port, e.g.
+	// "registry.example.com:5000/juicedata/mount:ce-v1.2.3".
+	name := image
+	if slash := strings.LastIndex(image, "/"); slash >= 0 {
+		name = image[slash+1:]
+	}
+	imageSplits := strings.SplitN(name, ":", 2)
 	if len(imageSplits) < 2 {
 		// latest
 		return ClientVersion{IsCe: true, Major: math.MaxInt32}
 	}
-	_, tag := imageSplits[0], imageSplits[1]
+	tag := imageSplits[1]
 	version := ClientVersion{Dev: true}
 	var re *regexp.Regexp
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -717,6 +717,56 @@ func TestParseClientVersion(t *testing.T) {
 				Nightly: true,
 			},
 		},
+		{
+			name: "ce-with-registry-port",
+			args: args{
+				image: "registry.example.com:5000/juicedata/mount:ce-v1.2.3",
+			},
+			want: ClientVersion{
+				IsCe:  true,
+				Dev:   false,
+				Major: 1,
+				Minor: 2,
+				Patch: 3,
+			},
+		},
+		{
+			name: "ee-with-registry-port",
+			args: args{
+				image: "hub.example.com:8443/kbdp/mount:ee-5.1.0",
+			},
+			want: ClientVersion{
+				IsCe:  false,
+				Dev:   false,
+				Major: 5,
+				Minor: 1,
+				Patch: 0,
+			},
+		},
+		{
+			name: "ce-with-registry-port-and-digest",
+			args: args{
+				image: "registry.example.com:5000/juicedata/mount:ce-v1.2.3@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			},
+			want: ClientVersion{
+				IsCe:  true,
+				Dev:   false,
+				Major: 1,
+				Minor: 2,
+				Patch: 3,
+			},
+		},
+		{
+			name: "ce-latest-with-registry-port",
+			args: args{
+				image: "registry.example.com:5000/juicedata/mount",
+			},
+			want: ClientVersion{
+				IsCe:  true,
+				Dev:   false,
+				Major: math.MaxInt32,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -796,6 +846,19 @@ func TestSupportFusePassPod(t *testing.T) {
 					Containers: []corev1.Container{
 						{
 							Image: "juicedata/mount:ce-v1.2.1",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod with supporting image and registry port (ce-v1.2.3)",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Image: "hub.example.com:8443/kbdp/mount:ce-v1.2.3",
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

- Fix `parseClientVersionFromImage` so image tags are taken from the last path component instead of splitting the whole reference on the first `:`.
- Private registries that expose a non-default port (e.g. `hub.example.com:8443/project/mount:ce-v1.2.3`) were previously misparsed: the "tag" became `8443/project/mount:ce-v1.2.3`, `SupportFusePass` returned false, and Mount Pods incorrectly got a default `preStop` `umount` hook. That breaks smooth upgrade / mount-point recovery for CSI >= 0.25.
- Also strip an image digest (`@sha256:...`) before parsing the tag.

## Test plan

- [x] `go test -gcflags=all=-l ./pkg/util/ -run 'TestParseClientVersion|TestSupportFusePassPod'` — passed (covers existing cases plus registry-port / digest cases)
- [x] Online validation before the code fix: using a mount image reference without a registry port made CSI stop injecting `preStop umount` for `ce-v1.2.3`; with `:8443` in the reference it kept injecting
