### PR TITLE
fix: make kubelet access error counting race-free and per-client

### DIFF
--- a/pkg/k8sclient/kubelet_client.go
+++ b/pkg/k8sclient/kubelet_client.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -39,15 +40,19 @@ const (
 )
 
 var (
-	kubeletLog            = klog.NewKlogr().WithName("kubelet-client")
-	kubeletAccessErrCount = 0
-	kubeletAccessErrMax   = 5
+	kubeletLog          = klog.NewKlogr().WithName("kubelet-client")
+	kubeletAccessErrMax = 5
 )
 
 type KubeletClient struct {
 	host   string
 	port   int
 	client *http.Client
+	// accessErrCount is this client's own consecutive-failure streak; atomic
+	// because a single client is polled by concurrent mount handlers.
+	accessErrCount atomic.Int32
+	// exitFunc runs on limit-exceeded; os.Exit in production, stubbed in tests.
+	exitFunc func(int)
 }
 
 // KubeletClientConfig defines config parameters for the kubelet client
@@ -156,6 +161,7 @@ func NewKubeletClient(host string, port int) (*KubeletClient, error) {
 			Transport: trans,
 			Timeout:   config.HTTPTimeout,
 		},
+		exitFunc: os.Exit,
 	}, nil
 }
 
@@ -176,22 +182,22 @@ func (kc *KubeletClient) Access() error {
 	return nil
 }
 
-func checkKubeletAccessErr(err error) {
+func (kc *KubeletClient) checkAccessErr(err error) {
 	if err == nil {
-		kubeletAccessErrCount = 0
+		kc.accessErrCount.Store(0)
 		return
 	}
-	kubeletAccessErrCount++
-	if kubeletAccessErrCount >= kubeletAccessErrMax {
+	// Concurrent failures may call exitFunc more than once; harmless, first wins.
+	if kc.accessErrCount.Add(1) >= int32(kubeletAccessErrMax) {
 		kubeletLog.Error(fmt.Errorf("kubelet access error count exceeds the limit %d", kubeletAccessErrMax), "last error", err)
-		os.Exit(1)
+		kc.exitFunc(1)
 	}
 }
 
 func (kc *KubeletClient) GetNodeRunningPods() (*corev1.PodList, error) {
 	resp, err := kc.client.Get(fmt.Sprintf("https://%v:%d/pods/", kc.host, kc.port))
 	if err != nil {
-		checkKubeletAccessErr(err)
+		kc.checkAccessErr(err)
 		return nil, err
 	}
 	defer func() {
@@ -201,16 +207,16 @@ func (kc *KubeletClient) GetNodeRunningPods() (*corev1.PodList, error) {
 
 	if resp.StatusCode/100 != 2 {
 		err := fmt.Errorf("unexpected status code %d", resp.StatusCode)
-		checkKubeletAccessErr(err)
+		kc.checkAccessErr(err)
 		return nil, err
 	}
 
 	podLists := &corev1.PodList{}
 	if err = json.NewDecoder(resp.Body).Decode(podLists); err != nil {
 		kubeletLog.Error(err, "GetNodeRunningPods err")
-		checkKubeletAccessErr(err)
+		kc.checkAccessErr(err)
 		return nil, err
 	}
-	checkKubeletAccessErr(nil)
+	kc.checkAccessErr(nil)
 	return podLists, nil
 }

--- a/pkg/k8sclient/kubelet_client_test.go
+++ b/pkg/k8sclient/kubelet_client_test.go
@@ -1,0 +1,98 @@
+/*
+ Copyright 2026 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package k8sclient
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+// TestCheckAccessErrPerClientIsolation locks in that the failure streak is
+// per-client. Before the fix a single package-global counter was shared by the
+// reconciler client and the mount client, so one client's success reset the
+// other's accumulated failures (and vice versa). Here client A must reach its
+// own limit even though client B reports a success in between, and B must never
+// exit because of A's failures.
+func TestCheckAccessErrPerClientIsolation(t *testing.T) {
+	fail := errors.New("kubelet unreachable")
+	var aExits, bExits int
+	a := &KubeletClient{exitFunc: func(int) { aExits++ }}
+	b := &KubeletClient{exitFunc: func(int) { bExits++ }}
+
+	// A accumulates failures up to one short of the limit.
+	for i := 0; i < kubeletAccessErrMax-1; i++ {
+		a.checkAccessErr(fail)
+	}
+	// A success on B must not touch A's streak.
+	b.checkAccessErr(nil)
+	if aExits != 0 {
+		t.Fatalf("A exited before reaching the limit: aExits=%d", aExits)
+	}
+
+	// A's next failure crosses its own limit and exits A only.
+	a.checkAccessErr(fail)
+	if aExits == 0 {
+		t.Fatalf("A did not exit after %d consecutive failures", kubeletAccessErrMax)
+	}
+	if bExits != 0 {
+		t.Fatalf("B exited because of A's failures: bExits=%d", bExits)
+	}
+}
+
+// TestCheckAccessErrResetsOnSuccess documents that a success clears the streak,
+// so a single client below the limit never exits no matter how many isolated
+// failures it has seen between successes.
+func TestCheckAccessErrResetsOnSuccess(t *testing.T) {
+	fail := errors.New("kubelet unreachable")
+	var exits int
+	kc := &KubeletClient{exitFunc: func(int) { exits++ }}
+
+	for i := 0; i < kubeletAccessErrMax*3; i++ {
+		kc.checkAccessErr(fail) // one failure...
+		kc.checkAccessErr(nil)  // ...immediately cleared
+	}
+	if exits != 0 {
+		t.Fatalf("client exited despite every failure being reset: exits=%d", exits)
+	}
+}
+
+// TestCheckAccessErrDataRace drives one client's counter from several goroutines
+// at once, mirroring the concurrent CSI mount handlers that share a single
+// KubeletClient. exitFunc is a no-op so the probe never terminates the process.
+// With the per-client atomic counter this passes cleanly under `go test -race`;
+// reverting the counter to a plain int makes the race detector fail here.
+func TestCheckAccessErrDataRace(t *testing.T) {
+	fail := errors.New("kubelet unreachable")
+	kc := &KubeletClient{exitFunc: func(int) {}}
+
+	const goroutines = 4
+	const iterations = 2000
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				kc.checkAccessErr(fail) // failure branch: increment
+				kc.checkAccessErr(nil)  // success branch: reset
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Resolves #1638