### PR TITLE
fix: variable shadowing causing nil pointer panic in fuse abort job wait loop

### DIFF
--- a/pkg/controller/pod_driver.go
+++ b/pkg/controller/pod_driver.go
@@ -1111,7 +1111,7 @@ func (p *PodDriver) DoAbortFuse(mountpod *corev1.Pod, devMinor uint32) error {
 			log.Error(waitCtx.Err(), "fuse abort job timeout", "namespace", job.Namespace, "name", job.Name)
 			break
 		}
-		job, err := p.Client.GetJob(waitCtx, job.Name, job.Namespace)
+		currentJob, err := p.Client.GetJob(waitCtx, job.Name, job.Namespace)
 		if apierrors.IsNotFound(err) {
 			break
 		}
@@ -1120,8 +1120,8 @@ func (p *PodDriver) DoAbortFuse(mountpod *corev1.Pod, devMinor uint32) error {
 			time.Sleep(10 * time.Second)
 			continue
 		}
-		if resource.IsJobCompleted(job) {
-			log.Info("fuse abort job completed", "namespace", job.Namespace, "name", job.Name)
+		if resource.IsJobCompleted(currentJob) {
+			log.Info("fuse abort job completed", "namespace", currentJob.Namespace, "name", currentJob.Name)
 			break
 		}
 		time.Sleep(10 * time.Second)


### PR DESCRIPTION
The inner short declaration shadows the outer job variable. When GetJob returns error, the inner job is nil, and accessing job.Namespace/job.Name will panic.
Rename inner variable to currentJob to fix shadowing.
