### PR TITLE
fix: compress large batch upgrade configs

### DIFF
--- a/cmd/dashboard/upgrade.go
+++ b/cmd/dashboard/upgrade.go
@@ -642,9 +642,9 @@ func (u *BatchUpgrade) Write(p []byte) (n int, err error) {
 	runningRegex := `POD-START \[([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)\]`
 	runningRe := regexp.MustCompile(runningRegex)
 
-	runningMatches := runningRe.FindStringSubmatch(msg)
-	if len(runningMatches) > 1 {
-		podName := runningMatches[1]
+	runningMatches := runningRe.FindAllStringSubmatch(msg, -1)
+	for _, match := range runningMatches {
+		podName := match[1]
 		u.lock.Lock()
 		u.podsStatus[podName] = config.Running
 		u.lock.Unlock()
@@ -653,9 +653,9 @@ func (u *BatchUpgrade) Write(p []byte) (n int, err error) {
 	successRegex := `POD-SUCCESS \[([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)\]`
 	successRe := regexp.MustCompile(successRegex)
 
-	successMatches := successRe.FindStringSubmatch(msg)
-	if len(successMatches) > 1 {
-		podName := successMatches[1]
+	successMatches := successRe.FindAllStringSubmatch(msg, -1)
+	for _, match := range successMatches {
+		podName := match[1]
 		u.lock.Lock()
 		u.podsStatus[podName] = config.Success
 		u.lock.Unlock()
@@ -664,9 +664,9 @@ func (u *BatchUpgrade) Write(p []byte) (n int, err error) {
 	failRegex := `POD-FAIL \[([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)\]`
 	failRe := regexp.MustCompile(failRegex)
 
-	failMatches := failRe.FindStringSubmatch(msg)
-	if len(failMatches) > 1 {
-		podName := failMatches[1]
+	failMatches := failRe.FindAllStringSubmatch(msg, -1)
+	for _, match := range failMatches {
+		podName := match[1]
 		u.lock.Lock()
 		u.podsStatus[podName] = config.Fail
 		u.lock.Unlock()
@@ -675,9 +675,9 @@ func (u *BatchUpgrade) Write(p []byte) (n int, err error) {
 	skipRegex := `POD-SKIP \[([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)\]`
 	skipRe := regexp.MustCompile(skipRegex)
 
-	skipMatches := skipRe.FindStringSubmatch(msg)
-	if len(skipMatches) > 1 {
-		podName := skipMatches[1]
+	skipMatches := skipRe.FindAllStringSubmatch(msg, -1)
+	for _, match := range skipMatches {
+		podName := match[1]
 		u.lock.Lock()
 		u.podsStatus[podName] = config.Skip
 		u.lock.Unlock()

--- a/pkg/config/batch_config.go
+++ b/pkg/config/batch_config.go
@@ -17,9 +17,12 @@
 package config
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
@@ -132,8 +135,20 @@ func LoadUpgradeConfig(ctx context.Context, client *k8s.K8sClient, configName st
 
 func LoadBatchConfig(cm *corev1.ConfigMap) (*BatchConfig, error) {
 	cfg := &BatchConfig{}
+	data := []byte(cm.Data["upgrade"])
+	if compressed, ok := cm.BinaryData["upgrade"]; ok {
+		reader, err := gzip.NewReader(bytes.NewReader(compressed))
+		if err != nil {
+			return nil, err
+		}
+		defer reader.Close()
+		data, err = io.ReadAll(reader)
+		if err != nil {
+			return nil, err
+		}
+	}
 
-	err := json.Unmarshal([]byte(cm.Data["upgrade"]), cfg)
+	err := json.Unmarshal(data, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -164,6 +179,33 @@ func GetAllUpgradeConfigs(ctx context.Context, client *k8s.K8sClient) (map[strin
 	return configs, nil
 }
 
+func setUpgradeConfigData(cfg *corev1.ConfigMap, config *BatchConfig) error {
+	data, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+	if len(data) < corev1.MaxSecretSize/2 {
+		cfg.Data = map[string]string{"upgrade": string(data)}
+		cfg.BinaryData = nil
+		return nil
+	}
+
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := writer.Write(data); err != nil {
+		return err
+	}
+	if err := writer.Close(); err != nil {
+		return err
+	}
+	if compressed.Len() > corev1.MaxSecretSize {
+		return fmt.Errorf("compressed upgrade config is too large: %d bytes", compressed.Len())
+	}
+	cfg.Data = nil
+	cfg.BinaryData = map[string][]byte{"upgrade": compressed.Bytes()}
+	return nil
+}
+
 func CreateUpgradeConfig(ctx context.Context, client *k8s.K8sClient, configName string, config *BatchConfig) (*corev1.ConfigMap, error) {
 	if configName == "" {
 		return nil, fmt.Errorf("config name is empty")
@@ -176,10 +218,6 @@ func CreateUpgradeConfig(ctx context.Context, client *k8s.K8sClient, configName 
 		}
 		cfg = nil
 	}
-	data, err := json.Marshal(config)
-	if err != nil {
-		return nil, err
-	}
 	if cfg == nil {
 		cfg = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -189,7 +227,9 @@ func CreateUpgradeConfig(ctx context.Context, client *k8s.K8sClient, configName 
 					common.PodTypeKey: common.ConfigTypeValue,
 				},
 			},
-			Data: map[string]string{"upgrade": string(data)},
+		}
+		if err := setUpgradeConfigData(cfg, config); err != nil {
+			return nil, err
 		}
 		return cfg, client.CreateConfigMap(ctx, cfg)
 
@@ -206,11 +246,9 @@ func UpdateUpgradeConfig(ctx context.Context, client *k8s.K8sClient, configName 
 	if cfg, err = client.GetConfigMap(ctx, configName, Namespace); err != nil {
 		return nil, err
 	}
-	data, err := json.Marshal(config)
-	if err != nil {
+	if err := setUpgradeConfigData(cfg, config); err != nil {
 		return nil, err
 	}
-	cfg.Data = map[string]string{"upgrade": string(data)}
 	return cfg, client.UpdateConfigMap(ctx, cfg)
 }
 


### PR DESCRIPTION
Fix large batch upgrades exceeding the ConfigMap 1 MiB limit by storing large configurations as gzip-compressed BinaryData.