### PR TITLE
fix: always sync derived secret when regenerating mount pod spec

### DIFF
--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -953,10 +953,8 @@ func (p *PodDriver) applyConfigPatch(ctx context.Context, pod *corev1.Pod) error
 		newPod.Spec.SchedulerName = pod.Spec.SchedulerName
 		newPod.Spec.Tolerations = util.CopySlice(pod.Spec.Tolerations)
 		newPod.Spec.NodeSelector = pod.Spec.NodeSelector
-		if setting.HashVal != pod.Labels[common.PodJuiceHashLabelKey] {
-			if err := resource.CreateOrUpdateSecret(ctx, p.Client, &secret); err != nil {
-				return err
-			}
+		if err := resource.CreateOrUpdateSecret(ctx, p.Client, &secret); err != nil {
+			return err
 		}
 		pod.Spec = newPod.Spec
 		pod.ObjectMeta = newPod.ObjectMeta


### PR DESCRIPTION
`CreateOrUpdateSecret` already skips the write when the content is unchanged, so dropping the hash gate keeps the secret consistent with the spec without extra writes.

Fixes #1668