### PR TITLE
upgrade EE mount image to Debian bookworm

### DIFF
--- a/docker/ee.juicefs.Dockerfile
+++ b/docker/ee.juicefs.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.9.21-slim-bullseye
+FROM python:3.9.21-slim-bookworm
 
 ARG JFSCHAN
 
@@ -29,10 +29,6 @@ ENV PKG_TYPE=${PKG_TYPE:-"full"}
 RUN <<INSTALL-DEPENDENCIES
 bash -c "
 if [[ '${TARGETARCH}' == amd64 && '${PKG_TYPE}' != min ]]; then
-  apt update
-  apt install -y software-properties-common wget gnupg gnupg2
-  wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add -
-  echo deb https://download.ceph.com/debian-16.2.15/ bullseye main | tee /etc/apt/sources.list.d/ceph.list
   apt-get update
   apt-get install -y uuid-dev libglusterfs-dev glusterfs-common librados2 librados-dev
 fi


### PR DESCRIPTION
- Debian 11 bullseye support has reached its end-of-life in 31 August 2026, https://www-fastly.debian.org/News/2026/20260831

- [Bookworm's official sources now offer Ceph 16.2.15](https://packages.debian.org/bookworm/librados2)