### PR TITLE
precheck before batch upgrade

### DIFF
--- a/cmd/dashboard/upgrade.go
+++ b/cmd/dashboard/upgrade.go
@@ -47,6 +47,9 @@ import (
 
 var batchConfigName string
 
+const batchUpgradeTimeoutEnv = "BATCH_UPGRADE_TIMEOUT"
+const defaultPodUpgradeTimeout = 300 * time.Second
+
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "trigger upgrade mount pod smoothly",
@@ -100,6 +103,7 @@ var upgradeCmd = &cobra.Command{
 			k8sConfig:       k8sconfig,
 			k8sClient:       k8sClient,
 			clientset:       clientset,
+			podUpgradeTimeout: defaultPodUpgradeTimeout,
 			lock:            sync.Mutex{},
 			podsStatus:      podsStatus,
 			status:          config.Running,
@@ -156,6 +160,7 @@ type BatchUpgrade struct {
 	k8sConfig    *rest.Config
 	k8sClient    *k8sclient.K8sClient
 	clientset    *kubernetes.Clientset
+	podUpgradeTimeout time.Duration
 
 	batches         []map[string][]*PodUpgrade
 	lock            sync.Mutex
@@ -173,6 +178,13 @@ type PodUpgrade struct {
 }
 
 func (u *BatchUpgrade) Run(ctx context.Context) {
+	timeout, err := getBatchUpgradeTimeout()
+	if err != nil {
+		logger(fmt.Sprintf("BATCH-FAIL invalid %s: %v", batchUpgradeTimeoutEnv, err))
+		os.Exit(1)
+	}
+	u.podUpgradeTimeout = timeout
+
 	if len(u.conf.Batches) == 0 {
 		logger("BATCH-SUCCESS no batch found")
 		u.status = config.Success
@@ -298,7 +310,18 @@ func (u *BatchUpgrade) processBatch(ctx context.Context, batchIdx int) {
 		for csiNode, mps := range csiNodeNames {
 			wg.Add(1)
 
-			go func() {
+			go func(csiNode string, mps []config.MountPodUpgrade) {
+				if ok, reason := u.precheckNode(ctx, csiNode); !ok {
+					for _, p := range mps {
+						u.lock.Lock()
+						u.podsStatus[p.Name] = config.Skip
+						u.lock.Unlock()
+						logger(fmt.Sprintf("POD-SKIP [%s] %s", p.Name, reason))
+					}
+					resultCh <- nil
+					wg.Done()
+					return
+				}
 				resultCh <- u.triggerUpgrade(ctx, csiNode, batchConfigName, batchIdx)
 				needWait := false
 				node := ""
@@ -315,7 +338,7 @@ func (u *BatchUpgrade) processBatch(ctx context.Context, batchIdx int) {
 				}
 
 				wg.Done()
-			}()
+			}(csiNode, mps)
 		}
 	}()
 	// pod upgrade error:
@@ -334,6 +357,43 @@ func (u *BatchUpgrade) processBatch(ctx context.Context, batchIdx int) {
 	}
 	u.lock.Unlock()
 	u.setCrtBatchStatus(crtBatchFinalStatus)
+}
+
+// precheckNode verifies that the node and its CSI node pod are in a state that
+// allows a smooth upgrade. It returns false (with a reason) when the upgrade of
+// all pods on the node should be skipped:
+//  1. the node is marked SchedulingDisabled (spec.unschedulable == true)
+//  2. the CSI node pod on the node is not ready
+//
+// When the node or CSI node pod state cannot be confirmed due to an API error,
+// it conservatively returns false so the node is skipped rather than upgraded.
+func (u *BatchUpgrade) precheckNode(ctx context.Context, csiNode string) (bool, string) {
+	if csiNode == "" {
+		return false, "skip upgrade: no csi node pod found"
+	}
+
+	po, err := u.k8sClient.GetPod(ctx, csiNode, u.sysNamespace)
+	if err != nil {
+		return false, fmt.Sprintf("skip upgrade: can not get csi node pod %s: %s", csiNode, err.Error())
+	}
+	nodeName := po.Spec.NodeName
+	if nodeName == "" {
+		return false, fmt.Sprintf("skip upgrade: csi node pod %s has no node name", csiNode)
+	}
+
+	node, err := u.k8sClient.GetNode(ctx, nodeName)
+	if err != nil {
+		return false, fmt.Sprintf("skip upgrade: can not get node %s: %s", nodeName, err.Error())
+	}
+	if node.Spec.Unschedulable {
+		return false, fmt.Sprintf("skip upgrade: node %s is marked SchedulingDisabled", nodeName)
+	}
+
+	if !resource.IsPodReady(po) {
+		return false, fmt.Sprintf("skip upgrade: csi node pod %s on node %s is not ready", csiNode, nodeName)
+	}
+
+	return true, ""
 }
 
 func (u *BatchUpgrade) setCrtBatchStatus(s config.UpgradeStatus) {
@@ -430,7 +490,7 @@ func (u *BatchUpgrade) triggerUpgrade(ctx context.Context, csiNode string, confi
 }
 
 func (u *BatchUpgrade) waitForUpgrade(ctx context.Context, index int, nodeName, csiNode string) {
-	ctx, cancel := context.WithTimeout(ctx, 300*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, u.podUpgradeTimeout)
 	defer cancel()
 	timer := time.NewTicker(5 * time.Second)
 	defer timer.Stop()
@@ -557,6 +617,21 @@ func (u *BatchUpgrade) waitForUpgrade(ctx context.Context, index int, nodeName, 
 	}
 }
 
+func getBatchUpgradeTimeout() (time.Duration, error) {
+	value := os.Getenv(batchUpgradeTimeoutEnv)
+	if value == "" {
+		return defaultPodUpgradeTimeout, nil
+	}
+	timeout, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", batchUpgradeTimeoutEnv, err)
+	}
+	if timeout <= 0 {
+		return 0, fmt.Errorf("%s must be greater than 0", batchUpgradeTimeoutEnv)
+	}
+	return timeout, nil
+}
+
 func (u *BatchUpgrade) Write(p []byte) (n int, err error) {
 	msg := string(p)
 	fmt.Print(msg)
@@ -591,6 +666,17 @@ func (u *BatchUpgrade) Write(p []byte) (n int, err error) {
 		podName := failMatches[1]
 		u.lock.Lock()
 		u.podsStatus[podName] = config.Fail
+		u.lock.Unlock()
+	}
+
+	skipRegex := `POD-SKIP \[([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)\]`
+	skipRe := regexp.MustCompile(skipRegex)
+
+	skipMatches := skipRe.FindStringSubmatch(msg)
+	if len(skipMatches) > 1 {
+		podName := skipMatches[1]
+		u.lock.Lock()
+		u.podsStatus[podName] = config.Skip
 		u.lock.Unlock()
 	}
 

--- a/cmd/dashboard/upgrade.go
+++ b/cmd/dashboard/upgrade.go
@@ -626,7 +626,7 @@ func getBatchUpgradeTimeout() (time.Duration, error) {
 	}
 	seconds, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("parse %s: invalid integer: %w", batchUpgradeTimeoutEnv, err)
+		return 0, fmt.Errorf("parse %s: must be an integer (seconds), got %q", batchUpgradeTimeoutEnv, value)
 	}
 	timeout := time.Duration(seconds) * time.Second
 	if timeout < minPodUpgradeTimeout {

--- a/cmd/dashboard/upgrade.go
+++ b/cmd/dashboard/upgrade.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -47,8 +48,9 @@ import (
 
 var batchConfigName string
 
-const batchUpgradeTimeoutEnv = "BATCH_UPGRADE_TIMEOUT"
+const batchUpgradeTimeoutEnv = "BATCH_UPGRADE_TIMEOUT_SECONDS"
 const defaultPodUpgradeTimeout = 300 * time.Second
+const minPodUpgradeTimeout = 5 * time.Second
 
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
@@ -98,18 +100,18 @@ var upgradeCmd = &cobra.Command{
 			}
 		}
 		bu := &BatchUpgrade{
-			sysNamespace:    sysNamespace,
-			conf:            conf,
-			k8sConfig:       k8sconfig,
-			k8sClient:       k8sClient,
-			clientset:       clientset,
+			sysNamespace:      sysNamespace,
+			conf:              conf,
+			k8sConfig:         k8sconfig,
+			k8sClient:         k8sClient,
+			clientset:         clientset,
 			podUpgradeTimeout: defaultPodUpgradeTimeout,
-			lock:            sync.Mutex{},
-			podsStatus:      podsStatus,
-			status:          config.Running,
-			crtBatchStatus:  config.Pending,
-			nextBatchStatus: config.Pending,
-			crtBatch:        0,
+			lock:              sync.Mutex{},
+			podsStatus:        podsStatus,
+			status:            config.Running,
+			crtBatchStatus:    config.Pending,
+			nextBatchStatus:   config.Pending,
+			crtBatch:          0,
 		}
 		bu.flushStatus(context.TODO())
 		ctx, cancel := context.WithCancel(context.Background())
@@ -155,11 +157,11 @@ func (u *BatchUpgrade) handleSignal() {
 }
 
 type BatchUpgrade struct {
-	sysNamespace string
-	conf         *config.BatchConfig
-	k8sConfig    *rest.Config
-	k8sClient    *k8sclient.K8sClient
-	clientset    *kubernetes.Clientset
+	sysNamespace      string
+	conf              *config.BatchConfig
+	k8sConfig         *rest.Config
+	k8sClient         *k8sclient.K8sClient
+	clientset         *kubernetes.Clientset
 	podUpgradeTimeout time.Duration
 
 	batches         []map[string][]*PodUpgrade
@@ -622,12 +624,13 @@ func getBatchUpgradeTimeout() (time.Duration, error) {
 	if value == "" {
 		return defaultPodUpgradeTimeout, nil
 	}
-	timeout, err := time.ParseDuration(value)
+	seconds, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("parse %s: %w", batchUpgradeTimeoutEnv, err)
+		return 0, fmt.Errorf("parse %s: invalid integer: %w", batchUpgradeTimeoutEnv, err)
 	}
-	if timeout <= 0 {
-		return 0, fmt.Errorf("%s must be greater than 0", batchUpgradeTimeoutEnv)
+	timeout := time.Duration(seconds) * time.Second
+	if timeout < minPodUpgradeTimeout {
+		return 0, fmt.Errorf("%s must be at least %v", batchUpgradeTimeoutEnv, minPodUpgradeTimeout)
 	}
 	return timeout, nil
 }

--- a/cmd/dashboard/upgrade_test.go
+++ b/cmd/dashboard/upgrade_test.go
@@ -49,7 +49,7 @@ func TestPrecheckNode(t *testing.T) {
 	tests := []struct {
 		name    string
 		objects []runtime.Object
-		csiNode  string
+		csiNode string
 		wantOK  bool
 	}{
 		{
@@ -59,7 +59,7 @@ func TestPrecheckNode(t *testing.T) {
 				readyCSINodePod("csi-node-1", ns, "node-1"),
 			},
 			csiNode: "csi-node-1",
-			wantOK: true,
+			wantOK:  true,
 		},
 		{
 			name: "node marked SchedulingDisabled",
@@ -71,7 +71,7 @@ func TestPrecheckNode(t *testing.T) {
 				readyCSINodePod("csi-node-1", ns, "node-1"),
 			},
 			csiNode: "csi-node-1",
-			wantOK: false,
+			wantOK:  false,
 		},
 		{
 			name: "csi node pod not ready",
@@ -88,7 +88,7 @@ func TestPrecheckNode(t *testing.T) {
 				},
 			},
 			csiNode: "csi-node-1",
-			wantOK: false,
+			wantOK:  false,
 		},
 		{
 			name: "node not found (api error) -> skip",
@@ -96,7 +96,7 @@ func TestPrecheckNode(t *testing.T) {
 				readyCSINodePod("csi-node-1", ns, "node-1"),
 			},
 			csiNode: "csi-node-1",
-			wantOK: false,
+			wantOK:  false,
 		},
 		{
 			name: "csi node pod not found (api error) -> skip",
@@ -104,7 +104,7 @@ func TestPrecheckNode(t *testing.T) {
 				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
 			},
 			csiNode: "csi-node-1",
-			wantOK: false,
+			wantOK:  false,
 		},
 		{
 			name: "empty csi node pod name -> skip",
@@ -112,7 +112,7 @@ func TestPrecheckNode(t *testing.T) {
 				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
 			},
 			csiNode: "",
-			wantOK: false,
+			wantOK:  false,
 		},
 	}
 

--- a/cmd/dashboard/upgrade_test.go
+++ b/cmd/dashboard/upgrade_test.go
@@ -1,0 +1,152 @@
+/*
+ Copyright 2024 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/k8sclient"
+)
+
+func readyCSINodePod(name, namespace, nodeName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       corev1.PodSpec{NodeName: nodeName},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				{Type: corev1.ContainersReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func TestPrecheckNode(t *testing.T) {
+	const ns = "kube-system"
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		csiNode  string
+		wantOK  bool
+	}{
+		{
+			name: "schedulable node with ready csi node pod",
+			objects: []runtime.Object{
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+				readyCSINodePod("csi-node-1", ns, "node-1"),
+			},
+			csiNode: "csi-node-1",
+			wantOK: true,
+		},
+		{
+			name: "node marked SchedulingDisabled",
+			objects: []runtime.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+					Spec:       corev1.NodeSpec{Unschedulable: true},
+				},
+				readyCSINodePod("csi-node-1", ns, "node-1"),
+			},
+			csiNode: "csi-node-1",
+			wantOK: false,
+		},
+		{
+			name: "csi node pod not ready",
+			objects: []runtime.Object{
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "csi-node-1", Namespace: ns},
+					Spec:       corev1.PodSpec{NodeName: "node-1"},
+					Status: corev1.PodStatus{
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+					},
+				},
+			},
+			csiNode: "csi-node-1",
+			wantOK: false,
+		},
+		{
+			name: "node not found (api error) -> skip",
+			objects: []runtime.Object{
+				readyCSINodePod("csi-node-1", ns, "node-1"),
+			},
+			csiNode: "csi-node-1",
+			wantOK: false,
+		},
+		{
+			name: "csi node pod not found (api error) -> skip",
+			objects: []runtime.Object{
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+			},
+			csiNode: "csi-node-1",
+			wantOK: false,
+		},
+		{
+			name: "empty csi node pod name -> skip",
+			objects: []runtime.Object{
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+			},
+			csiNode: "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &k8sclient.K8sClient{Interface: fake.NewSimpleClientset(tt.objects...)}
+			u := &BatchUpgrade{sysNamespace: ns, k8sClient: client}
+			ok, reason := u.precheckNode(context.Background(), tt.csiNode)
+			assert.Equal(t, tt.wantOK, ok)
+			if !ok {
+				assert.NotEmpty(t, reason)
+			}
+		})
+	}
+}
+
+func TestGetBatchUpgradeTimeout(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		t.Setenv(batchUpgradeTimeoutEnv, "")
+		timeout, err := getBatchUpgradeTimeout()
+		assert.NoError(t, err)
+		assert.Equal(t, defaultPodUpgradeTimeout, timeout)
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		t.Setenv(batchUpgradeTimeoutEnv, "45s")
+		timeout, err := getBatchUpgradeTimeout()
+		assert.NoError(t, err)
+		assert.Equal(t, 45*time.Second, timeout)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		t.Setenv(batchUpgradeTimeoutEnv, "nope")
+		_, err := getBatchUpgradeTimeout()
+		assert.Error(t, err)
+	})
+}

--- a/cmd/dashboard/upgrade_test.go
+++ b/cmd/dashboard/upgrade_test.go
@@ -138,10 +138,23 @@ func TestGetBatchUpgradeTimeout(t *testing.T) {
 	})
 
 	t.Run("custom", func(t *testing.T) {
-		t.Setenv(batchUpgradeTimeoutEnv, "45s")
+		t.Setenv(batchUpgradeTimeoutEnv, "45")
 		timeout, err := getBatchUpgradeTimeout()
 		assert.NoError(t, err)
 		assert.Equal(t, 45*time.Second, timeout)
+	})
+
+	t.Run("below minimum", func(t *testing.T) {
+		t.Setenv(batchUpgradeTimeoutEnv, "5")
+		_, err := getBatchUpgradeTimeout()
+		assert.Error(t, err)
+	})
+
+	t.Run("at minimum", func(t *testing.T) {
+		t.Setenv(batchUpgradeTimeoutEnv, "10")
+		timeout, err := getBatchUpgradeTimeout()
+		assert.NoError(t, err)
+		assert.Equal(t, 10*time.Second, timeout)
 	})
 
 	t.Run("invalid", func(t *testing.T) {

--- a/cmd/dashboard/upgrade_test.go
+++ b/cmd/dashboard/upgrade_test.go
@@ -137,7 +137,7 @@ func TestGetBatchUpgradeTimeout(t *testing.T) {
 		assert.Equal(t, defaultPodUpgradeTimeout, timeout)
 	})
 
-	t.Run("custom", func(t *testing.T) {
+	t.Run("integer seconds", func(t *testing.T) {
 		t.Setenv(batchUpgradeTimeoutEnv, "45")
 		timeout, err := getBatchUpgradeTimeout()
 		assert.NoError(t, err)
@@ -145,20 +145,26 @@ func TestGetBatchUpgradeTimeout(t *testing.T) {
 	})
 
 	t.Run("below minimum", func(t *testing.T) {
-		t.Setenv(batchUpgradeTimeoutEnv, "5")
+		t.Setenv(batchUpgradeTimeoutEnv, "4")
 		_, err := getBatchUpgradeTimeout()
 		assert.Error(t, err)
 	})
 
 	t.Run("at minimum", func(t *testing.T) {
-		t.Setenv(batchUpgradeTimeoutEnv, "10")
+		t.Setenv(batchUpgradeTimeoutEnv, "5")
 		timeout, err := getBatchUpgradeTimeout()
 		assert.NoError(t, err)
-		assert.Equal(t, 10*time.Second, timeout)
+		assert.Equal(t, 5*time.Second, timeout)
 	})
 
-	t.Run("invalid", func(t *testing.T) {
+	t.Run("invalid integer", func(t *testing.T) {
 		t.Setenv(batchUpgradeTimeoutEnv, "nope")
+		_, err := getBatchUpgradeTimeout()
+		assert.Error(t, err)
+	})
+
+	t.Run("duration string rejected", func(t *testing.T) {
+		t.Setenv(batchUpgradeTimeoutEnv, "45s")
 		_, err := getBatchUpgradeTimeout()
 		assert.Error(t, err)
 	})

--- a/dashboard-ui-v2/src/pages/batch-upgrade-job-detail.tsx
+++ b/dashboard-ui-v2/src/pages/batch-upgrade-job-detail.tsx
@@ -63,7 +63,7 @@ const BatchUpgradeJobDetail: React.FC<{
     setDeleteTime(formatTime(timeToBeDeletedOfJob(upgradeJob?.job)))
 
     const successCount = Array.from(newDiffStatus.values()).filter(
-      (v) => v === 'success',
+      (v) => v === 'success' || v === 'skip',
     ).length
     setPercent(
       totalPods !== 0
@@ -74,7 +74,7 @@ const BatchUpgradeJobDetail: React.FC<{
 
   const calculatePercent = () => {
     const successMatches = Array.from(diffStatus.values()).filter(
-      (v) => v === 'success',
+      (v) => v === 'success' || v === 'skip',
     ).length
     setPercent(
       total !== 0
@@ -104,7 +104,11 @@ const BatchUpgradeJobDetail: React.FC<{
       for (const match of message.matchAll(regex)) {
         const podName = match[1]
         const prevStatus = diffStatus.get(podName)
-        if (prevStatus !== 'success' && prevStatus !== 'fail') {
+        if (
+          prevStatus !== 'success' &&
+          prevStatus !== 'fail' &&
+          prevStatus !== 'skip'
+        ) {
           setDiffStatus((prev) => new Map(prev).set(podName, status))
           calculatePercent()
         }
@@ -122,6 +126,10 @@ const BatchUpgradeJobDetail: React.FC<{
     updateStatus(
       /POD-FAIL \[([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)\]/g,
       'fail',
+    )
+    updateStatus(
+      /POD-SKIP \[([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)\]/g,
+      'skip',
     )
   }
 

--- a/dashboard-ui-v2/src/utils/index.ts
+++ b/dashboard-ui-v2/src/utils/index.ts
@@ -703,6 +703,8 @@ export const getUpgradeStatusBadge = (finalStatus: string) => {
     case 'pause':
     case 'stop':
       return 'default'
+    case 'skip':
+      return 'warning'
     case 'running':
       return 'processing'
     case 'success':

--- a/pkg/config/batch_config.go
+++ b/pkg/config/batch_config.go
@@ -56,6 +56,7 @@ const (
 	Fail    UpgradeStatus = "fail"
 	Stop    UpgradeStatus = "stop"
 	Pause   UpgradeStatus = "pause"
+	Skip    UpgradeStatus = "skip"
 )
 
 // used by kubectl plugin
@@ -238,7 +239,7 @@ func GetDiffWithNode(mountPod *corev1.Pod, pvc *corev1.PersistentVolumeClaim, pv
 
 // IsPodUpgradeOngoing checks if a pod's upgrade status indicates it's still in progress
 func IsPodUpgradeOngoing(status UpgradeStatus) bool {
-	return status != Success && status != Fail && status != Stop
+	return status != Success && status != Fail && status != Stop && status != Skip
 }
 
 // filterPodsFromConfigs extracts pod names that are in ongoing upgrades from the given configs

--- a/pkg/config/batch_config_test.go
+++ b/pkg/config/batch_config_test.go
@@ -322,6 +322,7 @@ func TestIsPodUpgradeOngoing(t *testing.T) {
 		{Success, false},
 		{Fail, false},
 		{Stop, false},
+		{Skip, false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/dashboard/batch.go
+++ b/pkg/dashboard/batch.go
@@ -76,6 +76,10 @@ func (api *API) createUpgradeJob() gin.HandlerFunc {
 			c.String(400, "smooth upgrade is disabled")
 			return
 		}
+		if err := validateBatchUpgradeTimeoutEnv(); err != nil {
+			c.String(500, err.Error())
+			return
+		}
 		createJobBody := struct {
 			JobName     string `json:"jobName,omitempty"`
 			NodeName    string `json:"nodeName,omitempty"`
@@ -466,6 +470,17 @@ func NewUpgradeJob(jobName string) *batchv1.Job {
 			},
 		},
 	}
+}
+
+func validateBatchUpgradeTimeoutEnv() error {
+	timeout, ok := os.LookupEnv(batchUpgradeTimeoutEnv)
+	if !ok || timeout == "" {
+		return nil
+	}
+	if _, err := strconv.ParseInt(timeout, 10, 64); err != nil {
+		return fmt.Errorf("%s must be an integer number of seconds", batchUpgradeTimeoutEnv)
+	}
+	return nil
 }
 
 type PodDiff struct {

--- a/pkg/dashboard/batch.go
+++ b/pkg/dashboard/batch.go
@@ -45,6 +45,8 @@ import (
 
 var batchLog = klog.NewKlogr().WithName("batch")
 
+const batchUpgradeTimeoutEnv = "BATCH_UPGRADE_TIMEOUT_SECONDS"
+
 type ListJobResult struct {
 	Total    int           `json:"total"`
 	Continue string        `json:"continue"`
@@ -421,6 +423,13 @@ func NewUpgradeJob(jobName string) *batchv1.Job {
 		sa = os.Getenv("JUICEFS_CSI_DASHBOARD_SA")
 	}
 	configName := GenUpgradeConfig(jobName)
+	envs := []corev1.EnvVar{
+		{Name: "SYS_NAMESPACE", Value: sysNamespace},
+		{Name: common.JfsUpgradeConfig, Value: configName},
+	}
+	if timeout, ok := os.LookupEnv(batchUpgradeTimeoutEnv); ok {
+		envs = append(envs, corev1.EnvVar{Name: batchUpgradeTimeoutEnv, Value: timeout})
+	}
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
@@ -449,10 +458,7 @@ func NewUpgradeJob(jobName string) *batchv1.Job {
 						Name:    "juicefs-upgrade",
 						Image:   strings.TrimSpace(os.Getenv("DASHBOARD_IMAGE")),
 						Command: cmds,
-						Env: []corev1.EnvVar{
-							{Name: "SYS_NAMESPACE", Value: sysNamespace},
-							{Name: common.JfsUpgradeConfig, Value: configName},
-						},
+						Env:     envs,
 					}},
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ServiceAccountName: sa,

--- a/pkg/dashboard/batch_test.go
+++ b/pkg/dashboard/batch_test.go
@@ -1,0 +1,48 @@
+/*
+ Copyright 2024 Juicedata Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/juicedata/juicefs-csi-driver/pkg/config"
+)
+
+func TestNewUpgradeJobIncludesBatchUpgradeTimeoutEnv(t *testing.T) {
+	originalNamespace := config.Namespace
+	config.Namespace = "kube-system"
+	t.Cleanup(func() {
+		config.Namespace = originalNamespace
+	})
+
+	t.Setenv(batchUpgradeTimeoutEnv, "45s")
+
+	job := NewUpgradeJob("job-1")
+	envs := job.Spec.Template.Spec.Containers[0].Env
+
+	timeoutEnv := ""
+	for _, env := range envs {
+		if env.Name == batchUpgradeTimeoutEnv {
+			timeoutEnv = env.Value
+			break
+		}
+	}
+
+	assert.Equal(t, "45s", timeoutEnv)
+}

--- a/pkg/dashboard/batch_test.go
+++ b/pkg/dashboard/batch_test.go
@@ -31,7 +31,7 @@ func TestNewUpgradeJobIncludesBatchUpgradeTimeoutEnv(t *testing.T) {
 		config.Namespace = originalNamespace
 	})
 
-	t.Setenv(batchUpgradeTimeoutEnv, "45s")
+	t.Setenv(batchUpgradeTimeoutEnv, "45")
 
 	job := NewUpgradeJob("job-1")
 	envs := job.Spec.Template.Spec.Containers[0].Env
@@ -44,5 +44,22 @@ func TestNewUpgradeJobIncludesBatchUpgradeTimeoutEnv(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, "45s", timeoutEnv)
+	assert.Equal(t, "45", timeoutEnv)
+}
+
+func TestValidateBatchUpgradeTimeoutEnv(t *testing.T) {
+	t.Run("unset", func(t *testing.T) {
+		t.Setenv(batchUpgradeTimeoutEnv, "")
+		assert.NoError(t, validateBatchUpgradeTimeoutEnv())
+	})
+
+	t.Run("integer", func(t *testing.T) {
+		t.Setenv(batchUpgradeTimeoutEnv, "45")
+		assert.NoError(t, validateBatchUpgradeTimeoutEnv())
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		t.Setenv(batchUpgradeTimeoutEnv, "45s")
+		assert.Error(t, validateBatchUpgradeTimeoutEnv())
+	})
 }


### PR DESCRIPTION
1. skip pod upgrade when node is SchedulingDisabled, which means the node may be something wrong.
2. skip pod upgrade when csi node is not ready
3. make timeout of batch pod upgrade configurable