### PR TITLE
fix: bound OS threads stranded by checks on an unresponsive mount

### DIFF
--- a/pkg/controller/mountinfo.go
+++ b/pkg/controller/mountinfo.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 
@@ -187,7 +188,7 @@ type targetItem struct {
 }
 
 func (ti *targetItem) check(ctx context.Context, mounted bool) {
-	err := util.DoWithTimeout(ctx, defaultCheckoutTimeout, func(ctx context.Context) error {
+	err := util.DoPathWithTimeout(ctx, defaultCheckoutTimeout, ti.target, func(ctx context.Context) error {
 		_, err := os.Stat(ti.target)
 		return err
 	})
@@ -208,7 +209,7 @@ func (ti *targetItem) check(ctx context.Context, mounted bool) {
 			ti.err = err
 		}
 
-		if err.Error() == "function timeout" {
+		if errors.Is(err, util.ErrFunctionTimeout) {
 			ti.status = targetStatusCorrupt
 			return
 		}

--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -771,7 +771,7 @@ func (p *PodDriver) recoverTarget(ctx context.Context, podName, sourcePath strin
 		}
 		if ti.subpath != "" {
 			sourcePath += "/" + ti.subpath
-			err = util.DoWithTimeout(ctx, defaultCheckoutTimeout, func(ctx context.Context) error {
+			err = util.DoPathWithTimeout(ctx, defaultCheckoutTimeout, sourcePath, func(ctx context.Context) error {
 				_, err = os.Stat(sourcePath)
 				return err
 			})
@@ -1061,7 +1061,7 @@ func (p *PodDriver) DoAbortFuse(mountpod *corev1.Pod, devMinor uint32) error {
 	}
 	supFusePass := config.SupportFusePass(mountpod)
 	if supFusePass {
-		err = util.DoWithTimeout(context.Background(), defaultCheckoutTimeout, func(ctx context.Context) error {
+		err = util.DoPathWithTimeout(context.Background(), defaultCheckoutTimeout, mntPath, func(ctx context.Context) error {
 			finfo, err := os.Stat(mntPath)
 			if err != nil {
 				return err
@@ -1196,7 +1196,7 @@ func (p *PodDriver) newMountPod(ctx context.Context, pod *corev1.Pod, newPodName
 			passfd.GlobalFds.StopFd(ctx, pod)
 		}
 		// umount mount point before recreate mount pod
-		err := util.DoWithTimeout(ctx, defaultCheckoutTimeout, func(ctx context.Context) error {
+		err := util.DoPathWithTimeout(ctx, defaultCheckoutTimeout, sourcePath, func(ctx context.Context) error {
 			exist, _ := mount.PathExists(sourcePath)
 			if !exist {
 				return fmt.Errorf("%s not exist", sourcePath)

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -372,7 +372,7 @@ func (d *nodeService) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 	podUID := extractPodUIDFromVolumePath(volumePath)
 	var exists bool
 
-	err := util.DoWithTimeout(ctx, defaultCheckTimeout, func(ctx context.Context) (err error) {
+	err := util.DoPathWithTimeout(ctx, defaultCheckTimeout, volumePath, func(ctx context.Context) (err error) {
 		exists, err = mount.PathExists(volumePath)
 		return
 	})
@@ -384,7 +384,7 @@ func (d *nodeService) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 		}
 		if d.SafeFormatAndMount.Interface != nil {
 			var notMnt bool
-			err := util.DoWithTimeout(ctx, defaultCheckTimeout, func(ctx context.Context) (err error) {
+			err := util.DoPathWithTimeout(ctx, defaultCheckTimeout, volumePath, func(ctx context.Context) (err error) {
 				notMnt, err = mount.IsNotMountPoint(d.SafeFormatAndMount.Interface, volumePath)
 				return err
 			})
@@ -412,7 +412,7 @@ func (d *nodeService) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 		return nil, status.Errorf(codes.Internal, "Check volume path, err: %s", err)
 	}
 
-	totalSize, freeSize, totalInodes, freeInodes := util.GetDiskUsage(volumePath)
+	totalSize, freeSize, totalInodes, freeInodes := util.GetDiskUsage(ctx, defaultCheckTimeout, volumePath)
 	usedSize := int64(totalSize) - int64(freeSize)
 	usedInodes := int64(totalInodes) - int64(freeInodes)
 

--- a/pkg/fuse/grace/grace.go
+++ b/pkg/fuse/grace/grace.go
@@ -311,7 +311,7 @@ func (p *PodUpgrade) prepareShutdown(ctx context.Context, conn net.Conn) (*util.
 	msg := "get pid from config"
 	log.V(1).Info(msg, "path", mntPath, "pod", p.pod.Name)
 	var conf []byte
-	err = util.DoWithTimeout(ctx, 2*time.Second, func(ctx context.Context) error {
+	err = util.DoPathWithTimeout(ctx, 2*time.Second, mntPath, func(ctx context.Context) error {
 		configFileName := util.GetJfsInternalFileName(p.pod, ".config")
 		confPath := path.Join(mntPath, configFileName)
 		conf, err = os.ReadFile(confPath)

--- a/pkg/juicefs/juicefs.go
+++ b/pkg/juicefs/juicefs.go
@@ -118,7 +118,7 @@ func (fs *jfs) CreateVol(ctx context.Context, volumeID, subPath string) (string,
 	volPath := filepath.Join(fs.MountPath, subPath)
 	log.V(1).Info("checking volPath exists", "volPath", volPath, "fs", fs)
 	var exists bool
-	if err := util.DoWithTimeout(ctx, defaultCheckTimeout, func(ctx context.Context) (err error) {
+	if err := util.DoPathWithTimeout(ctx, defaultCheckTimeout, fs.MountPath, func(ctx context.Context) (err error) {
 		exists, err = mount.PathExists(volPath)
 		return
 	}); err != nil {
@@ -132,7 +132,7 @@ func (fs *jfs) CreateVol(ctx context.Context, volumeID, subPath string) (string,
 			return "", fmt.Errorf("could not make directory for meta %q: %v", volPath, err)
 		}
 		var fi os.FileInfo
-		if err := util.DoWithTimeout(ctx, defaultCheckTimeout, func(ctx context.Context) (err error) {
+		if err := util.DoPathWithTimeout(ctx, defaultCheckTimeout, fs.MountPath, func(ctx context.Context) (err error) {
 			fi, err = os.Stat(volPath)
 			return err
 		}); err != nil {
@@ -720,7 +720,7 @@ func (j *juicefs) CreateTarget(ctx context.Context, target string) error {
 	var corruptedMnt bool
 
 	for {
-		err := util.DoWithTimeout(ctx, defaultCheckTimeout, func(ctx context.Context) (err error) {
+		err := util.DoPathWithTimeout(ctx, defaultCheckTimeout, target, func(ctx context.Context) (err error) {
 			_, err = mount.PathExists(target)
 			return
 		})

--- a/pkg/juicefs/mount/process_mount.go
+++ b/pkg/juicefs/mount/process_mount.go
@@ -61,7 +61,7 @@ func (p *ProcessMount) JCreateVolume(ctx context.Context, jfsSetting *jfsConfig.
 
 	log.V(1).Info("checking exists", "volPath", volPath, "mountPath", jfsSetting.MountPath)
 	var exists bool
-	if err := util.DoWithTimeout(ctx, defaultCheckTimeout, func(ctx context.Context) (err error) {
+	if err := util.DoPathWithTimeout(ctx, defaultCheckTimeout, jfsSetting.MountPath, func(ctx context.Context) (err error) {
 		exists, err = k8sMount.PathExists(volPath)
 		return
 	}); err != nil {
@@ -76,7 +76,7 @@ func (p *ProcessMount) JCreateVolume(ctx context.Context, jfsSetting *jfsConfig.
 		}
 
 		var fi os.FileInfo
-		if err := util.DoWithTimeout(ctx, defaultCheckTimeout, func(ctx context.Context) (err error) {
+		if err := util.DoPathWithTimeout(ctx, defaultCheckTimeout, jfsSetting.MountPath, func(ctx context.Context) (err error) {
 			fi, err = os.Stat(volPath)
 			return err
 		}); err != nil {
@@ -112,7 +112,7 @@ func (p *ProcessMount) JDeleteVolume(ctx context.Context, jfsSetting *jfsConfig.
 
 	var existed bool
 
-	if err := util.DoWithTimeout(ctx, defaultCheckTimeout, func(ctx context.Context) (err error) {
+	if err := util.DoPathWithTimeout(ctx, defaultCheckTimeout, jfsSetting.MountPath, func(ctx context.Context) (err error) {
 		existed, err = k8sMount.PathExists(volPath)
 		return err
 	}); err != nil {
@@ -166,7 +166,7 @@ func (p *ProcessMount) jmount(ctx context.Context, source, mountPath, storage st
 
 	var exist bool
 
-	if err := util.DoWithTimeout(ctx, defaultCheckTimeout, func(ctx context.Context) (err error) {
+	if err := util.DoPathWithTimeout(ctx, defaultCheckTimeout, mountPath, func(ctx context.Context) (err error) {
 		exist, err = k8sMount.PathExists(mountPath)
 		return
 	}); err != nil {
@@ -181,7 +181,7 @@ func (p *ProcessMount) jmount(ctx context.Context, source, mountPath, storage st
 	}
 
 	var notMounted bool
-	if err := util.DoWithTimeout(ctx, defaultCheckTimeout, func(ctx context.Context) (err error) {
+	if err := util.DoPathWithTimeout(ctx, defaultCheckTimeout, mountPath, func(ctx context.Context) (err error) {
 		notMounted, err = p.IsLikelyNotMountPoint(mountPath)
 		return
 	}); err != nil {
@@ -210,7 +210,7 @@ func (p *ProcessMount) jmount(ctx context.Context, source, mountPath, storage st
 	defer cancel()
 	for {
 		var finfo os.FileInfo
-		if err := util.DoWithTimeout(waitCtx, defaultCheckTimeout, func(ctx context.Context) (err error) {
+		if err := util.DoPathWithTimeout(waitCtx, defaultCheckTimeout, mountPath, func(ctx context.Context) (err error) {
 			finfo, err = os.Stat(mountPath)
 			return err
 		}); err != nil {
@@ -241,7 +241,7 @@ func (p *ProcessMount) GetMountRef(ctx context.Context, target, podName string) 
 	var corruptedMnt bool
 	var exists bool
 
-	err := util.DoWithTimeout(ctx, defaultCheckTimeout, func(ctx context.Context) (err error) {
+	err := util.DoPathWithTimeout(ctx, defaultCheckTimeout, target, func(ctx context.Context) (err error) {
 		exists, err = k8sMount.PathExists(target)
 		return
 	})
@@ -251,7 +251,7 @@ func (p *ProcessMount) GetMountRef(ctx context.Context, target, podName string) 
 			return 0, nil
 		}
 		var notMnt bool
-		err := util.DoWithTimeout(ctx, defaultCheckTimeout, func(ctx context.Context) (err error) {
+		err := util.DoPathWithTimeout(ctx, defaultCheckTimeout, target, func(ctx context.Context) (err error) {
 			notMnt, err = k8sMount.IsNotMountPoint(p, target)
 			return err
 		})
@@ -287,7 +287,7 @@ func (p *ProcessMount) JUmount(ctx context.Context, target, podName string) erro
 	var corruptedMnt bool
 	var exists bool
 
-	err := util.DoWithTimeout(ctx, defaultCheckTimeout, func(ctx context.Context) (err error) {
+	err := util.DoPathWithTimeout(ctx, defaultCheckTimeout, target, func(ctx context.Context) (err error) {
 		exists, err = k8sMount.PathExists(target)
 		return
 	})
@@ -297,7 +297,7 @@ func (p *ProcessMount) JUmount(ctx context.Context, target, podName string) erro
 			return nil
 		}
 		var notMnt bool
-		err := util.DoWithTimeout(ctx, defaultCheckTimeout, func(ctx context.Context) (err error) {
+		err := util.DoPathWithTimeout(ctx, defaultCheckTimeout, target, func(ctx context.Context) (err error) {
 			notMnt, err = k8sMount.IsNotMountPoint(p, target)
 			return err
 		})

--- a/pkg/util/resource/pod.go
+++ b/pkg/util/resource/pod.go
@@ -310,7 +310,7 @@ func WaitUntilMountReady(ctx context.Context, podName, mntPath string, timeout t
 	// Wait until the mount point is ready
 	for {
 		var finfo os.FileInfo
-		if err := util.DoWithTimeout(waitCtx, timeout, func(ctx context.Context) (err error) {
+		if err := util.DoPathWithTimeout(waitCtx, timeout, mntPath, func(ctx context.Context) (err error) {
 			finfo, err = os.Stat(mntPath)
 			return err
 		}); err != nil {

--- a/pkg/util/timeout_test.go
+++ b/pkg/util/timeout_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2026 Juicedata Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// A syscall on an unresponsive mount never returns and its goroutine keeps the
+// OS thread, so every retry strands one. These tests check the bound on that.
+
+// blockingCall never returns. It reports starting so tests can count what ran.
+func blockingCall(started *atomic.Int64, release <-chan struct{}) func(context.Context) error {
+	return func(context.Context) error {
+		started.Add(1)
+		<-release
+		return nil
+	}
+}
+
+// waitFor polls: the bookkeeping happens on the goroutine running f, not here.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	for deadline := time.Now().Add(10 * time.Second); time.Now().Before(deadline); {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func TestDoPathWithTimeoutBoundsInflightCalls(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	var started atomic.Int64
+
+	const path = "/jfs/bounds-inflight"
+	for i := 0; i < maxInflightPerPath+20; i++ {
+		err := DoPathWithTimeout(context.Background(), 10*time.Millisecond, path, blockingCall(&started, release))
+		if !errors.Is(err, ErrFunctionTimeout) {
+			t.Fatalf("call %d: got %v, want ErrFunctionTimeout", i, err)
+		}
+	}
+
+	waitFor(t, "the budget to fill", func() bool { return started.Load() >= maxInflightPerPath })
+	// A refused call costs no goroutine and no thread.
+	time.Sleep(100 * time.Millisecond)
+	if got := started.Load(); got != maxInflightPerPath {
+		t.Errorf("f ran %d times, want at most %d", got, maxInflightPerPath)
+	}
+}
+
+func TestDoPathWithTimeoutReleasesBudgetWhenCallsReturn(t *testing.T) {
+	release := make(chan struct{})
+	var started atomic.Int64
+
+	const path = "/jfs/releases-budget"
+	for i := 0; i < maxInflightPerPath; i++ {
+		_ = DoPathWithTimeout(context.Background(), 10*time.Millisecond, path, blockingCall(&started, release))
+	}
+	waitFor(t, "the budget to fill", func() bool { return started.Load() >= maxInflightPerPath })
+
+	err := DoPathWithTimeout(context.Background(), time.Second, path, func(context.Context) error { return nil })
+	if !errors.Is(err, ErrFunctionTimeout) {
+		t.Fatalf("got %v, want ErrFunctionTimeout while the budget is full", err)
+	}
+
+	// Aborting the fuse connection is what makes the blocked syscalls return.
+	close(release)
+	waitFor(t, "the path to accept calls again", func() bool {
+		return DoPathWithTimeout(context.Background(), time.Second, path, func(context.Context) error { return nil }) == nil
+	})
+}
+
+func TestDoPathWithTimeoutKeepsPathBudgetsSeparate(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	var started atomic.Int64
+
+	for i := 0; i < maxInflightPerPath+5; i++ {
+		_ = DoPathWithTimeout(context.Background(), 10*time.Millisecond, "/jfs/separate-stuck", blockingCall(&started, release))
+	}
+	waitFor(t, "the budget to fill", func() bool { return started.Load() >= maxInflightPerPath })
+
+	err := DoPathWithTimeout(context.Background(), time.Second, "/jfs/separate-healthy", func(context.Context) error { return nil })
+	if err != nil {
+		t.Errorf("got %v, want one stuck mount not to affect the others", err)
+	}
+}
+
+func TestDoPathWithTimeoutRefusalReportsParentError(t *testing.T) {
+	// WaitUntilMountReady and ceMount retry until the error is their parent's,
+	// so a refusal has to report that one or those loops never end.
+	release := make(chan struct{})
+	defer close(release)
+	var started atomic.Int64
+
+	const path = "/jfs/refusal-reports-parent"
+	for i := 0; i < maxInflightPerPath; i++ {
+		_ = DoPathWithTimeout(context.Background(), 10*time.Millisecond, path, blockingCall(&started, release))
+	}
+	waitFor(t, "the budget to fill", func() bool { return started.Load() >= maxInflightPerPath })
+
+	parent, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	waitFor(t, "the parent to expire", func() bool { return parent.Err() != nil })
+
+	err := DoPathWithTimeout(parent, time.Second, path, func(context.Context) error { return nil })
+	if err != context.DeadlineExceeded {
+		t.Errorf("got %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestDoPathWithTimeoutForgetsSettledPaths(t *testing.T) {
+	// Every mount point is a key, so keys have to go when nothing is in flight.
+	paths := make([]string, 50)
+	for i := range paths {
+		paths[i] = fmt.Sprintf("/jfs/settled-%d", i)
+		if err := DoPathWithTimeout(context.Background(), time.Second, paths[i], func(context.Context) error { return nil }); err != nil {
+			t.Fatalf("%s: %v", paths[i], err)
+		}
+	}
+
+	inflight.Lock()
+	defer inflight.Unlock()
+	for _, path := range paths {
+		if n, ok := inflight.n[path]; ok {
+			t.Errorf("%s still tracked with %d in flight", path, n)
+		}
+	}
+}
+
+func TestDoWithTimeoutReturnsErrFunctionTimeout(t *testing.T) {
+	// pkg/controller/mountinfo matches this error to decide a target is stuck.
+	release := make(chan struct{})
+	defer close(release)
+
+	err := DoWithTimeout(context.Background(), 10*time.Millisecond, func(context.Context) error {
+		<-release
+		return nil
+	})
+	if !errors.Is(err, ErrFunctionTimeout) {
+		t.Errorf("got %v, want ErrFunctionTimeout", err)
+	}
+
+	// Operators grep logs for this message; no code compares it any more.
+	if got := ErrFunctionTimeout.Error(); got != "function timeout" {
+		t.Errorf("message is %q, want the original", got)
+	}
+}
+
+func TestDoPathWithTimeoutRefusalIsDistinguishable(t *testing.T) {
+	// Logs have to tell a timeout apart from a call that never started.
+	release := make(chan struct{})
+	defer close(release)
+	var started atomic.Int64
+
+	const path = "/jfs/refusal-distinguishable"
+	for i := 0; i < maxInflightPerPath; i++ {
+		_ = DoPathWithTimeout(context.Background(), 10*time.Millisecond, path, blockingCall(&started, release))
+	}
+	waitFor(t, "the budget to fill", func() bool { return started.Load() >= maxInflightPerPath })
+
+	refused := DoPathWithTimeout(context.Background(), time.Second, path, func(context.Context) error { return nil })
+	expired := DoWithTimeout(context.Background(), 10*time.Millisecond, func(context.Context) error {
+		<-release
+		return nil
+	})
+
+	// Both wrap ErrFunctionTimeout so callers branching on it still work.
+	if !errors.Is(refused, ErrFunctionTimeout) {
+		t.Errorf("refusal: got %v, want it to wrap ErrFunctionTimeout", refused)
+	}
+	if !errors.Is(expired, ErrFunctionTimeout) {
+		t.Errorf("expiry: got %v, want ErrFunctionTimeout", expired)
+	}
+
+	if !errors.Is(refused, ErrTooManyInflight) {
+		t.Errorf("refusal: got %v, want ErrTooManyInflight", refused)
+	}
+	if errors.Is(expired, ErrTooManyInflight) {
+		t.Errorf("expiry: got %v, want it not to be ErrTooManyInflight", expired)
+	}
+	if refused.Error() == expired.Error() {
+		t.Errorf("both read %q, so the cap is invisible in logs", refused.Error())
+	}
+
+	// %w keeps the original message at the front so log greps still match.
+	if !strings.HasPrefix(refused.Error(), ErrFunctionTimeout.Error()) {
+		t.Errorf("refusal reads %q, want it to start with %q",
+			refused.Error(), ErrFunctionTimeout.Error())
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -33,6 +33,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -326,6 +327,8 @@ func RandStringRunes(n int) string {
 	return string(b)
 }
 
+var ErrFunctionTimeout = errors.New("function timeout")
+
 func DoWithTimeout(parent context.Context, timeout time.Duration, f func(ctx context.Context) error) error {
 	subCtx, cancel := context.WithTimeout(parent, timeout)
 	defer cancel()
@@ -339,10 +342,62 @@ func DoWithTimeout(parent context.Context, timeout time.Duration, f func(ctx con
 	case <-parent.Done():
 		return parent.Err()
 	case <-subCtx.Done():
-		return errors.New("function timeout")
+		return ErrFunctionTimeout
 	case err := <-doneCh:
 		return err
 	}
+}
+
+// maxInflightPerPath caps the calls DoPathWithTimeout may have running on one
+// path. A syscall on an unresponsive mount never returns and keeps its thread.
+const maxInflightPerPath = 8
+
+// ErrTooManyInflight wraps ErrFunctionTimeout so callers keep working, but
+// tells the two apart in logs: this one never reached f.
+var ErrTooManyInflight = fmt.Errorf("%w: too many calls in flight on this path", ErrFunctionTimeout)
+
+var inflight = struct {
+	sync.Mutex
+	n map[string]int
+}{n: make(map[string]int)}
+
+func acquirePath(path string) bool {
+	inflight.Lock()
+	defer inflight.Unlock()
+	if inflight.n[path] >= maxInflightPerPath {
+		return false
+	}
+	inflight.n[path]++
+	return true
+}
+
+func releasePath(path string) {
+	inflight.Lock()
+	defer inflight.Unlock()
+	if inflight.n[path] > 1 {
+		inflight.n[path]--
+		return
+	}
+	delete(inflight.n, path)
+}
+
+// DoPathWithTimeout is DoWithTimeout for a call that only reads path. It
+// refuses to start once maxInflightPerPath calls on that path are running.
+//
+// path groups the calls that block together, so pass the mount point when f
+// reads under it. Not for umount, which must stay reachable on a stuck mount.
+func DoPathWithTimeout(parent context.Context, timeout time.Duration, path string, f func(ctx context.Context) error) error {
+	if !acquirePath(path) {
+		// Retry loops end on the parent's error, not on ours.
+		if err := parent.Err(); err != nil {
+			return err
+		}
+		return ErrTooManyInflight
+	}
+	return DoWithTimeout(parent, timeout, func(ctx context.Context) error {
+		defer releasePath(path)
+		return f(ctx)
+	})
 }
 
 func CheckDynamicPV(name string) (bool, error) {
@@ -454,9 +509,11 @@ func ImageResol(image string) (hasCE, hasEE bool) {
 	return true, true
 }
 
-func GetDiskUsage(path string) (uint64, uint64, uint64, uint64) {
+func GetDiskUsage(ctx context.Context, timeout time.Duration, path string) (uint64, uint64, uint64, uint64) {
 	var stat syscall.Statfs_t
-	if err := syscall.Statfs(path, &stat); err == nil {
+	if err := DoPathWithTimeout(ctx, timeout, path, func(context.Context) error {
+		return syscall.Statfs(path, &stat)
+	}); err == nil {
 		// in bytes
 		blockSize := uint64(stat.Bsize)
 		totalSize := blockSize * stat.Blocks
@@ -539,7 +596,7 @@ func Exists(path string) bool {
 }
 
 func MkdirIfNotExist(ctx context.Context, mntPath string) (err error) {
-	return DoWithTimeout(ctx, 3*time.Second, func(ctx context.Context) error {
+	return DoPathWithTimeout(ctx, 3*time.Second, mntPath, func(ctx context.Context) error {
 		exist := Exists(mntPath)
 		if !exist {
 			return os.MkdirAll(mntPath, 0777)


### PR DESCRIPTION
Resolves #1653

`DoPathWithTimeout` is `DoWithTimeout` with a cap of 8 in-flight calls per path. Once a path reaches the cap, the next call returns an error instead of stranding another goroutine. A slot is freed when its call returns, so a mount that recovers needs no cleanup.

Applied to the 23 call sites that only read a path. umount stays uncapped, since it has to work on a mount whose checks are all stuck. `GetDiskUsage` had no timeout at all and now takes one.

Verified in kind with one hung mount and fd passing off, same base image one commit apart:

| | without the cap | with the cap |
|---|---|---|
| OS threads | 42 to 107 | 16 to 24 |
| observed | 372s, still increasing | 906s, no further increase |