### PR TITLE
fix delayed mount pod deletion with kubelet sync

### DIFF
--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juicedata/juicefs-csi-driver/pkg/common"
 	"github.com/juicedata/juicefs-csi-driver/pkg/config"
 	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+	"github.com/juicedata/juicefs-csi-driver/pkg/util"
 	"github.com/juicedata/juicefs-csi-driver/pkg/util/resource"
 )
 
@@ -123,6 +124,9 @@ func doReconcile(ks *k8sclient.K8sClient, kc *k8sclient.KubeletClient) {
 			_, immediateReconcile := pod.Annotations[common.ImmediateReconcilerKey]
 			if !immediateReconcile {
 				if ok {
+					if delayAt, err := util.GetTime(pod.Annotations[common.DeleteDelayAtKey]); err == nil && delayAt.Before(lastStatus.nextSyncAt) {
+						lastStatus.nextSyncAt = delayAt
+					}
 					if lastStatus.podStatus == crtPodStatus && time.Now().Before(lastStatus.nextSyncAt) {
 						// skipped
 						continue


### PR DESCRIPTION
## What changed

Use the `juicefs-delete-at` annotation as an earlier reconciliation deadline when polling mount pods through kubelet.

## Why

The kubelet reconciler skips mount pods whose status has not changed until `nextSyncAt`. That timestamp defaults to 10 minutes, so a newly added delayed-deletion deadline could be ignored until the default reconciliation window elapsed. For example, a 3-minute mount pod deletion delay could take more than 10 minutes.

This change keeps the existing status-based skip behavior while moving `nextSyncAt` forward when `juicefs-delete-at` is earlier.

## Impact

Mount pods configured for delayed deletion are reconciled near their configured deletion deadline instead of being held by the default 10-minute interval.

## Validation

- `go test ./pkg/controller`