### PR TITLE
fix(dashboard): fix mount pod debug info download

### DIFF
--- a/dashboard-ui-v2/src/components/debug-modal.tsx
+++ b/dashboard-ui-v2/src/components/debug-modal.tsx
@@ -57,7 +57,7 @@ const DebugModal: React.FC<{
         profileSec,
       },
       onMessage: (msg) => {
-        if (msg.data.includes('All files are collected to')) {
+        if (msg.data.toLowerCase().includes('all files are collected to')) {
           setCanDownload(true)
         }
         setData((prev) => prev + msg.data)

--- a/dashboard-ui-v2/src/hooks/use-api.ts
+++ b/dashboard-ui-v2/src/hooks/use-api.ts
@@ -155,6 +155,17 @@ export function useWebsocket(
   )
 }
 
+function triggerBlobDownload(blob: Blob, filename: string) {
+  const url = window.URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  window.setTimeout(() => {
+    window.URL.revokeObjectURL(url)
+  }, 1000)
+}
+
 export function useDownloadPodLogs(
   namespace?: string,
   name?: string,
@@ -164,12 +175,7 @@ export function useDownloadPodLogs(
     const blob = await apiFetchBlob(
       `/api/v1/pod/${namespace}/${name}/logs/${container}?download=true`,
     )
-    const url = window.URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `${namespace}-${name}-${container}.log`
-    a.click()
-    window.URL.revokeObjectURL(url)
+    triggerBlobDownload(blob, `${namespace}-${name}-${container}.log`)
   })
 }
 
@@ -178,8 +184,6 @@ export function useDownloadPodDebugInfos(namespace?: string, name?: string) {
     const blob = await apiFetchBlob(
       `/api/v1/pod/${namespace}/${name}/downloadAllDebugInfo`,
     )
-    const url = window.URL.createObjectURL(blob)
-    const a = document.createElement('a')
     const now = new Date()
     const formattedDate = now.toLocaleDateString('zh-CN', {
       year: 'numeric',
@@ -192,10 +196,10 @@ export function useDownloadPodDebugInfos(namespace?: string, name?: string) {
       second: '2-digit',
       hour12: false,
     })
-    a.download = `${name}-debug-collect-${formattedDate}-${formattedTime}.zip`
-    a.href = url
-    a.click()
-    window.URL.revokeObjectURL(url)
+    triggerBlobDownload(
+      blob,
+      `${name}-debug-collect-${formattedDate}-${formattedTime}.zip`,
+    )
   })
 }
 
@@ -204,12 +208,7 @@ export function useDownloadPodDebugFiles(namespace?: string, name?: string) {
     const blob = await apiFetchBlob(
       `/api/v1/pod/${namespace}/${name}/downloadDebugFile`,
     )
-    const url = window.URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.download = `${namespace}-${name}-debug.zip`
-    a.href = url
-    a.click()
-    window.URL.revokeObjectURL(url)
+    triggerBlobDownload(blob, `${namespace}-${name}-debug.zip`)
   })
 }
 

--- a/pkg/dashboard/pod.go
+++ b/pkg/dashboard/pod.go
@@ -81,7 +81,18 @@ func (api *API) getCSINode(ctx context.Context, nodeName string) (*corev1.Pod, e
 	if err != nil {
 		return nil, err
 	}
-	return &pods[0], err
+	if len(pods) == 0 {
+		return nil, fmt.Errorf("csi node not found on node %s", nodeName)
+	}
+	return &pods[0], nil
+}
+
+func (api *API) getPVCByPV(ctx context.Context, pv *corev1.PersistentVolume) (*corev1.PersistentVolumeClaim, error) {
+	if pv == nil || pv.Spec.ClaimRef == nil {
+		return nil, nil
+	}
+
+	return api.client.GetPersistentVolumeClaim(ctx, pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace)
 }
 
 func (api *API) getPodMiddileware() gin.HandlerFunc {
@@ -347,10 +358,12 @@ func (api *API) downloadDebugInfo() gin.HandlerFunc {
 		pod, err := api.client.GetPod(c, name, namespace)
 		if err != nil || pod == nil {
 			podLog.Error(err, "Failed to get pod")
+			c.JSON(500, gin.H{"error": fmt.Sprintf("Failed to get pod: %v", err)})
 			return
 		}
 		if !utils.IsMountPod(pod) {
-			podLog.Error(err, "not a mount pod")
+			podLog.Error(nil, "not a mount pod", "pod", name)
+			c.JSON(400, gin.H{"error": "not a mount pod"})
 			return
 		}
 		// create tmp dir
@@ -359,6 +372,7 @@ func (api *API) downloadDebugInfo() gin.HandlerFunc {
 		err = os.MkdirAll(dir, 0777)
 		if err != nil {
 			podLog.Error(err, "Failed to create tmp dir")
+			c.JSON(500, gin.H{"error": fmt.Sprintf("Failed to create tmp dir: %v", err)})
 			return
 		}
 
@@ -406,7 +420,7 @@ func (api *API) downloadDebugInfo() gin.HandlerFunc {
 				return
 			}
 			pvcYaml := filepath.Join(dir, "pvc.yaml")
-			pvc, err := api.client.GetPersistentVolume(c, pv.Name)
+			pvc, err := api.getPVCByPV(c, pv)
 			if err != nil {
 				podLog.Error(err, "Failed to get pvc by pv: %s", pv.Name)
 			}


### PR DESCRIPTION
## Changes

- **backend**: fix `getCSINode` panic when CSI node pod list is empty (index out of bounds)
- **backend**: fix silent 200 empty response on early errors in `downloadDebugInfo`; return proper 4xx/5xx
- **backend**: fix PVC yaml using `GetPersistentVolume` instead of `GetPersistentVolumeClaim`
- **frontend**: fix Debug modal Download button staying disabled due to case-sensitive completion message check
- **frontend**: fix 0-byte downloads caused by `revokeObjectURL` called immediately after `click()`